### PR TITLE
feat(dry_run): 워크플로우 실행 검증용 dry_run 모드 추가

### DIFF
--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.10.0] - 2026-04-13
+### Added
+- `TradingHoursFilterNode`: `context.is_dry_run=True` 시 대기 없이 즉시 통과 (`{"passed": True, "reason": "dry_run_bypass"}`)
+
 ## [1.9.9] - 2026-04-06
 ### Fixed
 - `_filter_data()` regex 연산자 매칭 순서 수정: `>=|<=` 를 `>|<` 보다 앞으로 이동 (longest match first)

--- a/src/core/programgarden_core/nodes/trigger.py
+++ b/src/core/programgarden_core/nodes/trigger.py
@@ -245,6 +245,11 @@ class TradingHoursFilterNode(BaseNode):
         - 워크플로우 종료 시: graceful shutdown
         """
         import time as _time
+        # dry_run: 거래시간 대기 없이 즉시 통과
+        if getattr(context, "is_dry_run", False):
+            context.log("info", "[dry_run] TradingHoursFilter bypassed", self.id)
+            return {"passed": True, "reason": "dry_run_bypass"}
+
         check_interval = 60  # 1분마다 체크
         wait_start = _time.monotonic()
         max_wait_sec = self.max_wait_hours * 3600

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-core"
-version = "1.9.9"
+version = "1.10.0"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 readme = "README.md"
 

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.18.0] - 2026-04-13
+### Added
+- **dry_run 모드**: `context_params={"dry_run": True}`로 워크플로우 실행 검증 (`ExecutionContext.is_dry_run` property)
+  - `ScheduleNode` / `TradingHoursFilterNode`: 1 cycle 후 즉시 종료 (또는 대기 없이 통과)
+  - 주문 노드 (`NewOrder` / `ModifyOrder` / `CancelOrder`): LS API 미호출, `{"order_id": "DRYRUN-<uuid>", "status": "simulated", ...}` 반환
+  - Realtime 노드 (`RealAccount` / `RealMarketData` / `RealOrderEvent`): WebSocket 미개방, `{"status": "skipped_dry_run"}` 반환
+  - Messaging 노드 (TelegramNode 등): no-op, `{"status": "simulated"}` 반환
+  - 조회/백테스트 노드: 기존 동작 유지 (실제 API 경로)
+
 ## [1.17.0] - 2026-04-09
 ### Added
 - 워크플로우 예제 5개 추가 (63~67번): RSI Divergence, KDJ+Aroon, Heikin-Ashi+Vortex, Hurst Regime, Performance Ratios

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [1.18.0] - 2026-04-13
 ### Added
-- **dry_run 모드**: `context_params={"dry_run": True}`로 워크플로우 실행 검증 (`ExecutionContext.is_dry_run` property)
+- **dry_run 모드**: `pg.run(workflow, context={"dry_run": True})`로 워크플로우 실행 검증 (`ExecutionContext.is_dry_run` property)
   - `ScheduleNode` / `TradingHoursFilterNode`: 1 cycle 후 즉시 종료 (또는 대기 없이 통과)
   - 주문 노드 (`NewOrder` / `ModifyOrder` / `CancelOrder`): LS API 미호출, `{"order_id": "DRYRUN-<uuid>", "status": "simulated", ...}` 반환
   - Realtime 노드 (`RealAccount` / `RealMarketData` / `RealOrderEvent`): WebSocket 미개방, `{"status": "skipped_dry_run"}` 반환

--- a/src/programgarden/README.md
+++ b/src/programgarden/README.md
@@ -62,6 +62,24 @@ job = await pg.run_async(
 await job.stop()
 ```
 
+### Dry Run (워크플로우 검증용 모의 실행)
+
+실제 주문/알림/Realtime WebSocket 연결 없이 워크플로우를 검증합니다.
+
+- ScheduleNode / TradingHoursFilterNode → 1 cycle 후 즉시 종료
+- 주문 노드 → LS API 미호출, `{"order_id": "DRYRUN-<uuid>", "status": "simulated", ...}` 반환
+- Realtime 노드 → WebSocket 미개방, `{"status": "skipped_dry_run"}` 반환
+- Messaging 노드(Telegram 등) → no-op, `{"status": "simulated"}` 반환
+- 조회/백테스트 노드 → 기존 동작 유지 (실제 API 경로)
+
+```python
+job = await pg.run_async(
+    definition=workflow_definition,
+    context={"dry_run": True},
+    secrets={...},
+)
+```
+
 ### 워크플로우 정의 (JSON)
 
 ```json

--- a/src/programgarden/programgarden/__init__.py
+++ b/src/programgarden/programgarden/__init__.py
@@ -80,7 +80,7 @@ except ImportError:
     # Community package not installed
     pass
 
-__version__ = "1.7.0"
+__version__ = "1.18.0"
 __all__ = [
     # Core
     "ProgramGarden",

--- a/src/programgarden/programgarden/client.py
+++ b/src/programgarden/programgarden/client.py
@@ -83,6 +83,14 @@ class ProgramGarden:
             ...     secrets={"credential_id": {"appkey": "...", "appsecret": "..."}},
             ...     storage_dir="./my_data",
             ... )
+
+            # Dry run (검증용): 주문/Realtime/알림 노드 실제 호출 없이 시뮬레이션
+            >>> job = pg.run(
+            ...     workflow,
+            ...     context={"dry_run": True},
+            ...     wait=True,
+            ...     timeout=60,
+            ... )
         """
         # Parse resource_limits if provided
         limits = None

--- a/src/programgarden/programgarden/context.py
+++ b/src/programgarden/programgarden/context.py
@@ -278,6 +278,19 @@ class ExecutionContext:
         db_dir.mkdir(parents=True, exist_ok=True)
         return str(db_dir / db_filename)
 
+    # === Dry Run ===
+
+    @property
+    def is_dry_run(self) -> bool:
+        """Workflow is running in dry_run mode.
+
+        When True, side-effectful nodes (주문/Realtime/알림) skip external calls
+        and return simulated responses. Query/백테스트 nodes still execute normally.
+
+        Enable via ``context_params={"dry_run": True}`` in ``pg.run_async``.
+        """
+        return bool(self.context_params.get("dry_run", False))
+
     # === DAG Index Building ===
 
     def _build_dag_index(

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -364,7 +364,23 @@ class GenericNodeExecutor(NodeExecutorBase):
         except Exception as e:
             context.log("error", f"Failed to create node instance: {e}", node_id)
             return {"error": str(e)}
-        
+
+        # dry_run 가드: Messaging/Notification 노드는 no-op 반환
+        if context.is_dry_run:
+            try:
+                from programgarden_core.nodes.base import NodeCategory
+                node_category = getattr(node_instance, "category", None)
+                if node_category == NodeCategory.MESSAGING:
+                    context.log(
+                        "info",
+                        f"[dry_run] {node_type} skipped (messaging node)",
+                        node_id,
+                    )
+                    return {"status": "simulated", "dry_run": True}
+            except Exception:
+                # NodeCategory import 실패는 무시 — dry_run 가드가 동작 안 할 뿐
+                pass
+
         # execute() 메서드 호출
         if hasattr(node_instance, "execute"):
             try:
@@ -916,6 +932,25 @@ class ScheduleNodeExecutor(NodeExecutorBase):
                     itr = croniter(cron_expr, datetime.now(tz))
 
                 while cnt < count and context.is_running:
+                    # dry_run: 루프 진입 즉시 1회 emit 후 종료
+                    if context.is_dry_run:
+                        cnt += 1
+                        context.log(
+                            "info",
+                            f"[dry_run] Schedule tick #{cnt} (single cycle), exiting scheduler",
+                            node_id,
+                        )
+                        await context.emit_event(
+                            event_type="schedule_tick",
+                            source_node_id=node_id,
+                            data={
+                                "cron": cron_expr,
+                                "count": cnt,
+                                "triggered_at": datetime.now(tz).isoformat(),
+                                "dry_run": True,
+                            },
+                        )
+                        break
                     # M-6: max_duration_hours 초과 시 스케줄 종료
                     if (_time.monotonic() - start_mono) >= max_duration_sec:
                         context.log(
@@ -3800,14 +3835,24 @@ class RealAccountNodeExecutor(NodeExecutorBase):
         **kwargs,
     ) -> Dict[str, Any]:
         import sys
+
+        # dry_run: WebSocket 미개방, skip 반환
+        if context.is_dry_run:
+            context.log(
+                "warning",
+                f"[dry_run] {node_type} skipped (realtime WebSocket disabled)",
+                node_id,
+            )
+            return {"status": "skipped_dry_run", "dry_run": True}
+
         # 옵션 확인
         stay_connected = config.get("stay_connected", True)
         sync_interval_sec = config.get("sync_interval_sec", 60)
-        
-        
+
+
         # config에서 connection 확인 (자동 주입 또는 명시적 바인딩)
         broker_connection = config.get("connection")
-        
+
         # connection 없으면 에러 - 자동 주입 또는 명시적 바인딩 필요
         if not broker_connection:
             context.log("error", "RealAccountNode: connection이 자동 주입되지 않았습니다. 매칭되는 BrokerNode가 워크플로우에 있는지 확인하세요.", node_id)
@@ -4682,12 +4727,21 @@ class RealMarketDataNodeExecutor(NodeExecutorBase):
         **kwargs,
     ) -> Dict[str, Any]:
         from programgarden_core.exceptions import ValidationError, ConnectionError
-        
+
+        # dry_run: WebSocket 미개방, skip 반환
+        if context.is_dry_run:
+            context.log(
+                "warning",
+                f"[dry_run] {node_type} skipped (realtime WebSocket disabled)",
+                node_id,
+            )
+            return {"status": "skipped_dry_run", "dry_run": True}
+
         # ========================================
         # 1. BrokerNode connection 획득 (config 바인딩 필수)
         # ========================================
         broker_connection = config.get("connection")
-        
+
         # connection 없으면 에러 - 자동 주입 또는 명시적 바인딩 필요
         if not broker_connection:
             error_msg = (
@@ -5343,9 +5397,18 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
         context: ExecutionContext,
         **kwargs,
     ) -> Dict[str, Any]:
+        # dry_run: WebSocket 미개방, skip 반환
+        if context.is_dry_run:
+            context.log(
+                "warning",
+                f"[dry_run] {node_type} skipped (realtime WebSocket disabled)",
+                node_id,
+            )
+            return {"status": "skipped_dry_run", "dry_run": True}
+
         # 옵션 확인
         stay_connected = config.get("stay_connected", True)
-        
+
         # config에서 connection 확인 (자동 주입 또는 명시적 바인딩)
         broker_connection = config.get("connection")
 
@@ -10830,6 +10893,22 @@ class NewOrderNodeExecutor(NodeExecutorBase):
     ) -> Dict[str, Any]:
         """신규 주문 실행"""
 
+        # dry_run: LS API 미호출, 모의 응답 반환
+        if context.is_dry_run:
+            import uuid
+            order_id = f"DRYRUN-{uuid.uuid4()}"
+            context.log(
+                "info",
+                f"[dry_run] {node_type} simulated order → {order_id}",
+                node_id,
+            )
+            return {
+                "order_id": order_id,
+                "status": "simulated",
+                "dry_run": True,
+                "requested": config,
+            }
+
         # M-10: Risk halt 체크 - critical risk event로 주문 중단
         if context.is_risk_halted:
             context.log(
@@ -11566,6 +11645,22 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
     ) -> Dict[str, Any]:
         """주문 정정 실행"""
 
+        # dry_run: LS API 미호출, 모의 응답 반환
+        if context.is_dry_run:
+            import uuid
+            order_id = f"DRYRUN-{uuid.uuid4()}"
+            context.log(
+                "info",
+                f"[dry_run] {node_type} simulated modify → {order_id}",
+                node_id,
+            )
+            return {
+                "order_id": order_id,
+                "status": "simulated",
+                "dry_run": True,
+                "requested": config,
+            }
+
         # M-10: Risk halt 체크
         if context.is_risk_halted:
             context.log("warning", f"{node_type}: 위험 이벤트로 인해 주문 정정이 중단되었습니다", node_id)
@@ -11974,6 +12069,22 @@ class CancelOrderNodeExecutor(NodeExecutorBase):
         **kwargs,
     ) -> Dict[str, Any]:
         """주문 취소 실행"""
+
+        # dry_run: LS API 미호출, 모의 응답 반환
+        if context.is_dry_run:
+            import uuid
+            order_id = f"DRYRUN-{uuid.uuid4()}"
+            context.log(
+                "info",
+                f"[dry_run] {node_type} simulated cancel → {order_id}",
+                node_id,
+            )
+            return {
+                "order_id": order_id,
+                "status": "simulated",
+                "dry_run": True,
+                "requested": config,
+            }
 
         # === 1. Connection 확인 ===
         broker_connection = config.get("connection")

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.17.0"
+version = "1.18.0"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
 
@@ -29,7 +29,7 @@ pytickersymbols = {version = ">=1.17.5", python = ">=3.12,<4.0"}
 aiosqlite = "^0.20.0"
 litellm = ">=1.40.0"
 fastembed = ">=0.4.0"
-programgarden-core = "^1.9.9"
+programgarden-core = "^1.10.0"
 programgarden-finance = "^1.4.4"
 programgarden-community = "^1.11.0"
     

--- a/src/programgarden/tests/test_dry_run.py
+++ b/src/programgarden/tests/test_dry_run.py
@@ -1,0 +1,282 @@
+"""
+dry_run 모드 테스트
+
+`context_params={"dry_run": True}`로 워크플로우를 실행할 때 각 노드 카테고리가
+올바르게 동작하는지 검증한다.
+
+- ScheduleNode / TradingHoursFilterNode: 1 cycle 후 종료
+- 주문 노드: LS API 미호출, simulated 응답 반환
+- Realtime 노드: WebSocket 미개방, skip 반환
+- Messaging 노드: no-op, simulated 반환
+- 조회 노드: dry_run 과 무관하게 실제 경로 타는지 (mock 으로 검증)
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import (
+    CancelOrderNodeExecutor,
+    MarketDataNodeExecutor,
+    ModifyOrderNodeExecutor,
+    NewOrderNodeExecutor,
+    RealAccountNodeExecutor,
+    RealMarketDataNodeExecutor,
+    RealOrderEventNodeExecutor,
+    ScheduleNodeExecutor,
+    WorkflowExecutor,
+)
+
+
+# ============================================================
+# Helper
+# ============================================================
+
+def make_context(dry_run: bool | None = None, job_id: str = "dry-run-test") -> ExecutionContext:
+    """Helper: ExecutionContext 생성"""
+    ctx_params: dict = {}
+    if dry_run is not None:
+        ctx_params["dry_run"] = dry_run
+    ctx = ExecutionContext(
+        job_id=job_id,
+        workflow_id="wf-dry-run-test",
+        context_params=ctx_params,
+    )
+    ctx._is_running = True  # scheduler_task 루프 진입용
+    return ctx
+
+
+# ============================================================
+# 1. dry_run flag propagation
+# ============================================================
+
+def test_dry_run_flag_propagates():
+    """context_params={"dry_run": True} → ctx.is_dry_run True"""
+    ctx = make_context(dry_run=True)
+    assert ctx.is_dry_run is True
+
+
+def test_dry_run_default_false():
+    """context_params 미지정 / dry_run 미지정 → False"""
+    ctx = make_context()
+    assert ctx.is_dry_run is False
+
+    ctx2 = make_context(dry_run=False)
+    assert ctx2.is_dry_run is False
+
+
+# ============================================================
+# 2. Order nodes return simulated response
+# ============================================================
+
+async def test_order_node_returns_simulated():
+    """NewOrderNodeExecutor: dry_run 시 LS API 호출 없이 simulated 응답 반환"""
+    ctx = make_context(dry_run=True)
+    executor = NewOrderNodeExecutor()
+
+    config = {
+        "symbol": "AAPL",
+        "exchange": "NASDAQ",
+        "quantity": 10,
+        "price": 150.0,
+        # 일부러 connection 미제공 — dry_run 가드가 먼저 return 해야 함
+    }
+
+    result = await executor.execute(
+        node_id="order-1",
+        node_type="OverseasStockNewOrderNode",
+        config=config,
+        context=ctx,
+    )
+
+    assert result["status"] == "simulated"
+    assert result["dry_run"] is True
+    assert result["order_id"].startswith("DRYRUN-")
+    assert result["requested"] == config
+
+
+async def test_modify_order_returns_simulated():
+    ctx = make_context(dry_run=True)
+    executor = ModifyOrderNodeExecutor()
+
+    result = await executor.execute(
+        node_id="modify-1",
+        node_type="OverseasStockModifyOrderNode",
+        config={"original_order_id": "ORD-123", "new_quantity": 5},
+        context=ctx,
+    )
+
+    assert result["status"] == "simulated"
+    assert result["order_id"].startswith("DRYRUN-")
+
+
+async def test_cancel_order_returns_simulated():
+    ctx = make_context(dry_run=True)
+    executor = CancelOrderNodeExecutor()
+
+    result = await executor.execute(
+        node_id="cancel-1",
+        node_type="OverseasStockCancelOrderNode",
+        config={"original_order_id": "ORD-123"},
+        context=ctx,
+    )
+
+    assert result["status"] == "simulated"
+    assert result["order_id"].startswith("DRYRUN-")
+
+
+# ============================================================
+# 3. ScheduleNode exits after one cycle
+# ============================================================
+
+async def test_schedule_node_exits_after_one_cycle():
+    """ScheduleNode: dry_run 시 1 cycle emit 후 scheduler_task 종료"""
+    ctx = make_context(dry_run=True)
+    executor = ScheduleNodeExecutor()
+
+    # 첫 실행 → trigger 반환 + 백그라운드 task 등록
+    result = await executor.execute(
+        node_id="schedule-1",
+        node_type="ScheduleNode",
+        config={
+            "cron": "*/5 * * * *",  # 실제로는 대기하지 않음 — dry_run 분기 진입
+            "timezone": "UTC",
+            "enabled": True,
+            "count": 1000,
+        },
+        context=ctx,
+    )
+
+    assert result.get("trigger") is True
+
+    # 백그라운드 scheduler_task 가 등록되어 있어야 함
+    assert "schedule-1" in ctx._persistent_tasks
+    task = ctx._persistent_tasks["schedule-1"]
+
+    # dry_run 이므로 1 cycle 후 즉시 종료 — 3초 안에 끝나야 함
+    await asyncio.wait_for(task, timeout=3.0)
+    assert task.done()
+
+    # schedule_tick event 가 1회 emit 되었는지
+    events = []
+    while not ctx._event_queue.empty():
+        events.append(ctx._event_queue.get_nowait())
+
+    schedule_ticks = [e for e in events if e.type == "schedule_tick"]
+    assert len(schedule_ticks) == 1
+    assert schedule_ticks[0].data.get("dry_run") is True
+
+
+# ============================================================
+# 4. Realtime nodes skipped
+# ============================================================
+
+async def test_realtime_account_skipped():
+    ctx = make_context(dry_run=True)
+    executor = RealAccountNodeExecutor()
+
+    result = await executor.execute(
+        node_id="real-acc-1",
+        node_type="OverseasStockRealAccountNode",
+        config={},
+        context=ctx,
+    )
+
+    assert result["status"] == "skipped_dry_run"
+    assert result["dry_run"] is True
+
+
+async def test_realtime_market_data_skipped():
+    ctx = make_context(dry_run=True)
+    executor = RealMarketDataNodeExecutor()
+
+    result = await executor.execute(
+        node_id="real-md-1",
+        node_type="OverseasStockRealMarketDataNode",
+        config={},
+        context=ctx,
+    )
+
+    assert result["status"] == "skipped_dry_run"
+
+
+async def test_realtime_order_event_skipped():
+    ctx = make_context(dry_run=True)
+    executor = RealOrderEventNodeExecutor()
+
+    result = await executor.execute(
+        node_id="real-ord-1",
+        node_type="OverseasStockRealOrderEventNode",
+        config={},
+        context=ctx,
+    )
+
+    assert result["status"] == "skipped_dry_run"
+
+
+# ============================================================
+# 5. Query nodes still call API
+# ============================================================
+
+async def test_query_node_still_calls_api():
+    """MarketDataNode 는 dry_run 과 무관하게 실제 경로 타야 함.
+
+    connection 미제공이므로 에러 응답이 나오지만, 핵심은:
+    - `status == "skipped_dry_run"` 이 아님
+    - `dry_run == True` 짐수가 없음
+    → dry_run 분기를 타지 않았음을 증명
+    """
+    ctx = make_context(dry_run=True)
+    executor = MarketDataNodeExecutor()
+
+    result = await executor.execute(
+        node_id="md-1",
+        node_type="OverseasStockMarketDataNode",
+        config={},  # connection 없음 → 에러 경로 진입
+        context=ctx,
+    )
+
+    # dry_run 가드가 개입했다면 이 두 조건 중 하나를 만족했을 것
+    assert result.get("status") != "skipped_dry_run"
+    assert result.get("dry_run") is not True
+
+
+# ============================================================
+# 6. End-to-end: workflow completes quickly under dry_run
+# ============================================================
+
+async def test_dry_run_completes_quickly():
+    """ScheduleNode + Order 조합 워크플로우가 dry_run 으로 30초 이내 종료"""
+    workflow = {
+        "id": "test-dry-run-wf",
+        "name": "Dry Run Quick Test",
+        "nodes": [
+            {"id": "start", "type": "StartNode"},
+        ],
+        "edges": [],
+    }
+
+    executor = WorkflowExecutor()
+    start = time.monotonic()
+
+    job = await executor.execute(
+        workflow,
+        context_params={"dry_run": True},
+        job_id=f"dry-run-quick-{int(time.time() * 1000)}",
+    )
+
+    # 완료 대기 (최대 30초)
+    deadline = start + 30.0
+    while job.status in ("pending", "running"):
+        if time.monotonic() > deadline:
+            break
+        await asyncio.sleep(0.1)
+
+    elapsed = time.monotonic() - start
+    assert elapsed < 30.0, f"dry_run 워크플로우가 30초 내 종료되지 않음 (elapsed={elapsed:.1f}s)"
+    assert job.status in ("completed", "finished", "success"), (
+        f"dry_run workflow should complete, got status={job.status}"
+    )


### PR DESCRIPTION
## Summary

- `context={"dry_run": True}` 지정 시 주문·Realtime·Messaging 노드를 실제 호출 없이 시뮬레이션, ScheduleNode 는 1 cycle 후 종료
- 조회·백테스트 노드는 **기존 동작 유지** — "실행이 정말로 되는가"를 검증하는 것이 목적
- AI 가 생성한 워크플로우를 저장·배포하기 전에 안전하게 실행 검증하기 위한 용도 (`programgarden_server` 의 Phase 2/3 에서 소비 예정)

## 핵심 변경

### `programgarden` 1.18.0
- `ExecutionContext.is_dry_run` property 추가 (`context_params.get("dry_run", False)`)
- `ScheduleNodeExecutor`: dry_run 에서 scheduler_task 루프가 1 cycle emit 후 break
- `NewOrder`/`ModifyOrder`/`CancelOrderNodeExecutor`: LS API 미호출, `{"order_id": "DRYRUN-<uuid>", "status": "simulated", "requested": ...}` 반환
- `RealAccount`/`RealMarketData`/`RealOrderEventNodeExecutor`: WebSocket 미개방, `{"status": "skipped_dry_run"}` 반환
- `GenericNodeExecutor`: `NodeCategory.MESSAGING` 은 dry_run 에서 no-op, `{"status": "simulated"}` 반환

### `programgarden-core` 1.10.0
- `TradingHoursFilterNode.execute`: dry_run 에서 시간대 대기 없이 `{"passed": True, "reason": "dry_run_bypass"}`

### Docs
- `README.md` dry_run 섹션 추가 (public API: `pg.run(workflow, context={"dry_run": True})`)
- `client.py` docstring 에 dry_run 예제
- `CHANGELOG.md` 항목 추가

## Test plan

- [x] 신규 `tests/test_dry_run.py` 11 케이스 전부 통과 (0.41s)
  - `is_dry_run` property 전파/기본값
  - 주문 3종 simulated 응답
  - Realtime 3종 skipped
  - ScheduleNode 1 cycle 후 종료
  - 조회 노드는 여전히 실제 API 경로
  - 전체 워크플로우 dry_run 30초 내 종료
- [x] 기존 회귀 없음 — `programgarden` 621 passed / `core` 551 passed / `community` 1203 passed
- [x] public API `pg.run(workflow, context={"dry_run": True})` 로 호출 시 소비처(`programgarden_computer_app/app/services/workflow_runner.py`) 기존 코드 변경 없이 동작

## 버전 bump

| 패키지 | 이전 | 이후 |
|-------|-----|------|
| `programgarden` | 1.17.0 | **1.18.0** |
| `programgarden-core` | 1.9.9 | **1.10.0** |

## 후속 작업 (소비처)

머지·PyPI 배포 후 `programgarden_server` 측에서:
- 서브모듈 pin 이동
- `programgarden_ai` / `sandbox_for_ai` / `firebase/functions_dsl` 의 `requirements.txt` 버전 동기화
- Phase 2: `sandbox_for_ai` 에 `/dry_run_workflow` 엔드포인트 신설