### PR TITLE
feat(validation): ConditionNode 데이터 바인딩 정적 검증 + 깨진 예제 4개 수정

### DIFF
--- a/src/programgarden/examples/workflows/13-logic-complex.json
+++ b/src/programgarden/examples/workflows/13-logic-complex.json
@@ -66,7 +66,15 @@
       "id": "rsi_condition",
       "type": "ConditionNode",
       "plugin": "RSI",
-      "data": "{{ nodes.historical.values }}",
+      "items": {
+        "from": "{{ item.time_series }}",
+        "extract": {
+          "symbol": "{{ item.symbol }}",
+          "exchange": "{{ item.exchange }}",
+          "date": "{{ row.date }}",
+          "close": "{{ row.close }}"
+        }
+      },
       "fields": {
         "period": 14,
         "threshold": 30,
@@ -81,7 +89,15 @@
       "id": "macd_condition",
       "type": "ConditionNode",
       "plugin": "MACD",
-      "data": "{{ nodes.historical.values }}",
+      "items": {
+        "from": "{{ item.time_series }}",
+        "extract": {
+          "symbol": "{{ item.symbol }}",
+          "exchange": "{{ item.exchange }}",
+          "date": "{{ row.date }}",
+          "close": "{{ row.close }}"
+        }
+      },
       "fields": {
         "fast_period": 12,
         "slow_period": 26,

--- a/src/programgarden/examples/workflows/23-display-line-chart.json
+++ b/src/programgarden/examples/workflows/23-display-line-chart.json
@@ -39,11 +39,19 @@
       "id": "condition",
       "type": "ConditionNode",
       "plugin": "RSI",
-      "data": "{{ nodes.historical.values }}",
-      "params": {
+      "items": {
+        "from": "{{ nodes.historical.value.time_series }}",
+        "extract": {
+          "symbol": "{{ nodes.historical.value.symbol }}",
+          "exchange": "{{ nodes.historical.value.exchange }}",
+          "date": "{{ row.date }}",
+          "close": "{{ row.close }}"
+        }
+      },
+      "fields": {
         "period": 14,
-        "overbought": 70,
-        "oversold": 30
+        "threshold": 30,
+        "direction": "below"
       },
       "position": {
         "x": 600,

--- a/src/programgarden/examples/workflows/24-display-multi-line.json
+++ b/src/programgarden/examples/workflows/24-display-multi-line.json
@@ -58,9 +58,19 @@
       "id": "condition",
       "type": "ConditionNode",
       "plugin": "RSI",
-      "data": "{{ nodes.historical.values }}",
-      "params": {
-        "period": 14
+      "items": {
+        "from": "{{ item.time_series }}",
+        "extract": {
+          "symbol": "{{ item.symbol }}",
+          "exchange": "{{ item.exchange }}",
+          "date": "{{ row.date }}",
+          "close": "{{ row.close }}"
+        }
+      },
+      "fields": {
+        "period": 14,
+        "threshold": 30,
+        "direction": "below"
       },
       "position": {
         "x": 550,
@@ -87,12 +97,12 @@
       "to": "broker"
     },
     {
-      "from": "watchlist",
-      "to": "historical"
+      "from": "broker",
+      "to": "watchlist"
     },
     {
-      "from": "broker",
-      "to": "condition"
+      "from": "watchlist",
+      "to": "historical"
     },
     {
       "from": "historical",

--- a/src/programgarden/examples/workflows/58-notification-rsi-test.json
+++ b/src/programgarden/examples/workflows/58-notification-rsi-test.json
@@ -22,8 +22,8 @@
       }
     },
     {
-      "id": "historical",
-      "type": "OverseasStockHistoricalDataNode",
+      "id": "watchlist",
+      "type": "WatchlistNode",
       "symbols": [
         {
           "symbol": "AAPL",
@@ -38,11 +38,20 @@
           "exchange": "NASDAQ"
         }
       ],
+      "position": {
+        "x": 400,
+        "y": 200
+      }
+    },
+    {
+      "id": "historical",
+      "type": "OverseasStockHistoricalDataNode",
+      "symbol": "{{ item }}",
       "start_date": "{{ date.ago(30, format='yyyymmdd') }}",
       "end_date": "{{ date.today(format='yyyymmdd') }}",
-      "interval": "1d",
+      "period": "D",
       "position": {
-        "x": 500,
+        "x": 600,
         "y": 200
       }
     },
@@ -50,7 +59,15 @@
       "id": "rsi",
       "type": "ConditionNode",
       "plugin": "RSI",
-      "data": "{{ nodes.historical.values }}",
+      "items": {
+        "from": "{{ item.time_series }}",
+        "extract": {
+          "symbol": "{{ item.symbol }}",
+          "exchange": "{{ item.exchange }}",
+          "date": "{{ row.date }}",
+          "close": "{{ row.close }}"
+        }
+      },
       "fields": {
         "period": 14,
         "threshold": 70,
@@ -69,6 +86,10 @@
     },
     {
       "from": "broker",
+      "to": "watchlist"
+    },
+    {
+      "from": "watchlist",
       "to": "historical"
     },
     {

--- a/src/programgarden/programgarden/resolver.py
+++ b/src/programgarden/programgarden/resolver.py
@@ -274,6 +274,74 @@ class WorkflowResolver:
                             suggestion="Install programgarden-community or register the plugin manually.",
                         )
                     )
+                else:
+                    # Plugin exists — verify the data binding shape matches the
+                    # plugin's contract. Mirrors the runtime branch in
+                    # executor (_execute_condition_node): position-management
+                    # plugins read `positions`, indicator plugins iterate
+                    # `items {from, extract}`. Without this static check the
+                    # wrong shape (legacy `data`/`params`) passes validate()
+                    # and only fails at dry_run, so the AI build self-correct
+                    # loop never sees it.
+                    plugin_schema = plugin_registry.get_schema(plugin_id)
+                    required_data = (
+                        plugin_schema.required_data if plugin_schema else ["data"]
+                    )
+                    is_positions_based = (
+                        "positions" in required_data and "data" not in required_data
+                    )
+                    if is_positions_based:
+                        if not node.get("positions"):
+                            result.add(
+                                build_error(
+                                    ErrorCode.MISSING_REQUIRED_FIELD,
+                                    f"ConditionNode '{node.get('id')}' uses position "
+                                    f"plugin '{plugin_id}' but has no 'positions' binding",
+                                    location=ErrorLocation(
+                                        node_id=node.get("id"),
+                                        node_type=node.get("type"),
+                                        plugin_id=plugin_id,
+                                        field_path="positions",
+                                    ),
+                                    suggestion=(
+                                        "Position-management plugins (StopLoss / "
+                                        "ProfitTarget / TrailingStop) read holdings from "
+                                        "'positions'. Bind it to an account node's "
+                                        "positions output, e.g. positions: "
+                                        "'{{ nodes.account.positions }}'. The 'data' / "
+                                        "'params' fields are not used here."
+                                    ),
+                                )
+                            )
+                    else:
+                        items = node.get("items")
+                        if (
+                            not isinstance(items, dict)
+                            or not items.get("from")
+                            or not items.get("extract")
+                        ):
+                            result.add(
+                                build_error(
+                                    ErrorCode.MISSING_REQUIRED_FIELD,
+                                    f"ConditionNode '{node.get('id')}' uses indicator "
+                                    f"plugin '{plugin_id}' but has no valid 'items' "
+                                    f"binding (items.from + items.extract)",
+                                    location=ErrorLocation(
+                                        node_id=node.get("id"),
+                                        node_type=node.get("type"),
+                                        plugin_id=plugin_id,
+                                        field_path="items",
+                                    ),
+                                    suggestion=(
+                                        "Indicator plugins iterate OHLCV through 'items'. "
+                                        "Add items with 'from' (the source array) and "
+                                        "'extract' (per-row field map), e.g. items: "
+                                        "{from: '{{ item.time_series }}', extract: "
+                                        "{symbol, exchange, date, close}}. The legacy "
+                                        "'data' / 'params' fields are not used."
+                                    ),
+                                )
+                            )
 
         # 5. 노드 연결 규칙 검증 (실시간 → 위험 노드 직결 차단)
         self._validate_connection_rules(workflow, registry, result)


### PR DESCRIPTION
## Summary

- `resolver.validate()` 에 ConditionNode 의 plugin 카테고리별 필수 입력 검증 추가:
  - **indicator 플러그인**(RSI/MACD 등) → `items {from, extract}` 필수
  - **position 플러그인**(StopLoss/ProfitTarget/TrailingStop) → `positions` 필수
  - 누락 시 `MISSING_REQUIRED_FIELD` 반환.
- 기존에는 잘못된 형태(legacy `data` / `params`)가 static `validate()` 를 통과하고 **dry_run 런타임에서만** `"items가 설정되지 않았습니다"` 로 실패 → AI 챗봇의 build 자가수정 루프가 이를 잡지 못했음. executor 의 런타임 분기(`is_positions_based = "positions" in required_data and "data" not in required_data`)를 그대로 미러링해 build 단계에서 결정적으로 surface.

## 부수 — 잠재 결함 예제 4개 수정

이 검증이 죽은 `data` 필드를 쓰던 셋업 예제를 드러냄. RSI/MACD 가 실제로 평가되지 않던 잠재 결함(dry_run 이 흡수해 `errors_count=0` 으로 통과하던 케이스):

| 예제 | 수정 |
|------|------|
| `13-logic-complex` | RSI+MACD `data` → `items {from, extract}` |
| `23-display-line-chart` | 단일 심볼 RSI `data`/`params` → `items` (`nodes.historical.value.time_series`) |
| `24-display-multi-line` | `data`/`params` → `items`, `broker→condition` 제거하고 `broker→watchlist→historical→condition` 으로 auto-iterate 보정 |
| `58-notification-rsi-test` | `data` → `items`, `symbols:[list]` → WatchlistNode 추가로 auto-iterate 보정 |

## Validation

- `pytest tests/test_examples_validation.py` → **244 passed, 1 skipped, 1 xfailed** (회귀 없음)
- buggy 형태(params/data)는 `is_valid=False`, 정답 형태(items/positions)는 `is_valid=True` 로 검증 확인

## 주의

- `main` 에서 다른 작업이 진행 중이라 직접 머지하지 말고 리뷰 후 반영 요청.
- 이 변경이 반영/릴리스되면 `programgarden_ai` 의 build 자가수정 루프가 ConditionNode 바인딩 오류를 build 단계에서 잡게 됩니다.