### PR TITLE
fix(deep-validate): 모든 노드의 {{ }} 필드 정적 평가로 검증 누락 갭 근본 수정

### DIFF
--- a/src/core/programgarden_core/expression/evaluator.py
+++ b/src/core/programgarden_core/expression/evaluator.py
@@ -24,7 +24,7 @@ Jinja2 스타일 {{ }} 표현식 평가기
 - 파일/네트워크 접근 차단
 """
 
-from typing import Any, Dict, Optional, List, Set
+from typing import Any, Callable, Dict, Optional, List, Set
 import re
 import ast
 import operator
@@ -1004,27 +1004,63 @@ class ExpressionEvaluator:
 
         return self.EXPRESSION_PATTERN.sub(replace_expr, value)
 
-    def evaluate_fields(self, fields: Dict[str, Any]) -> Dict[str, Any]:
+    def evaluate_fields(
+        self,
+        fields: Dict[str, Any],
+        on_error: Optional[Callable[[str, Exception], None]] = None,
+    ) -> Dict[str, Any]:
         """
         필드 딕셔너리의 모든 값 평가
 
         Args:
             fields: 노드의 fields 딕셔너리
+            on_error: (선택) leaf 표현식 평가 실패 시 호출되는 콜백
+                ``(expression_text, exception)``. 기본값 None.
+
+                - None 이면 leaf 실패 시 **기존대로 예외를 raise** 한다
+                  (정상 runtime/dry_run 동작 불변 — 이 메서드의 default 시맨틱).
+                - 콜백이 주어지면 raise 하지 않고 ``on_error(value, exc)`` 를
+                  호출한 뒤 **원본 leaf 값을 그대로 유지**한다. 이는
+                  ``evaluate_all_bindings`` 와 동일한 leaf 단위(per-leaf)
+                  try/except 시맨틱으로, deep_validate 가 미해결 binding 을
+                  leaf 단위로 수집할 수 있게 한다.
+
+                dict/list 재귀 시 콜백은 그대로 전파된다.
 
         Returns:
             평가된 필드 딕셔너리
         """
         result = {}
         for key, value in fields.items():
-            if isinstance(value, dict):
-                # 중첩 딕셔너리 재귀 처리
-                result[key] = self.evaluate_fields(value)
-            elif isinstance(value, list):
-                # 리스트 내 표현식 처리
-                result[key] = [self.evaluate(item) for item in value]
-            else:
-                result[key] = self.evaluate(value)
+            result[key] = self._evaluate_field_value(value, on_error)
         return result
+
+    def _evaluate_field_value(
+        self,
+        value: Any,
+        on_error: Optional[Callable[[str, Exception], None]],
+    ) -> Any:
+        """evaluate_fields 의 단일 값 평가 (dict/list 재귀, leaf 단위 on_error)."""
+        if isinstance(value, dict):
+            # 중첩 딕셔너리 재귀 처리 — 콜백 전파
+            return {
+                k: self._evaluate_field_value(v, on_error)
+                for k, v in value.items()
+            }
+        if isinstance(value, list):
+            # 리스트 내 표현식 처리 — 콜백 전파
+            return [self._evaluate_field_value(item, on_error) for item in value]
+        # leaf 값
+        if on_error is None or not self.is_expression(value):
+            # 기존 경로: on_error 없으면 실패 시 raise (동작 불변),
+            # 표현식이 아니면 그대로 반환.
+            return self.evaluate(value)
+        # on_error 모드 + 표현식 leaf: leaf 단위 try/except (evaluate_all_bindings 시맨틱)
+        try:
+            return self.evaluate(value)
+        except Exception as exc:  # noqa: BLE001 - leaf 단위로 사유를 콜백에 전달
+            on_error(value, exc)
+            return value
 
     def _eval_expression(self, expression: str) -> Any:
         """단일 표현식 평가"""

--- a/src/core/programgarden_core/expression/evaluator.py
+++ b/src/core/programgarden_core/expression/evaluator.py
@@ -1040,17 +1040,35 @@ class ExpressionEvaluator:
         value: Any,
         on_error: Optional[Callable[[str, Exception], None]],
     ) -> Any:
-        """evaluate_fields 의 단일 값 평가 (dict/list 재귀, leaf 단위 on_error)."""
+        """evaluate_fields 의 단일 값 평가.
+
+        재귀 깊이는 정상 모드(``on_error is None``)와 deep 모드(콜백 주어짐)에서
+        **동일**하다 — 기존 ``evaluate_fields`` 시맨틱과 100% 일치시킨다:
+
+        - dict 값 → ``evaluate_fields`` 재귀 (콜백 전파)
+        - list 값 → ``[self.evaluate(item) for item in value]`` (각 item 을
+          ``self.evaluate`` 로만 평가; **list 내부 dict/nested list 는 재귀하지
+          않는다** — 기존 동작). deep 모드면 item 단위 on_error try/except 적용.
+        - 그 외(leaf) → ``self.evaluate(value)`` (deep 모드면 leaf 단위 on_error)
+
+        ``on_error`` 가 주어진 경우(deep 모드)에만 평가 실패를 raise 하지 않고
+        콜백을 호출한 뒤 원본 값을 유지한다.
+        """
         if isinstance(value, dict):
-            # 중첩 딕셔너리 재귀 처리 — 콜백 전파
-            return {
-                k: self._evaluate_field_value(v, on_error)
-                for k, v in value.items()
-            }
+            # 중첩 딕셔너리 재귀 처리 — 콜백 전파 (기존 동작)
+            return self.evaluate_fields(value, on_error)
         if isinstance(value, list):
-            # 리스트 내 표현식 처리 — 콜백 전파
-            return [self._evaluate_field_value(item, on_error) for item in value]
+            # 리스트는 각 item 을 self.evaluate 로만 평가 (기존 동작 — dict 재귀 안 함)
+            return [self._evaluate_leaf(item, on_error) for item in value]
         # leaf 값
+        return self._evaluate_leaf(value, on_error)
+
+    def _evaluate_leaf(
+        self,
+        value: Any,
+        on_error: Optional[Callable[[str, Exception], None]],
+    ) -> Any:
+        """단일 leaf 값 평가 (dict/list 재귀 없음). deep 모드면 leaf 단위 on_error."""
         if on_error is None or not self.is_expression(value):
             # 기존 경로: on_error 없으면 실패 시 raise (동작 불변),
             # 표현식이 아니면 그대로 반환.

--- a/src/core/tests/test_expression_namespace.py
+++ b/src/core/tests/test_expression_namespace.py
@@ -394,3 +394,52 @@ class TestJsonLiteralAliases:
         assert evaluator.evaluate("{{ None }}") is None
         assert evaluator.evaluate("{{ True }}") is True
         assert evaluator.evaluate("{{ False }}") is False
+
+
+class TestEvaluateFieldsListSemantics:
+    """evaluate_fields 의 list/dict 재귀 깊이 불변 (runtime semantics).
+
+    정상 모드(on_error=None)는 기존 동작과 100% 동일해야 한다:
+    - dict 값 → evaluate_fields 재귀
+    - list 값 → 각 item 을 self.evaluate 로만 평가 (list 내부 dict 는 재귀 안 함)
+    deep 모드(on_error 콜백)도 재귀 깊이는 동일하다.
+    """
+
+    def _make_evaluator(self):
+        ctx = ExpressionContext()
+        ctx.set_node_output("mkt", "price", 123.45)
+        return ExpressionEvaluator(ctx)
+
+    def test_list_of_dict_inner_expression_not_evaluated_runtime(self):
+        """on_error=None: list 내부 dict 의 표현식은 평가되지 않고 리터럴 유지."""
+        evaluator = self._make_evaluator()
+        fields = {"orders": [{"p": "{{ nodes.mkt.price }}"}]}
+        out = evaluator.evaluate_fields(fields)
+        # 기존 [self.evaluate(item) ...] 시맨틱: dict item 은 self.evaluate 에
+        # 그대로 들어가고 dict 는 표현식이 아니므로 미평가 → 리터럴 유지.
+        assert out == {"orders": [{"p": "{{ nodes.mkt.price }}"}]}
+
+    def test_list_direct_expression_item_is_evaluated_runtime(self):
+        """on_error=None: list 의 직접 표현식 item 은 평가, dict 값은 재귀 평가."""
+        evaluator = self._make_evaluator()
+        fields = {
+            "a": ["{{ nodes.mkt.price }}", "lit"],
+            "b": {"c": "{{ nodes.mkt.price }}"},
+        }
+        out = evaluator.evaluate_fields(fields)
+        assert out == {"a": [123.45, "lit"], "b": {"c": 123.45}}
+
+    def test_deep_mode_same_recursion_depth_as_runtime(self):
+        """deep 모드(on_error 콜백)도 list 내부 dict 를 더 깊이 파지 않는다."""
+        evaluator = self._make_evaluator()
+        recorded = []
+
+        def on_error(expr, exc):
+            recorded.append((expr, type(exc).__name__))
+
+        fields = {"orders": [{"p": "{{ nodes.mkt.price }}"}]}
+        out = evaluator.evaluate_fields(fields, on_error)
+        # 정상 모드와 동일하게 list-of-dict 내부는 미평가 → 리터럴 유지.
+        assert out == {"orders": [{"p": "{{ nodes.mkt.price }}"}]}
+        # dict item 은 표현식이 아니므로 on_error 도 호출되지 않는다.
+        assert recorded == []

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -11,6 +11,8 @@ Workflow execution engine
 from typing import Optional, Dict, Any, List, Callable, Awaitable, Set, Tuple
 from datetime import datetime
 import asyncio
+import ast
+import re
 import uuid
 import logging
 
@@ -35,6 +37,47 @@ from programgarden_core.retry_executor import RetryExecutor
 from programgarden_core.nodes.base import BaseMessagingNode
 
 logger = logging.getLogger("programgarden.executor")
+
+
+# lib reserved iteration variable roots — valid ONLY mid-iteration.
+# `{{ item.* }}` (auto-iterate per-item) and `{{ row.* }}` (ConditionNode
+# items.extract) only resolve while the executor has an iteration context set;
+# before auto-iterate they legitimately fail to evaluate. These are lib
+# *identifiers* (single source of the engine's iteration binding), NOT
+# language keywords — the deep-validate recorder uses them as a structural
+# signal (AST free-variable roots) to avoid false-rejecting correct examples
+# whose nested config holds `{{ item.symbol }}` etc.
+_RESERVED_ITERATION_ROOTS: frozenset = frozenset({"item", "row"})
+
+_INLINE_EXPR_PATTERN = re.compile(r"\{\{\s*(.+?)\s*\}\}")
+
+
+def _free_root_names(text: str) -> Set[str]:
+    """Return the set of free-variable root identifiers referenced (ctx=Load) by
+    every ``{{ ... }}`` expression embedded in ``text``.
+
+    Used by the deep-validate binding recorder to decide whether an unresolved
+    expression is iteration-scoped (root in :data:`_RESERVED_ITERATION_ROOTS`)
+    and therefore expected to be deferred — not a real defect.
+
+    - ``{{ nodes.split.item }}`` → root ``nodes`` (``item`` is an attribute,
+      not a root) → NOT iteration-scoped.
+    - ``{{ x | length }}`` (unsupported pipe filter) → roots ``{x, length}``
+      → NOT iteration-scoped → recorded (desired).
+    - A genuinely malformed expression (SyntaxError) yields a sentinel
+      ``__syntax_error__`` root so the recorder treats it as a real defect.
+    """
+    roots: Set[str] = set()
+    for match in _INLINE_EXPR_PATTERN.findall(text):
+        try:
+            tree = ast.parse(match, mode="eval")
+        except SyntaxError:
+            # syntax error is a genuine defect → ensure it is recorded
+            return roots | {"__syntax_error__"}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+                roots.add(node.id)
+    return roots
 
 
 def _build_reconnect_hooks(
@@ -16749,7 +16792,7 @@ class WorkflowJob:
                     break  # 첫 번째 상위 노드만 사용
             
             # Resolve expressions in config ({{ input.xxx }}, {{ nodeId.port }})
-            config = self._resolve_config_expressions(config)
+            config = self._resolve_config_expressions(config, node_id)
 
             # Auto-inject connection from matching BrokerNode (Phase 5)
             config = self._auto_inject_connection(node_id, node, config)
@@ -17034,7 +17077,7 @@ class WorkflowJob:
             self.context.set_iteration_context(current_item, idx, total)
 
             # config 내 표현식 평가 ({{ item.xxx }}, {{ index }} 등)
-            item_config = self._resolve_config_expressions(config)
+            item_config = self._resolve_config_expressions(config, node_id)
 
             # 진행 상황 로그
             item_label = current_item.get("symbol", str(current_item)) if isinstance(current_item, dict) else str(current_item)
@@ -17428,7 +17471,7 @@ class WorkflowJob:
 
             # Prepare config
             config = dict(node.config)
-            config = self._resolve_config_expressions(config)
+            config = self._resolve_config_expressions(config, node_id)
             config = self._auto_inject_connection(node_id, node, config)
 
             # Connect inputs from upstream
@@ -17481,7 +17524,7 @@ class WorkflowJob:
         )
 
         config = dict(node.config)
-        config = self._resolve_config_expressions(config)
+        config = self._resolve_config_expressions(config, aggregate_id)
 
         try:
             outputs = await self.executor.execute_node(
@@ -17606,7 +17649,11 @@ class WorkflowJob:
         # 매칭 실패 시 원본 반환 (노드 executor에서 에러 처리)
         return config
 
-    def _resolve_config_expressions(self, config: Dict[str, Any]) -> Dict[str, Any]:
+    def _resolve_config_expressions(
+        self,
+        config: Dict[str, Any],
+        node_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """
         Config 내의 {{ }} 표현식을 resolve.
 
@@ -17619,6 +17666,17 @@ class WorkflowJob:
 
         Note: items 키는 제외 (ConditionNode의 _process_items_with_extract에서 별도 처리).
               items 내부에 {{ row.xxx }} 같은 지연 평가 표현식이 있어 여기서 평가하면 실패함.
+
+        Deep-validate 동작 (node_id 가 주어졌을 때만):
+            정상(runtime/dry_run) 모드는 한 필드라도 실패하면 전체 try/except 로
+            삼키고 원본을 유지한다(동작 불변). deep_validate 모드에서는 이 전체삼킴
+            경로가 미해결 ``{{ }}`` 표현식(잘못된 필드 경로·미정의 변수·미지원 pipe
+            filter 등)을 검증에서 그대로 통과시킨다 — 일부 executor 가
+            evaluate_all_bindings 를 부르지 않아 그 노드 표현식이 여기서만 평가되기
+            때문이다. 그래서 deep 모드 + node_id 가 있으면 leaf 단위 on_error
+            콜백으로 평가해 실패 leaf 를 record_deep_unresolved_binding 에 기록한다
+            (C1 가드 통과 시에만). 비-deep 모드 또는 node_id 가 없으면 기존
+            전체삼킴 경로 그대로다.
         """
         from programgarden_core.expression import ExpressionEvaluator
 
@@ -17634,13 +17692,48 @@ class WorkflowJob:
                 if isinstance(v, str) and "{{ item" in v:
                     deferred[k] = config_copy.pop(k)
 
-        try:
-            expr_context = self.context.get_expression_context()
-            evaluator = ExpressionEvaluator(expr_context)
-            resolved = evaluator.evaluate_fields(config_copy)
-        except Exception as e:
-            self.context.log("warning", f"Expression resolve failed: {e}")
-            resolved = config_copy
+        deep_mode = bool(getattr(self.context, "is_deep_validate", False))
+        if deep_mode and node_id is not None:
+            # deep_validate: leaf 단위로 평가하고 미해결 binding 을 기록.
+            def _recorder(expr: str, exc: Exception) -> None:
+                # C1 가드 — iteration 컨텍스트가 없을 때, 표현식이 lib 예약
+                # iteration 변수(item/row)를 자유변수 루트로 참조하면 기록 제외.
+                # `{{ item.* }}`(auto-iterate)·`{{ row.* }}`(items.extract)는
+                # iteration 시점에만 유효하고, top-level `{{ item`은 위에서 이미
+                # deferred 되지만 nested dict/list 안의 `{{ item.symbol }}`은
+                # deferred 를 빠져나가 auto-iterate 전 여기서 실패한다. 기록하면
+                # 정답 예제(30/31-liquidate-* 등)가 false-reject 된다.
+                if self.context._iteration_item is None:
+                    roots = _free_root_names(expr)
+                    if roots & _RESERVED_ITERATION_ROOTS:
+                        return
+                try:
+                    self.context.record_deep_unresolved_binding(
+                        node_id, expr, str(exc)
+                    )
+                except Exception:  # pragma: no cover - defensive
+                    pass
+
+            # NOTE: evaluator 구성(get_expression_context / ExpressionEvaluator
+            # → to_dict)도 try 안에 둔다 — 컨텍스트 자체가 손상돼 raise 하면 leaf
+            # on_error 가 아니라 여기서 터지므로, 기존 전체삼킴 경로와 동일하게
+            # 원본 config 를 유지해야 한다(동작 불변).
+            try:
+                expr_context = self.context.get_expression_context()
+                evaluator = ExpressionEvaluator(expr_context)
+                resolved = evaluator.evaluate_fields(config_copy, on_error=_recorder)
+            except Exception as e:  # pragma: no cover - on_error 가 leaf 에서 흡수
+                self.context.log("warning", f"Expression resolve failed: {e}")
+                resolved = config_copy
+        else:
+            # 정상 모드(또는 node_id 없음): 기존 전체삼킴 경로 (동작 불변).
+            try:
+                expr_context = self.context.get_expression_context()
+                evaluator = ExpressionEvaluator(expr_context)
+                resolved = evaluator.evaluate_fields(config_copy)
+            except Exception as e:
+                self.context.log("warning", f"Expression resolve failed: {e}")
+                resolved = config_copy
 
         # 지연 평가 필드 복원
         resolved.update(deferred)
@@ -17942,7 +18035,7 @@ class WorkflowJob:
                                 )
                 
                 # Resolve expressions in config
-                config_with_source = self._resolve_config_expressions(config_with_source)
+                config_with_source = self._resolve_config_expressions(config_with_source, node_id)
 
                 # Auto-inject connection from matching BrokerNode (Phase 5)
                 config_with_source = self._auto_inject_connection(node_id, node, config_with_source)

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -71,8 +71,11 @@ def _free_root_names(text: str) -> Set[str]:
     for match in _INLINE_EXPR_PATTERN.findall(text):
         try:
             tree = ast.parse(match, mode="eval")
-        except SyntaxError:
-            # syntax error is a genuine defect → ensure it is recorded
+        except (SyntaxError, ValueError):
+            # SyntaxError = genuine malformed expression.
+            # ValueError (incl. UnicodeEncodeError on surrogate chars) = the
+            # source cannot even be parsed/encoded — treat the same way so the
+            # expression is recorded (not dropped → no false-negative).
             return roots | {"__syntax_error__"}
         for node in ast.walk(tree):
             if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):

--- a/src/programgarden/tests/test_deep_validate.py
+++ b/src/programgarden/tests/test_deep_validate.py
@@ -845,3 +845,18 @@ async def test_c1_guard_nested_item_binding_not_false_rejected():
         + str([e.short() for e in binding_errs])
     )
     assert result.is_valid, [e.short() for e in result.errors]
+
+
+def test_free_root_names_does_not_raise_on_unparseable_source():
+    """_free_root_names must not raise on a value `ast.parse` can't even
+    encode (e.g. a lone surrogate char) — that would drop the whole node's
+    binding scan (false-negative). It must return the `__syntax_error__`
+    sentinel so the expression is still recorded as a real defect.
+
+    `ast.parse` raises ValueError (incl. UnicodeEncodeError) on surrogate
+    chars, not SyntaxError, so the guard must catch (SyntaxError, ValueError).
+    """
+    from programgarden.executor import _free_root_names
+
+    roots = _free_root_names("{{ \udcff }}")
+    assert "__syntax_error__" in roots

--- a/src/programgarden/tests/test_deep_validate.py
+++ b/src/programgarden/tests/test_deep_validate.py
@@ -16,6 +16,8 @@ All tests run with a hard timeout to guarantee no test hangs.
 from __future__ import annotations
 
 import asyncio
+import json
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -751,3 +753,95 @@ async def test_generic_node_invalid_config_lenient_in_dry_run():
     )
     assert isinstance(out, dict)
     assert "error" in out, "dry_run must keep lenient error output"
+
+
+# ============================================================
+# 14. Static binding scan — display/non-evaluate_all_bindings executors
+#
+# Some executors (DisplayNode / TableDisplayNode / Fundamental / Backtest /
+# Portfolio / LLM / AIAgent / SQLite ...) never call evaluate_all_bindings, so a
+# `{{ }}` expression in their config fields (data / title / limit ...) used to
+# slip past deep_validate entirely. The static binding scan in
+# `_resolve_config_expressions` (deep mode) now evaluates those leaves per-field
+# and records unresolved ones as DEEP_VALIDATION_BINDING_UNRESOLVED, while a C1
+# guard keeps mid-iteration `{{ item.* }}` / `{{ row.* }}` from false-rejecting
+# correct examples.
+# ============================================================
+
+_EXAMPLES_DIR = (
+    Path(__file__).resolve().parent / ".." / "examples" / "workflows"
+).resolve()
+
+
+def _load_example(name: str) -> dict:
+    """Load an examples/workflows/<name>.json workflow definition."""
+    return json.loads((_EXAMPLES_DIR / f"{name}.json").read_text())
+
+
+@pytest.mark.asyncio
+async def test_display_node_unsupported_filter_binding_is_caught():
+    """A TableDisplayNode `data` field using an unsupported pipe filter
+    (`{{ ... | length }}`) — which never resolves at runtime — must now be
+    flagged as a blocking DEEP_VALIDATION_BINDING_UNRESOLVED, not silently pass.
+
+    TableDisplayNode does not call evaluate_all_bindings, so before the static
+    binding scan this slipped through deep_validate (is_valid=True)."""
+    pg = ProgramGarden()
+    wf = _load_example("22-display-table")
+    for node in wf["nodes"]:
+        if node["id"] == "table":
+            node["data"] = "{{ nodes.account.positions | length }}"
+    result = await asyncio.wait_for(pg.executor.deep_validate(wf, timeout=12.0), timeout=20.0)
+    assert not result.is_valid, [e.short() for e in result.errors]
+    binding_errs = [e for e in result.errors if e.code == "DEEP_VALIDATION_BINDING_UNRESOLVED"]
+    assert binding_errs, [e.short() for e in result.errors]
+    assert "length" in binding_errs[0].message or "| length" in binding_errs[0].message
+
+
+@pytest.mark.asyncio
+async def test_display_node_undefined_variable_binding_is_caught():
+    """A DisplayNode `title` referencing an undefined variable must be flagged as
+    DEEP_VALIDATION_BINDING_UNRESOLVED (would keep its literal text at runtime)."""
+    pg = ProgramGarden()
+    wf = _load_example("22-display-table")
+    for node in wf["nodes"]:
+        if node["id"] == "table":
+            node["title"] = "{{ bogus_undefined_var }}"
+    result = await asyncio.wait_for(pg.executor.deep_validate(wf, timeout=12.0), timeout=20.0)
+    assert not result.is_valid, [e.short() for e in result.errors]
+    binding_errs = [e for e in result.errors if e.code == "DEEP_VALIDATION_BINDING_UNRESOLVED"]
+    assert binding_errs, [e.short() for e in result.errors]
+    assert "bogus_undefined_var" in binding_errs[0].message
+
+
+@pytest.mark.asyncio
+async def test_unmodified_display_table_example_still_passes():
+    """The pristine 22-display-table example (data = `{{ nodes.account.positions }}`,
+    a fully-resolvable binding) must remain valid with zero errors — the scan must
+    not introduce a false positive on a correct DisplayNode."""
+    pg = ProgramGarden()
+    wf = _load_example("22-display-table")
+    result = await asyncio.wait_for(pg.executor.deep_validate(wf, timeout=12.0), timeout=20.0)
+    assert result.is_valid, [e.short() for e in result.errors]
+    binding_errs = [e for e in result.errors if e.code == "DEEP_VALIDATION_BINDING_UNRESOLVED"]
+    assert not binding_errs, [e.short() for e in result.errors]
+
+
+@pytest.mark.asyncio
+async def test_c1_guard_nested_item_binding_not_false_rejected():
+    """C1 guard: the 30-liquidate-futures example wires nested `{{ item.symbol }}`
+    / `{{ item.quantity }}` etc. inside the order node's `order` dict. These are
+    auto-iterate bindings that only resolve mid-iteration; the static scan must
+    NOT record them as unresolved (would false-reject a correct example).
+
+    Proves the C1 reserved-iteration-root guard is load-bearing: the example must
+    have zero DEEP_VALIDATION_BINDING_UNRESOLVED errors and stay valid."""
+    pg = ProgramGarden()
+    wf = _load_example("30-liquidate-futures-positions")
+    result = await asyncio.wait_for(pg.executor.deep_validate(wf, timeout=12.0), timeout=20.0)
+    binding_errs = [e for e in result.errors if e.code == "DEEP_VALIDATION_BINDING_UNRESOLVED"]
+    assert not binding_errs, (
+        "nested {{ item.* }} must not be false-rejected: "
+        + str([e.short() for e in binding_errs])
+    )
+    assert result.is_valid, [e.short() for e in result.errors]


### PR DESCRIPTION
## 무엇을 (What)

`deep_validate`(=워크플로우를 실제로 돌리지 않고, 표현식만 정적으로 검사해 오류를 미리 잡는 검증 모드)가 **일부 노드의 `{{ }}` 표현식 필드를 검사하지 않고 빠져나가던 갭**을 모든 노드를 정적 평가하도록 근본 수정합니다.

## 왜 (Why)

기존에는 `deep_validate` 가 각 노드의 실행기를 돌리되, **`evaluate_all_bindings` 를 호출하는 노드만** `{{ }}` 표현식이 평가되고 미해결 바인딩이 기록됐습니다. 그래서 그 경로를 타지 않는 노드들 — DisplayNode/TableDisplayNode, Fundamental, Backtest, Portfolio, LLM, AIAgent, SQLite 등 — 의 config 필드(data/title/limit 등)에 들어있는

- 지원하지 않는 파이프 필터(예: `{{ ...|length }}`)
- 정의되지 않은 변수(예: `{{ bogus_var }}`)

가 검증을 그대로 통과(`is_valid=True`)했고, 런타임에는 그 표현식이 평가되지 않은 **문자 그대로의 텍스트**로 남아 버그가 됐습니다.

근본 원인: 메인 루프의 `_resolve_config_expressions` 가 `ExpressionEvaluator.evaluate_fields` 를 하나의 넓은 try/except 로 감싸, **필드 하나가 실패하면 통째로 삼켜져(warn 만)** 미해결 바인딩 기록 단계까지 도달하지 못했습니다. 반면 `evaluate_all_bindings` 는 leaf 단위 try/except 로 실패를 기록해 `deep_validate` 가 `DEEP_VALIDATION_BINDING_UNRESOLVED` 로 승격합니다. 이번 변경은 그 leaf 단위 기록을 **모든 노드 경로**로 확장합니다.

## 변경 내용

- **`evaluator.py` (`evaluate_fields`)**: `on_error` 콜백을 받아 leaf 단위로 실패를 보고. `on_error=None`(정상/dry_run 모드)일 때 시맨틱은 **불변** — 즉 정상 실행 결과는 그대로 유지.
- **`executor.py` (deep 모드)**: deep 모드에서 leaf 미해결 바인딩을 기록. **C1 가드** 포함 — 반복(iteration) 컨텍스트가 없을 때 예약 식별자(`item`/`row`)와 겹치는 자유변수 루트는 기록에서 제외해 false-reject(정상 워크플로우를 잘못 거부)를 방지.
- **NIT 1 수정 (런타임 시맨틱 보존)**: 새 helper 가 정상 모드(`on_error=None`)에서도 list-of-dict / 중첩 list 에 재귀해 원래 `evaluate_fields` 와 동작이 달라지던 문제를 수정. list 는 dict 재귀 없이 항목별 `self.evaluate` 만 적용하도록 원래 재귀 깊이에 맞춤.
- **ast.parse 가드 확대**: 파싱 불가 소스에서도 안전하게 빠지도록 보강.

## 변경 파일

- `src/core/programgarden_core/expression/evaluator.py`
- `src/programgarden/programgarden/executor.py`
- `src/programgarden/tests/test_deep_validate.py` (검증 테스트 추가)
- `src/core/tests/test_expression_namespace.py` (네임스페이스 테스트 추가)

## 검증

- reviewer **적대검증 PASS** — false-reject(정상 워크플로우 오거부) 0건, deep_validate 관련 테스트 전부 통과.
- 이 PR 브랜치에서 `test_deep_validate.py` 30개 + 예제 디스커버리/정적검증 테스트(86개 큐레이션 워크플로우) **전부 PASS**.
- 새로 추가된 가드 케이스: `22-display-table` 의 `{{ ...|length }}` / `{{ bogus_var }}` 가 이제 검증 단계에서 잡힘(=기존엔 빠져나가던 갭).
- 참고: `44-http-resilience` 의 dry_run 사이클 테스트는 외부 HTTP 호출에 의존하는 **사전 존재 환경 의존 실패**로, base(v1.23.0)에서도 동일하게 실패하며 이번 변경의 회귀가 아님(별도 확인).

## 비고

- **PyPI publish 는 별도 게이트라 이 PR 에 포함되지 않습니다** — 본 PR 은 소스 변경(git)만 담으며, 패키지 배포(PyPI publish)는 명시적 승인 후 별도로 진행합니다.