### PR TITLE
chore(license): core 1.15.2 + community 1.13.10 + programgarden 1.24.2 — AGPL 메타데이터 PyPI 노출

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "programgarden"
-version = "1.24.1"
+version = "1.24.2"
 description = "LS증권 API을 메인으로 제작된 노코딩 시스템 트레이딩 DSL 오픈소스"
 authors = [
     {name = "장용준",email = "coding@programgarden.com"}

--- a/src/community/CHANGELOG.md
+++ b/src/community/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.13.10] - 2026-06-28
+### Changed
+- 배포 메타데이터: `pyproject` `license = "AGPL-3.0-or-later"`(PEP 639, 저장소 LICENSE 일치)를 PyPI 공개 메타데이터에 노출. 코드/동작 변경 없음 (metadata-only patch).
+
 ## [1.13.9] - 2026-06-20
 ### Added
 - **TrailingStop v2.1.0 — `trail_percent` 고정 % 모드 + HWM 자가 갱신**

--- a/src/community/pyproject.toml
+++ b/src/community/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-community"
-version = "1.13.9"
+version = "1.13.10"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Community - 전략 플러그인 모음"
 readme = "README.md"

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.15.2] - 2026-06-28
+### Changed
+- 배포 메타데이터: `pyproject` `license = "AGPL-3.0-or-later"`(PEP 639, 저장소 LICENSE 일치)를 PyPI 공개 메타데이터에 노출. 코드/동작 변경 없음 (metadata-only patch).
+
 ## [1.15.1] - 2026-06-20
 ### Added
 - **Order reject diagnostics + empty-order reason 모델** (`programgarden_core.models.order_diagnostics`)

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-core"
-version = "1.15.1"
+version = "1.15.2"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 readme = "README.md"

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [1.24.2] - 2026-06-28
+### Changed
+- 배포 메타데이터: `pyproject` `license = "AGPL-3.0-or-later"`(PEP 639, 저장소 LICENSE 일치)를 PyPI 공개 메타데이터에 노출. 코드/동작 변경 없음 (metadata-only patch). 루트 `pyproject.toml` 버전도 1.24.2 동기화.
+
 ## [1.24.1] - 2026-06-20
 ### Added
 - **주문 거부 진단 + 빈주문 사유 구분** (order-error-mapping) — 라이브 런타임 주문 실패

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.24.1"
+version = "1.24.2"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"


### PR DESCRIPTION
직전 PyPI 배포본(core 1.15.1 / community 1.13.9 / programgarden 1.24.1)에 license 메타데이터가 없어 PyPI 공개 페이지에 AGPL 표기가 안 됨. metadata-only patch bump 으로 `license = "AGPL-3.0-or-later"`(PEP 639) 를 PyPI 에 반영.

- core 1.15.1 → 1.15.2
- community 1.13.9 → 1.13.10
- programgarden 1.24.1 → 1.24.2 (+ 루트 pyproject 동기화)

코드/동작 변경 없음. 의존성 제약(^x) 불변. finance 는 1.6.13 에서 이미 반영됨. 배포 후 PyPI 의존성 순서(core→community→programgarden)로 publish 예정.