### PR TITLE
release: core 1.18.0 / programgarden 1.26.0 — 국내주식(KRX) 카탈로그 + 선물 values 포트 배포갭 해소

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "programgarden"
-version = "1.24.2"
+version = "1.26.0"
 description = "LS증권 API을 메인으로 제작된 노코딩 시스템 트레이딩 DSL 오픈소스"
 authors = [
     {name = "장용준",email = "coding@programgarden.com"}

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.18.0] - 2026-07-13
+### Fixed
+- **`OverseasFuturesMarketDataNode` now declares a `values` OutputPort** (list of
+  market-data rows), matching `OverseasStockMarketDataNode` / `KoreaStockMarketDataNode`.
+  The deployed 1.17.0 exposed only the singular `value` port for futures, so a workflow
+  binding `{{ nodes.<market>.values }}` on a futures market-data node failed static
+  validation with `INVALID_EXPRESSION_REF` ("port 'values' is not an output of node ...").
+  Verified against `programgarden` examples/workflows: full-suite validate → **0 REJECT**
+  (was 2 — examples 81, 85) under this build; control group (port-name mutation → REJECT)
+  confirms the check is live. Overseas-stock and Korea stock were unaffected (already had
+  `values`). Released lockstep with Korea-stock support (see `programgarden` 1.26.0).
+
 ## [1.17.0] - 2026-07-11
 ### Added
 - `MissingDependencyError` (subclass of `ExecutionError`) in `exceptions.py` — a

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -1,4 +1,15 @@
 ## [1.18.0] - 2026-07-13
+### Added
+- **`FuturesContractNode`** — resolves an underlying futures product (`base_products`, e.g.
+  `HMH` = Mini Hang Seng) to its **currently listed contract symbol at execution time**, via the
+  LS contract-master query (o3101). Futures workflows previously hardcoded a month-coded symbol
+  (`HMHU26`), which dies **silently** the moment that month expires — LS returns empty bars and
+  no error, so the strategy just stops trading (14 of the 16 shipped futures examples were dead
+  this way). `contract_selection` picks `front` / `next` / `quarterly`. The `symbols` output has
+  the same `[{exchange, symbol}]` shape as `WatchlistNode`, so downstream futures nodes wire
+  unchanged. Requires an upstream `OverseasFuturesBrokerNode` (the master query needs a session).
+  i18n keys (en/ko) included.
+
 ### Fixed
 - **`OverseasFuturesMarketDataNode` now declares a `values` OutputPort** (list of
   market-data rows), matching `OverseasStockMarketDataNode` / `KoreaStockMarketDataNode`.

--- a/src/core/programgarden_core/__init__.py
+++ b/src/core/programgarden_core/__init__.py
@@ -35,6 +35,7 @@ __all__ = [
     # Nodes - Broker (상품별 분리)
     "OverseasStockBrokerNode",
     "OverseasFuturesBrokerNode",
+    "KoreaStockBrokerNode",
     # Nodes - Market (해외주식)
     "OverseasStockMarketDataNode",
     "OverseasStockHistoricalDataNode",
@@ -45,6 +46,12 @@ __all__ = [
     "OverseasFuturesHistoricalDataNode",
     "OverseasFuturesRealMarketDataNode",
     "OverseasFuturesSymbolQueryNode",
+    # Nodes - Market (국내주식)
+    "KoreaStockMarketDataNode",
+    "KoreaStockHistoricalDataNode",
+    "KoreaStockRealMarketDataNode",
+    "KoreaStockSymbolQueryNode",
+    "KoreaStockFundamentalNode",
     # Nodes - Account (해외주식)
     "OverseasStockAccountNode",
     "OverseasStockRealAccountNode",
@@ -53,6 +60,11 @@ __all__ = [
     "OverseasFuturesAccountNode",
     "OverseasFuturesRealAccountNode",
     "OverseasFuturesRealOrderEventNode",
+    # Nodes - Account (국내주식)
+    "KoreaStockAccountNode",
+    "KoreaStockOpenOrdersNode",
+    "KoreaStockRealAccountNode",
+    "KoreaStockRealOrderEventNode",
     # Nodes - Symbol (상품 무관)
     "WatchlistNode",
     "MarketUniverseNode",
@@ -79,6 +91,10 @@ __all__ = [
     "OverseasFuturesNewOrderNode",
     "OverseasFuturesModifyOrderNode",
     "OverseasFuturesCancelOrderNode",
+    # Nodes - Order (국내주식)
+    "KoreaStockNewOrderNode",
+    "KoreaStockModifyOrderNode",
+    "KoreaStockCancelOrderNode",
     # Nodes - Display (6개)
     "TableDisplayNode",
     "LineChartNode",

--- a/src/core/programgarden_core/__init__.py
+++ b/src/core/programgarden_core/__init__.py
@@ -46,6 +46,7 @@ __all__ = [
     "OverseasFuturesHistoricalDataNode",
     "OverseasFuturesRealMarketDataNode",
     "OverseasFuturesSymbolQueryNode",
+    "FuturesContractNode",
     # Nodes - Market (국내주식)
     "KoreaStockMarketDataNode",
     "KoreaStockHistoricalDataNode",

--- a/src/core/programgarden_core/i18n/locales/en.json
+++ b/src/core/programgarden_core/i18n/locales/en.json
@@ -1277,7 +1277,6 @@
   "ui.no_tables_create_first": "Create a table first",
   "ui.no_tables_found": "No tables found",
   "ui.select_table_first": "Select a table first",
-
   "connection_rules.realtime_to_order.reason": "Direct connection from realtime node to order node is blocked. Each tick would trigger an order, potentially causing unintended mass orders.",
   "connection_rules.realtime_to_order.suggestion": "Place a ThrottleNode between the realtime node and order node to control execution frequency.",
   "connection_rules.realtime_to_ai_agent.reason": "Direct connection from realtime node to AIAgentNode is blocked. Each tick would trigger an LLM call, potentially causing excessive costs.",
@@ -1286,12 +1285,10 @@
   "connection_rules.realtime_to_external_api.suggestion": "Place a ThrottleNode between the realtime node and external API node to control request frequency.",
   "connection_rules.realtime_to_http.reason": "Direct connection from realtime node to HTTPRequestNode is not recommended. Each tick would trigger an HTTP request, potentially hitting external API rate limits.",
   "connection_rules.realtime_to_http.suggestion": "Place a ThrottleNode between the realtime node and HTTP request node to control request frequency.",
-
   "fields.BaseOrderNode.rate_limit_interval": "Minimum order interval (seconds). Default 5 seconds. The next order will only execute after this time has elapsed since the last order.",
   "fields.BaseOrderNode.rate_limit_action": "Action when order interval is not met. skip: silently skip, error: raise error",
   "enums.rate_limit_action.skip": "Skip (default)",
   "enums.rate_limit_action.error": "Raise error",
-
   "plugins.TimeSeriesMomentum.name": "Time Series Momentum",
   "plugins.TimeSeriesMomentum.description": "Determines trading direction based on past returns of individual assets (Moskowitz et al. 2012)",
   "plugins.ConnorsRSI.name": "Connors RSI",
@@ -1321,5 +1318,13 @@
   "events.restart.data_gap_warning": "Data gap warning during restore: data may be missing for {gap_sec} seconds since checkpoint",
   "events.restart.skipped_nodes": "Restore: skipping {count} completed nodes",
   "events.restart.checkpoint_expired": "Checkpoint expired ({age_sec}s > 600s limit)",
-  "events.restart.workflow_changed": "Workflow definition changed, cannot restore (hash mismatch)"
+  "events.restart.workflow_changed": "Workflow definition changed, cannot restore (hash mismatch)",
+  "nodes.FuturesContractNode.name": "Futures Contract",
+  "nodes.FuturesContractNode.description": "Resolves an underlying futures product (e.g. Mini Hang Seng) to its currently listed contract symbol at execution time, so the workflow never breaks when a contract expires. Pick the front month, the next month (roll target), or the nearest quarterly. Outputs a symbol list identical in shape to WatchlistNode, so downstream futures nodes wire unchanged. Requires an upstream OverseasFuturesBrokerNode. Typical connection: FuturesContractNode → OverseasFuturesHistoricalDataNode / OverseasFuturesMarketDataNode.",
+  "fieldNames.FuturesContractNode.base_products": "Underlying Products",
+  "fieldNames.FuturesContractNode.contract_selection": "Contract Selection",
+  "fieldNames.FuturesContractNode.futures_exchange": "Exchange",
+  "enums.contract_selection.front": "Front month (nearest expiry)",
+  "enums.contract_selection.next": "Next month (roll target)",
+  "enums.contract_selection.quarterly": "Quarterly (Mar/Jun/Sep/Dec)"
 }

--- a/src/core/programgarden_core/i18n/locales/ko.json
+++ b/src/core/programgarden_core/i18n/locales/ko.json
@@ -1318,5 +1318,13 @@
   "events.restart.data_gap_warning": "복구 중 데이터 갭 경고: 체크포인트 이후 {gap_sec}초 동안의 데이터가 누락될 수 있습니다",
   "events.restart.skipped_nodes": "복구: {count}개 완료 노드 스킵",
   "events.restart.checkpoint_expired": "체크포인트가 만료됨 ({age_sec}초 > 600초 제한)",
-  "events.restart.workflow_changed": "워크플로우 정의가 변경되어 복구 불가 (해시 불일치)"
+  "events.restart.workflow_changed": "워크플로우 정의가 변경되어 복구 불가 (해시 불일치)",
+  "nodes.FuturesContractNode.name": "선물 월물 선택",
+  "nodes.FuturesContractNode.description": "기초자산(예: 미니 항셍)을 실행 시점에 **현재 상장된 월물 종목코드**로 바꿔줍니다. 월물을 직접 적어두면 만기가 지나는 순간 시세가 조용히 끊기는데, 이 노드를 쓰면 시간이 지나도 자동으로 다음 월물로 넘어갑니다. 근월물/차월물/분기월물 중에서 고를 수 있습니다. 출력 형식이 관심종목 노드와 같아서 아래쪽 배선을 그대로 두면 됩니다. 위쪽에 해외선물 브로커 노드가 필요합니다.",
+  "fieldNames.FuturesContractNode.base_products": "기초자산",
+  "fieldNames.FuturesContractNode.contract_selection": "월물 선택",
+  "fieldNames.FuturesContractNode.futures_exchange": "거래소",
+  "enums.contract_selection.front": "근월물 (만기 가장 가까움)",
+  "enums.contract_selection.next": "차월물 (롤오버 대상)",
+  "enums.contract_selection.quarterly": "분기월물 (3·6·9·12월)"
 }

--- a/src/core/programgarden_core/models/credential.py
+++ b/src/core/programgarden_core/models/credential.py
@@ -160,6 +160,40 @@ BUILTIN_CREDENTIAL_SCHEMAS: Dict[str, CredentialTypeSchema] = {
         }
     ),
     # ============================================================
+    # LS증권 국내주식 (korea_stock) - 모의투자 미지원 (실전 전용)
+    # ============================================================
+    "broker_ls_korea_stock": CredentialTypeSchema(
+        type_id="broker_ls_korea_stock",
+        name="LS증권 국내주식",
+        description="국내주식 OpenAPI 인증 정보 (실전 전용 — 모의투자 미지원)",
+        widget_schema={
+            "fields": [
+                {
+                    "key": "name",
+                    "type": "text",
+                    "label": "Credential 이름",
+                    "hint": "my-ls-korea-cred",
+                    "description": "이 인증 정보를 식별할 이름",
+                    "required": True
+                },
+                {
+                    "key": "appkey",
+                    "type": "password",
+                    "label": "App Key",
+                    "description": "LS증권에서 발급받은 App Key",
+                    "required": True
+                },
+                {
+                    "key": "appsecret",
+                    "type": "password",
+                    "label": "App Secret",
+                    "description": "LS증권에서 발급받은 App Secret",
+                    "required": True
+                }
+            ]
+        }
+    ),
+    # ============================================================
     # Telegram Bot
     # ============================================================
     "telegram": CredentialTypeSchema(

--- a/src/core/programgarden_core/models/exchange.py
+++ b/src/core/programgarden_core/models/exchange.py
@@ -15,6 +15,7 @@ class ProductType(str, Enum):
     """상품 타입"""
     OVERSEAS_STOCK = "overseas_stock"
     OVERSEAS_FUTURES = "overseas_futures"
+    KOREA_STOCK = "korea_stock"        # 국내주식 (KOSPI/KOSDAQ, KRX 단일)
 
 
 class ExchangeInfo(BaseModel):
@@ -136,8 +137,20 @@ class ExchangeRegistry:
             ),
         }
         
+        # 국내주식 거래소 (KRX 단일 — KOSPI/KOSDAQ 통합)
+        ls_korea_stock = {
+            "KRX": ExchangeInfo(
+                code="KRX",
+                name="KRX",
+                full_name="Korea Exchange",
+                country="KR",
+                currency="KRW",
+            ),
+        }
+
         self.register_exchanges("ls", ProductType.OVERSEAS_STOCK, ls_overseas_stock)
         self.register_exchanges("ls", ProductType.OVERSEAS_FUTURES, ls_overseas_futures)
+        self.register_exchanges("ls", ProductType.KOREA_STOCK, ls_korea_stock)
     
     def register_exchanges(
         self, 
@@ -209,7 +222,11 @@ class ExchangeRegistry:
         # 해외선물: CME 기본
         if product == ProductType.OVERSEAS_FUTURES:
             return "CME" if "CME" in exchanges else exchanges[0]
-        
+
+        # 국내주식: KRX 단일
+        if product == ProductType.KOREA_STOCK:
+            return "KRX" if "KRX" in exchanges else exchanges[0]
+
         return exchanges[0]
 
 
@@ -229,6 +246,10 @@ class SymbolEntry(BaseModel):
     
     def to_api_symbol(self, broker: str, product: ProductType) -> str:
         """API용 종목코드 생성 (예: 82AAPL)"""
+        # 국내주식: 6자리 KRX 종목코드를 그대로 사용 (거래소 접두어 없음)
+        if product == ProductType.KOREA_STOCK:
+            return self.symbol
+
         code = exchange_registry.name_to_code(broker, product, self.exchange)
         if code is None:
             raise ValueError(f"Unknown exchange: {self.exchange}")

--- a/src/core/programgarden_core/nodes/__init__.py
+++ b/src/core/programgarden_core/nodes/__init__.py
@@ -45,7 +45,7 @@ from programgarden_core.nodes.account_futures import OverseasFuturesAccountNode
 from programgarden_core.nodes.open_orders_stock import OverseasStockOpenOrdersNode
 from programgarden_core.nodes.open_orders_futures import OverseasFuturesOpenOrdersNode
 from programgarden_core.nodes.symbol_stock import OverseasStockSymbolQueryNode
-from programgarden_core.nodes.symbol_futures import OverseasFuturesSymbolQueryNode
+from programgarden_core.nodes.symbol_futures import OverseasFuturesSymbolQueryNode, FuturesContractNode
 # Data (상품 무관)
 from programgarden_core.nodes.data import SQLiteNode, HTTPRequestNode, FieldMappingNode
 from programgarden_core.nodes.code import CodeNode
@@ -132,6 +132,7 @@ __all__ = [
     "OverseasFuturesHistoricalDataNode",
     "OverseasFuturesRealMarketDataNode",
     "OverseasFuturesSymbolQueryNode",
+    "FuturesContractNode",
     # Account - Stock (해외주식)
     "OverseasStockAccountNode",
     "OverseasStockRealAccountNode",

--- a/src/core/programgarden_core/nodes/data_futures.py
+++ b/src/core/programgarden_core/nodes/data_futures.py
@@ -102,14 +102,11 @@ class OverseasFuturesMarketDataNode(BaseNode):
                 "nodes": [
                     {"id": "start", "type": "StartNode"},
                     {"id": "broker", "type": "OverseasFuturesBrokerNode", "credential_id": "broker_cred", "paper_trading": False},
-                    {"id": "split", "type": "SplitNode", "items": [{"symbol": "ESH26", "exchange": "CME"}]},
-                    {"id": "market", "type": "OverseasFuturesMarketDataNode", "symbol": "{{ nodes.split.item }}"},
-                    {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.market.value }}"},
+                    {"id": "market", "type": "OverseasFuturesMarketDataNode", "symbols": [{"symbol": "ESH26", "exchange": "CME"}]},
+                    {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.market.values }}"},
                 ],
                 "edges": [
                     {"from": "start", "to": "broker"},
-                    {"from": "broker", "to": "split"},
-                    {"from": "split", "to": "market"},
                     {"from": "broker", "to": "market"},
                     {"from": "market", "to": "display"},
                 ],
@@ -124,7 +121,7 @@ class OverseasFuturesMarketDataNode(BaseNode):
                     }
                 ],
             },
-            "expected_output": "value port: {symbol, exchange, current_price, volume, open_interest, change_percent, bid, ask}.",
+            "expected_output": "values port: array of {symbol, exchange, current_price, volume, open_interest, change_percent, bid, ask}.",
         },
         {
             "title": "Multi-contract scan — compare HKEX futures prices",
@@ -135,14 +132,11 @@ class OverseasFuturesMarketDataNode(BaseNode):
                 "nodes": [
                     {"id": "start", "type": "StartNode"},
                     {"id": "broker", "type": "OverseasFuturesBrokerNode", "credential_id": "broker_cred", "paper_trading": False},
-                    {"id": "split", "type": "SplitNode", "items": [{"symbol": "MHIH26", "exchange": "HKEX"}, {"symbol": "MHIK26", "exchange": "HKEX"}]},
-                    {"id": "market", "type": "OverseasFuturesMarketDataNode", "symbol": "{{ nodes.split.item }}"},
-                    {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.market.value }}"},
+                    {"id": "market", "type": "OverseasFuturesMarketDataNode", "symbols": [{"symbol": "MHIH26", "exchange": "HKEX"}, {"symbol": "MHIK26", "exchange": "HKEX"}]},
+                    {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.market.values }}"},
                 ],
                 "edges": [
                     {"from": "start", "to": "broker"},
-                    {"from": "broker", "to": "split"},
-                    {"from": "split", "to": "market"},
                     {"from": "broker", "to": "market"},
                     {"from": "market", "to": "display"},
                 ],
@@ -157,23 +151,25 @@ class OverseasFuturesMarketDataNode(BaseNode):
                     }
                 ],
             },
-            "expected_output": "market.value emitted once per contract with price/volume data for each HKEX mini-futures contract.",
+            "expected_output": "market.values — array with one {price, volume, ...} entry per HKEX mini-futures contract.",
         },
     ]
     _node_guide: ClassVar[Dict[str, Any]] = {
         "input_handling": (
-            "The `symbol` field takes a single {exchange, symbol} dict. "
+            "The `symbols` field takes an array of {exchange, symbol} dicts — or bind a list source. "
             "Exchange values: CME, EUREX, SGX, HKEX. Symbol includes contract month code (e.g., ESH26 for March 2026). "
             "Broker connection auto-injected from OverseasFuturesBrokerNode."
         ),
         "output_consumption": (
-            "The `value` port emits: {symbol, exchange, current_price, volume, open_interest, change_percent, bid, ask}. "
-            "Access individual fields via `{{ nodes.market.value.current_price }}`."
+            "Consume the `values` port ONLY — an array of {symbol, exchange, current_price, volume, open_interest, change_percent, bid, ask}. "
+            "⚠️ The `value` (singular) port is NOT populated at runtime — the executor emits `values` only; "
+            "binding `{{ nodes.market.value }}` (or `.value.current_price`) silently resolves to None. "
+            "TableDisplayNode.data ← `{{ nodes.market.values }}`; PositionSizingNode.market_data ← `{{ nodes.market.values }}`."
         ),
         "common_combinations": [
-            "SplitNode.item → OverseasFuturesMarketDataNode → ConditionNode (per-contract signal)",
-            "OverseasFuturesMarketDataNode.value.current_price → PositionSizingNode.price",
-            "OverseasFuturesMarketDataNode.value → TableDisplayNode (futures monitor)",
+            "OverseasFuturesSymbolQueryNode → OverseasFuturesMarketDataNode.symbols (multi-contract fetch)",
+            "OverseasFuturesMarketDataNode.values → TableDisplayNode.data (futures monitor)",
+            "OverseasFuturesMarketDataNode.values → PositionSizingNode.market_data (with symbols + balance)",
         ],
         "pitfalls": [
             "Symbol must include contract month code (e.g., ESH26 not ES) — check OverseasFuturesSymbolQueryNode for valid codes",
@@ -188,6 +184,11 @@ class OverseasFuturesMarketDataNode(BaseNode):
     ]
     _outputs: List[OutputPort] = [
         OutputPort(name="value", type="market_data", description="i18n:ports.market_data_value", fields=PRICE_DATA_FIELDS),
+        OutputPort(
+            name="values",
+            type="array",
+            description="Array of per-contract market quotes — [{symbol, exchange, current_price, ...}, ...]",
+        ),
     ]
 
     _version: ClassVar[str] = "1.0.0"

--- a/src/core/programgarden_core/nodes/data_korea_stock.py
+++ b/src/core/programgarden_core/nodes/data_korea_stock.py
@@ -102,14 +102,11 @@ class KoreaStockMarketDataNode(BaseNode):
                 "nodes": [
                     {"id": "start", "type": "StartNode"},
                     {"id": "broker", "type": "KoreaStockBrokerNode", "credential_id": "broker_cred"},
-                    {"id": "split", "type": "SplitNode", "items": [{"symbol": "005930"}, {"symbol": "000660"}]},
-                    {"id": "market", "type": "KoreaStockMarketDataNode", "symbol": "{{ nodes.split.item }}"},
-                    {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.market.value }}"},
+                    {"id": "market", "type": "KoreaStockMarketDataNode", "symbols": [{"symbol": "005930"}, {"symbol": "000660"}]},
+                    {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.market.values }}"},
                 ],
                 "edges": [
                     {"from": "start", "to": "broker"},
-                    {"from": "broker", "to": "split"},
-                    {"from": "split", "to": "market"},
                     {"from": "broker", "to": "market"},
                     {"from": "market", "to": "display"},
                 ],
@@ -124,7 +121,7 @@ class KoreaStockMarketDataNode(BaseNode):
                     }
                 ],
             },
-            "expected_output": "value port: {symbol, current_price, volume, change_percent, bid, ask, per, eps} per domestic stock.",
+            "expected_output": "values port: array of {symbol, current_price, volume, change_percent, bid, ask, per, eps} per domestic stock.",
         },
         {
             "title": "Price lookup for domestic PositionSizingNode",
@@ -136,15 +133,12 @@ class KoreaStockMarketDataNode(BaseNode):
                     {"id": "start", "type": "StartNode"},
                     {"id": "broker", "type": "KoreaStockBrokerNode", "credential_id": "broker_cred"},
                     {"id": "account", "type": "KoreaStockAccountNode"},
-                    {"id": "split", "type": "SplitNode", "items": [{"symbol": "005930"}]},
-                    {"id": "market", "type": "KoreaStockMarketDataNode", "symbol": "{{ nodes.split.item }}"},
-                    {"id": "sizing", "type": "PositionSizingNode", "method": "fixed_percent", "max_percent": 5, "balance": "{{ nodes.account.balance }}", "price": "{{ nodes.market.value.current_price }}", "symbol": "{{ nodes.split.item }}"},
+                    {"id": "market", "type": "KoreaStockMarketDataNode", "symbols": [{"symbol": "005930"}]},
+                    {"id": "sizing", "type": "PositionSizingNode", "method": "fixed_percent", "max_percent": 5, "balance": "{{ nodes.account.balance.orderable_amount }}", "market_data": "{{ nodes.market.values }}", "symbols": "{{ nodes.market.values }}"},
                 ],
                 "edges": [
                     {"from": "start", "to": "broker"},
                     {"from": "broker", "to": "account"},
-                    {"from": "broker", "to": "split"},
-                    {"from": "split", "to": "market"},
                     {"from": "broker", "to": "market"},
                     {"from": "market", "to": "sizing"},
                     {"from": "account", "to": "sizing"},
@@ -160,7 +154,7 @@ class KoreaStockMarketDataNode(BaseNode):
                     }
                 ],
             },
-            "expected_output": "market.value.current_price is fed into PositionSizingNode to compute risk-adjusted domestic stock order quantity.",
+            "expected_output": "market.values (per-symbol price array) + account.balance.orderable_amount feed PositionSizingNode to compute risk-adjusted domestic stock order quantity (orders port).",
         },
     ]
     _node_guide: ClassVar[Dict[str, Any]] = {
@@ -170,13 +164,17 @@ class KoreaStockMarketDataNode(BaseNode):
             "Broker connection is auto-injected from KoreaStockBrokerNode."
         ),
         "output_consumption": (
-            "The `value` port emits: {symbol, current_price, volume, change_percent, bid, ask, per, eps, 52w_high, 52w_low}. "
-            "Access via `{{ nodes.market.value.current_price }}`."
+            "Consume the `values` port ONLY — an array of per-symbol snapshots "
+            "[{symbol, current_price, volume, change_percent, bid, ask, per, eps, 52w_high, 52w_low}, ...]. "
+            "⚠️ The `value` (singular) port is NOT populated at runtime — the executor emits `values` only; "
+            "binding `{{ nodes.market.value }}` (or `.value.current_price`) silently resolves to None. "
+            "TableDisplayNode.data ← `{{ nodes.market.values }}`; PositionSizingNode.market_data ← `{{ nodes.market.values }}` "
+            "(the array carries each symbol's current_price, which PositionSizingNode resolves internally)."
         ),
         "common_combinations": [
-            "SplitNode.item → KoreaStockMarketDataNode → ConditionNode (domestic price-based signal)",
-            "KoreaStockMarketDataNode.value.current_price → PositionSizingNode.price",
-            "KoreaStockMarketDataNode.value → TableDisplayNode (KRX price monitor)",
+            "KoreaStockMarketDataNode.values → TableDisplayNode.data (KRX price monitor)",
+            "KoreaStockMarketDataNode.values → PositionSizingNode.market_data (with symbols + balance=KoreaStockAccountNode.balance.orderable_amount)",
+            "KoreaStockSymbolQueryNode/ConditionNode.passed_symbols → PositionSizingNode.symbols (canonical symbol list)",
         ],
         "pitfalls": [
             "KoreaStock does not support paper trading — KoreaStockBrokerNode always uses a live session",

--- a/src/core/programgarden_core/nodes/data_stock.py
+++ b/src/core/programgarden_core/nodes/data_stock.py
@@ -102,14 +102,11 @@ class OverseasStockMarketDataNode(BaseNode):
                 "nodes": [
                     {"id": "start", "type": "StartNode"},
                     {"id": "broker", "type": "OverseasStockBrokerNode", "credential_id": "broker_cred", "paper_trading": False},
-                    {"id": "split", "type": "SplitNode", "items": [{"symbol": "AAPL", "exchange": "NASDAQ"}, {"symbol": "MSFT", "exchange": "NASDAQ"}]},
-                    {"id": "market", "type": "OverseasStockMarketDataNode", "symbol": "{{ nodes.split.item }}"},
-                    {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.market.value }}"},
+                    {"id": "market", "type": "OverseasStockMarketDataNode", "symbols": [{"symbol": "AAPL", "exchange": "NASDAQ"}, {"symbol": "MSFT", "exchange": "NASDAQ"}]},
+                    {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.market.values }}"},
                 ],
                 "edges": [
                     {"from": "start", "to": "broker"},
-                    {"from": "broker", "to": "split"},
-                    {"from": "split", "to": "market"},
                     {"from": "broker", "to": "market"},
                     {"from": "market", "to": "display"},
                 ],
@@ -124,7 +121,7 @@ class OverseasStockMarketDataNode(BaseNode):
                     }
                 ],
             },
-            "expected_output": "value port: {symbol, exchange, current_price, volume, change_percent, bid, ask, per, eps} for each symbol.",
+            "expected_output": "values port: array of {symbol, exchange, current_price, volume, change_percent, bid, ask, per, eps} for each symbol.",
         },
         {
             "title": "Price lookup feeding PositionSizingNode",
@@ -136,15 +133,12 @@ class OverseasStockMarketDataNode(BaseNode):
                     {"id": "start", "type": "StartNode"},
                     {"id": "broker", "type": "OverseasStockBrokerNode", "credential_id": "broker_cred", "paper_trading": False},
                     {"id": "account", "type": "OverseasStockAccountNode"},
-                    {"id": "split", "type": "SplitNode", "items": [{"symbol": "NVDA", "exchange": "NASDAQ"}]},
-                    {"id": "market", "type": "OverseasStockMarketDataNode", "symbol": "{{ nodes.split.item }}"},
-                    {"id": "sizing", "type": "PositionSizingNode", "method": "fixed_percent", "max_percent": 5, "balance": "{{ nodes.account.balance }}", "price": "{{ nodes.market.value.current_price }}", "symbol": "{{ nodes.split.item }}"},
+                    {"id": "market", "type": "OverseasStockMarketDataNode", "symbols": [{"symbol": "NVDA", "exchange": "NASDAQ"}]},
+                    {"id": "sizing", "type": "PositionSizingNode", "method": "fixed_percent", "max_percent": 5, "balance": "{{ nodes.account.balance }}", "market_data": "{{ nodes.market.values }}", "symbols": "{{ nodes.market.values }}"},
                 ],
                 "edges": [
                     {"from": "start", "to": "broker"},
                     {"from": "broker", "to": "account"},
-                    {"from": "broker", "to": "split"},
-                    {"from": "split", "to": "market"},
                     {"from": "broker", "to": "market"},
                     {"from": "market", "to": "sizing"},
                     {"from": "account", "to": "sizing"},
@@ -160,24 +154,27 @@ class OverseasStockMarketDataNode(BaseNode):
                     }
                 ],
             },
-            "expected_output": "market.value.current_price fed into PositionSizingNode to compute risk-adjusted order quantity.",
+            "expected_output": "market.values (per-symbol price array) fed into PositionSizingNode.market_data to compute risk-adjusted order quantity (orders port).",
         },
     ]
     _node_guide: ClassVar[Dict[str, Any]] = {
         "input_handling": (
-            "The `symbol` field takes a single {exchange, symbol} dict — always bind it to `{{ nodes.split.item }}` "
-            "when iterating over a list. Exchange codes: NASDAQ, NYSE, AMEX. "
+            "The `symbols` field takes an array of {exchange, symbol} dicts (e.g. [{\"symbol\": \"AAPL\", \"exchange\": \"NASDAQ\"}]) "
+            "— or bind a list source `{{ nodes.watchlist.symbols }}` / `{{ nodes.split_symbol.items }}`. Exchange codes: NASDAQ, NYSE, AMEX. "
             "The node auto-receives the broker connection via DAG traversal from OverseasStockBrokerNode."
         ),
         "output_consumption": (
-            "The `value` port emits a flat dict with fields: symbol, exchange, current_price, volume, change_percent, "
-            "bid, ask, per, eps, 52w_high, 52w_low. Access individual fields via `{{ nodes.market.value.current_price }}`."
+            "Consume the `values` port ONLY — an array of {symbol, exchange, current_price, volume, change_percent, "
+            "bid, ask, per, eps, 52w_high, 52w_low}. "
+            "⚠️ The `value` (singular) port is NOT populated at runtime — the executor emits `values` only; "
+            "binding `{{ nodes.market.value }}` (or `.value.current_price`) silently resolves to None. "
+            "TableDisplayNode.data ← `{{ nodes.market.values }}`; PositionSizingNode.market_data ← `{{ nodes.market.values }}` "
+            "(the array carries each symbol's current_price, resolved internally)."
         ),
         "common_combinations": [
-            "SplitNode.item → OverseasStockMarketDataNode (per-symbol price fetch in iteration)",
-            "OverseasStockMarketDataNode.value → ConditionNode (price-based signal trigger)",
-            "OverseasStockMarketDataNode.value.current_price → PositionSizingNode.price",
-            "OverseasStockMarketDataNode.value → TableDisplayNode (price monitoring display)",
+            "WatchlistNode/SymbolQueryNode → OverseasStockMarketDataNode.symbols (multi-symbol price fetch)",
+            "OverseasStockMarketDataNode.values → TableDisplayNode.data (price monitoring display)",
+            "OverseasStockMarketDataNode.values → PositionSizingNode.market_data (with symbols + balance)",
         ],
         "pitfalls": [
             "The symbol field must be a single dict — not a list. Use SplitNode for multi-symbol scenarios",

--- a/src/core/programgarden_core/nodes/symbol_futures.py
+++ b/src/core/programgarden_core/nodes/symbol_futures.py
@@ -1,8 +1,9 @@
 """
-ProgramGarden Core - Futures Symbol Query Node
+ProgramGarden Core - Futures Symbol Nodes
 
-해외선물 전체종목조회:
+해외선물 종목 관련:
 - OverseasFuturesSymbolQueryNode: 해외선물 전체 거래 가능 종목 조회 (o3101 API)
+- FuturesContractNode: 기초자산의 **현재 상장 월물**을 실행 시점에 해소 (o3101 API)
 """
 
 from typing import Any, Optional, List, Literal, Dict, ClassVar, TYPE_CHECKING
@@ -233,5 +234,261 @@ class OverseasFuturesSymbolQueryNode(BaseNode):
                 expression_mode=ExpressionMode.FIXED_ONLY,
                 example=500,
                 expected_type="int",
+            ),
+        }
+
+
+class FuturesContractNode(BaseNode):
+    """
+    해외선물 월물 해소 노드
+
+    기초자산(예: HMH=미니항셍)의 **현재 상장된 월물**을 실행 시점에 조회해
+    실제 종목코드(예: HMHN26)로 해소합니다. o3101 API (해외선물마스터조회) 사용.
+
+    워크플로우에 월물 코드를 하드코딩하면 만기가 지나는 순간 조용히 죽습니다
+    (LS 는 만기 경과 종목에 과거봉도 현재가도 주지 않고, 에러도 내지 않습니다).
+    이 노드는 저작 시점이 아니라 **실행 시점**에 월물을 고르므로 시간이 지나면
+    자동으로 다음 월물로 넘어갑니다.
+    """
+
+    type: Literal["FuturesContractNode"] = "FuturesContractNode"
+    category: NodeCategory = NodeCategory.MARKET
+    description: str = "i18n:nodes.FuturesContractNode.description"
+    _img_url: ClassVar[str] = ""
+    _product_scope: ClassVar[ProductScope] = ProductScope.FUTURES
+    _broker_provider: ClassVar[BrokerProvider] = BrokerProvider.LS
+
+    base_products: List[str] = Field(
+        default_factory=list,
+        description=(
+            "Underlying product codes to resolve (LS BscGdsCd). "
+            "e.g. ['HMH'] = Mini Hang Seng, ['HMCE'] = Mini H-Shares. "
+            "One contract is emitted per code, in the given order."
+        ),
+    )
+    contract_selection: Literal["front", "next", "quarterly"] = Field(
+        default="front",
+        description=(
+            "Which listed contract to pick per underlying: "
+            "'front' = nearest expiry (most liquid), "
+            "'next' = second nearest (roll target), "
+            "'quarterly' = nearest Mar/Jun/Sep/Dec contract."
+        ),
+    )
+    futures_exchange: Optional[str] = Field(
+        default=None,
+        description="Optional exchange filter by LS exchange code (ExchCd), e.g. 'HKEX'. Omit for all exchanges.",
+    )
+
+    _usage: ClassVar[Dict[str, Any]] = {
+        "when_to_use": [
+            "Any futures workflow that must keep working after the current contract expires — this is the default way to name a futures instrument",
+            "Trading/backtesting an index future by its underlying (Mini Hang Seng, Mini H-Shares) rather than a specific month",
+            "Rolling strategies that need the front month now and the next month as the roll target",
+        ],
+        "when_not_to_use": [
+            "For stocks — use WatchlistNode (stock symbols do not expire)",
+            "When the user explicitly pins one historical contract month for a fixed-period study (then hardcode it in WatchlistNode and accept it will expire)",
+            "To browse the whole futures universe — use OverseasFuturesSymbolQueryNode",
+        ],
+        "typical_scenarios": [
+            "FuturesContractNode → OverseasFuturesHistoricalDataNode → ConditionNode → OverseasFuturesNewOrderNode",
+            "FuturesContractNode → OverseasFuturesMarketDataNode (current price of the front month)",
+            "FuturesContractNode → OverseasFuturesRealMarketDataNode (realtime tick subscription)",
+        ],
+    }
+    _features: ClassVar[List[str]] = [
+        "Resolves underlying product codes to the **currently listed** contract symbols at execution time (o3101 master query)",
+        "Expired months are never returned — LS drops them from the master, and the node additionally filters out any month before the current one",
+        "`symbols` output has the exact same shape as WatchlistNode ([{exchange, symbol}]), so every downstream futures node wires unchanged",
+        "contract_selection: front (nearest) / next (roll target) / quarterly (nearest Mar-Jun-Sep-Dec)",
+        "Fails loudly with the list of available underlying codes when base_products contains an unknown code — never returns a silent empty list",
+    ]
+    _anti_patterns: ClassVar[List[Dict[str, str]]] = [
+        {
+            "pattern": "Hardcoding a contract month such as WatchlistNode symbols=[{'symbol': 'HMHU26'}]",
+            "reason": "The workflow dies silently the moment that month expires — LS returns empty bars and no error, so the strategy simply stops trading.",
+            "alternative": "Use FuturesContractNode with base_products=['HMH'] so the live month is resolved on every run.",
+        },
+        {
+            "pattern": "Putting a full contract symbol (HMHN26) into base_products",
+            "reason": "base_products expects the underlying product code (BscGdsCd), not the month-coded contract symbol.",
+            "alternative": "Use base_products=['HMH'] — the node appends the month code itself.",
+        },
+    ]
+    _examples: ClassVar[List[Dict[str, Any]]] = [
+        {
+            "title": "Front-month Mini Hang Seng price (never expires)",
+            "description": "Resolve the currently listed Mini Hang Seng front month and fetch its price.",
+            "workflow_snippet": {
+                "id": "futures_contract_front_month",
+                "name": "Mini Hang Seng Front Month",
+                "nodes": [
+                    {"id": "start", "type": "StartNode"},
+                    {"id": "broker", "type": "OverseasFuturesBrokerNode", "credential_id": "broker_cred", "paper_trading": False},
+                    {"id": "contract", "type": "FuturesContractNode", "base_products": ["HMH"], "contract_selection": "front"},
+                    {"id": "market", "type": "OverseasFuturesMarketDataNode", "symbol": "{{ item }}"},
+                    {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.market.values }}"},
+                ],
+                "edges": [
+                    {"from": "start", "to": "broker"},
+                    {"from": "broker", "to": "contract"},
+                    {"from": "contract", "to": "market"},
+                    {"from": "broker", "to": "market"},
+                    {"from": "market", "to": "display"},
+                ],
+                "credentials": [
+                    {
+                        "credential_id": "broker_cred",
+                        "type": "broker_ls_overseas_futures",
+                        "data": [
+                            {"key": "appkey", "value": "", "type": "password", "label": "App Key"},
+                            {"key": "appsecret", "value": "", "type": "password", "label": "App Secret"},
+                        ],
+                    }
+                ],
+            },
+            "expected_output": "symbols port: [{'exchange': 'HKEX', 'symbol': 'HMHN26'}] — the month code follows whatever LS currently lists.",
+        },
+        {
+            "title": "Two underlyings, front month each",
+            "description": "Resolve Mini Hang Seng and Mini H-Shares front months and run RSI on both.",
+            "workflow_snippet": {
+                "id": "futures_contract_two_underlyings",
+                "name": "HKEX Mini Futures RSI",
+                "nodes": [
+                    {"id": "start", "type": "StartNode"},
+                    {"id": "broker", "type": "OverseasFuturesBrokerNode", "credential_id": "broker_cred", "paper_trading": False},
+                    {"id": "contract", "type": "FuturesContractNode", "base_products": ["HMH", "HMCE"], "contract_selection": "front"},
+                    {"id": "historical", "type": "OverseasFuturesHistoricalDataNode", "symbol": "{{ item }}", "interval": "1d"},
+                    {"id": "rsi", "type": "ConditionNode", "conditions": [{"indicator": "rsi", "operator": "<", "value": 30}]},
+                ],
+                "edges": [
+                    {"from": "start", "to": "broker"},
+                    {"from": "broker", "to": "contract"},
+                    {"from": "contract", "to": "historical"},
+                    {"from": "broker", "to": "historical"},
+                    {"from": "historical", "to": "rsi"},
+                ],
+                "credentials": [
+                    {
+                        "credential_id": "broker_cred",
+                        "type": "broker_ls_overseas_futures",
+                        "data": [
+                            {"key": "appkey", "value": "", "type": "password", "label": "App Key"},
+                            {"key": "appsecret", "value": "", "type": "password", "label": "App Secret"},
+                        ],
+                    }
+                ],
+            },
+            "expected_output": "symbols port: [{'exchange': 'HKEX', 'symbol': 'HMHN26'}, {'exchange': 'HKEX', 'symbol': 'HMCEN26'}]",
+        },
+    ]
+    _node_guide: ClassVar[Dict[str, Any]] = {
+        "input_handling": (
+            "No symbol input — this node *produces* the symbol list. Requires an upstream "
+            "OverseasFuturesBrokerNode (the LS master query needs a session). "
+            "Set base_products to the underlying codes: HMH (Mini Hang Seng), HMCE (Mini H-Shares), "
+            "HSI (Hang Seng), HTI (Hang Seng TECH), HCEI (H-Share), MCA (MSCI China A50)."
+        ),
+        "output_consumption": (
+            "The `symbols` port emits [{exchange, symbol}] — identical to WatchlistNode. "
+            "Wire it into OverseasFuturesHistoricalDataNode / OverseasFuturesMarketDataNode / "
+            "OverseasFuturesRealMarketDataNode with `symbol: \"{{ item }}\"` (the engine auto-iterates one contract at a time). "
+            "The `contracts` port carries the full detail ({symbol, exchange, base_product, name, contract_month}) "
+            "when you need the month or product name for a report."
+        ),
+        "common_combinations": [
+            "FuturesContractNode.symbols → OverseasFuturesHistoricalDataNode (symbol: {{ item }}) → ConditionNode",
+            "FuturesContractNode.symbols → OverseasFuturesMarketDataNode (symbol: {{ item }})",
+            "FuturesContractNode.symbols → SymbolFilterNode → PositionSizingNode → OverseasFuturesNewOrderNode",
+        ],
+        "pitfalls": [
+            "base_products takes the underlying code (HMH), not the contract symbol (HMHN26)",
+            "Requires OverseasFuturesBrokerNode upstream — the o3101 master query needs an LS session",
+            "contract_selection='next' fails loudly if the underlying has only one listed month",
+        ],
+    }
+
+    _inputs: List[InputPort] = []
+    _outputs: List[OutputPort] = [
+        OutputPort(
+            name="symbols",
+            type="symbol_list",
+            description="i18n:ports.symbols",
+            fields=SYMBOL_LIST_FIELDS,
+            example=[{"exchange": "HKEX", "symbol": "HMHN26"}],
+        ),
+        OutputPort(
+            name="contracts",
+            type="array",
+            description="Resolved contract details",
+            fields=[
+                {"name": "symbol", "type": "string", "description": "계약 종목코드 (예: HMHN26)"},
+                {"name": "exchange", "type": "string", "description": "거래소 코드 (예: HKEX)"},
+                {"name": "base_product", "type": "string", "description": "기초자산 코드 (예: HMH)"},
+                {"name": "base_product_name", "type": "string", "description": "기초자산명 (예: Mini Hang Seng)"},
+                {"name": "name", "type": "string", "description": "종목명 (예: Mini Hang Seng(2026.07))"},
+                {"name": "contract_month", "type": "string", "description": "월물 (예: 2026-07)"},
+            ],
+            example=[{
+                "symbol": "HMHN26", "exchange": "HKEX", "base_product": "HMH",
+                "base_product_name": "Mini Hang Seng", "name": "Mini Hang Seng(2026.07)",
+                "contract_month": "2026-07",
+            }],
+        ),
+        OutputPort(name="count", type="integer", description="Resolved contract count"),
+    ]
+
+    _version: ClassVar[str] = "1.0.0"
+    _updated_at: ClassVar[str] = "2026-07-13"
+    _change_note: ClassVar[Optional[str]] = "신규 — 만기 하드코딩 제거(실행 시점 월물 해소)"
+
+    @classmethod
+    def get_field_schema(cls) -> Dict[str, "FieldSchema"]:
+        from programgarden_core.models.field_binding import FieldSchema, FieldType, FieldCategory, ExpressionMode
+        return {
+            "base_products": FieldSchema(
+                name="base_products",
+                type=FieldType.ARRAY,
+                description=(
+                    "기초자산 코드 목록. 코드마다 월물 1건씩 해소된다. "
+                    "HMH=미니 항셍, HMCE=미니 H주(HSCEI), HSI=항셍, HTI=항셍테크, "
+                    "HCEI=H주, MCA=MSCI 중국A50, HBI=항셍바이오텍"
+                ),
+                required=True,
+                category=FieldCategory.PARAMETERS,
+                expression_mode=ExpressionMode.FIXED_ONLY,
+                example=["HMH", "HMCE"],
+                expected_type="list[str]",
+                placeholder="HMH, HMCE",
+            ),
+            "contract_selection": FieldSchema(
+                name="contract_selection",
+                type=FieldType.ENUM,
+                description="월물 선택 방식. front=근월물(유동성 최대), next=차월물(롤오버 대상), quarterly=분기월물(3/6/9/12월 중 최근접)",
+                enum_values=["front", "next", "quarterly"],
+                enum_labels={
+                    "front": "i18n:enums.contract_selection.front",
+                    "next": "i18n:enums.contract_selection.next",
+                    "quarterly": "i18n:enums.contract_selection.quarterly",
+                },
+                default="front",
+                required=False,
+                category=FieldCategory.PARAMETERS,
+                expression_mode=ExpressionMode.FIXED_ONLY,
+                example="front",
+                expected_type="str",
+            ),
+            "futures_exchange": FieldSchema(
+                name="futures_exchange",
+                type=FieldType.STRING,
+                description="거래소 코드(ExchCd) 필터. 예: HKEX, LME. 비우면 전체 거래소에서 기초자산 코드로 찾는다.",
+                required=False,
+                category=FieldCategory.SETTINGS,
+                expression_mode=ExpressionMode.FIXED_ONLY,
+                example="HKEX",
+                expected_type="str",
+                placeholder="HKEX",
             ),
         }

--- a/src/core/programgarden_core/nodes/symbol_futures.py
+++ b/src/core/programgarden_core/nodes/symbol_futures.py
@@ -71,6 +71,8 @@ class OverseasFuturesSymbolQueryNode(BaseNode):
     _features: ClassVar[List[str]] = [
         "Queries o3101 API (overseas futures master) — returns [{symbol, exchange, name, contract_month, currency, ...}] list",
         "Filter by futures_exchange (1=all, 2=CME, 3=SGX, 4=EUREX, 5=ICE, 6=HKEX, 7=OSE) and futures_contract_month (front/next/F/2026F)",
+        "Overseas-futures entitlement is per exchange — a test account typically only carries HKEX and LME. Picking an exchange the account does not carry fails loudly with the list LS actually returns (never a silent empty universe)",
+        "Expired contract months are dropped — LS serves neither bars nor quotes for them, and reports no error",
         "Contract month codes: F=Jan, G=Feb, H=Mar, J=Apr, K=May, M=Jun, N=Jul, Q=Aug, U=Sep, V=Oct, X=Nov, Z=Dec",
         "max_results cap (100–10000) prevents runaway API calls; uses continuation query under the hood",
         "Outputs `symbols` (list) and `count` (int) ports",
@@ -89,15 +91,15 @@ class OverseasFuturesSymbolQueryNode(BaseNode):
     ]
     _examples: ClassVar[List[Dict[str, Any]]] = [
         {
-            "title": "List all front-month CME contracts",
-            "description": "Fetch near-month CME futures contracts and display the full list.",
+            "title": "List every front-month contract the account can trade",
+            "description": "Fetch the near-month contract of each listed product and display the full list.",
             "workflow_snippet": {
-                "id": "overseas_futures_symbol_query_cme",
-                "name": "CME Front Month Contracts",
+                "id": "overseas_futures_symbol_query_all",
+                "name": "Front Month Contracts",
                 "nodes": [
                     {"id": "start", "type": "StartNode"},
                     {"id": "broker", "type": "OverseasFuturesBrokerNode", "credential_id": "broker_cred", "paper_trading": False},
-                    {"id": "symbols", "type": "OverseasFuturesSymbolQueryNode", "futures_exchange": "2", "futures_contract_month": "front", "max_results": 100},
+                    {"id": "symbols", "type": "OverseasFuturesSymbolQueryNode", "futures_exchange": "1", "futures_contract_month": "front", "max_results": 100},
                     {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.symbols.symbols }}"},
                 ],
                 "edges": [
@@ -172,7 +174,8 @@ class OverseasFuturesSymbolQueryNode(BaseNode):
         ],
         "pitfalls": [
             "Omitting futures_contract_month returns all contract months — filter to 'front'/'next' for most strategies",
-            "Contract symbols expire — update futures_contract_month monthly or use 'front'/'next' to auto-select near-month",
+            "To trade one known underlying (Mini Hang Seng, …), use FuturesContractNode instead — this node browses the whole universe",
+            "futures_exchange is limited by the account's per-exchange entitlement; an exchange the account does not carry fails loudly (it is not silently empty)",
             "Use OverseasFuturesBrokerNode (not OverseasStockBrokerNode) as the upstream broker",
         ],
     }

--- a/src/core/programgarden_core/registry/node_registry.py
+++ b/src/core/programgarden_core/registry/node_registry.py
@@ -158,6 +158,7 @@ class NodeTypeRegistry:
             OverseasFuturesMarketDataNode, OverseasFuturesHistoricalDataNode,
             OverseasFuturesRealMarketDataNode,
             OverseasFuturesSymbolQueryNode,
+            FuturesContractNode,
             # Account - Stock (해외주식)
             OverseasStockAccountNode, OverseasStockRealAccountNode, OverseasStockRealOrderEventNode,
             # Account - Futures (해외선물)
@@ -205,6 +206,7 @@ class NodeTypeRegistry:
             OverseasFuturesMarketDataNode, OverseasFuturesHistoricalDataNode,
             OverseasFuturesRealMarketDataNode,
             OverseasFuturesSymbolQueryNode,
+            FuturesContractNode,
             # Account - Stock (해외주식)
             OverseasStockAccountNode, OverseasStockRealAccountNode, OverseasStockRealOrderEventNode,
             # Account - Futures (해외선물)

--- a/src/core/programgarden_core/registry/plugin_registry.py
+++ b/src/core/programgarden_core/registry/plugin_registry.py
@@ -25,6 +25,7 @@ class ProductType(str, Enum):
 
     OVERSEAS_STOCK = "overseas_stock"
     OVERSEAS_FUTURES = "overseas_futures"
+    KOREA_STOCK = "korea_stock"  # 국내(KOSPI/KOSDAQ) 주식
 
 
 class PluginSchema(BaseModel):

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-core"
-version = "1.17.0"
+version = "1.18.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 readme = "README.md"

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,5 +1,22 @@
 ## [Unreleased]
+
+## [1.26.0] - 2026-07-13
+> Korea (KRX) stock support — released lockstep with `programgarden-core` 1.18.0.
+### Changed
+- **Bumped `programgarden-core` dependency `^1.16.0` → `^1.18.0`** — pulls in the
+  `OverseasFuturesMarketDataNode.values` OutputPort fix. The deployed core 1.17.0 exposed
+  only the singular futures `value` port, so a futures workflow binding
+  `{{ nodes.<market>.values }}` failed static validation with `INVALID_EXPRESSION_REF`
+  (full-suite validate went from 2 REJECT — examples 81, 85 — to **0 REJECT** under core
+  1.18.0). ⚠️ core is a caret dependency, so consumers must ALSO pin
+  `programgarden-core==1.18.0` (an unpinned consumer can float to an old core that lacks
+  the port). Consumer requirements pin `programgarden==1.26.0` + `programgarden-core==1.18.0`.
 ### Added
+- **Korea (KRX) stock example workflows 94–97** (json + md) — order (RSI→sizing→limit buy,
+  real-account warning), strategy (multi-symbol RSI ∧ Bollinger), backtest (RSI + Bollinger),
+  and CodeNode composite. `examples/workflows` total → 99; full-suite validate → 0 REJECT
+  under core 1.18.0. KRX is a single exchange (no `exchange` param); Korea orders are
+  real-account (no paper-trading path).
 - **CodeNode example workflows 89–93** (json + md; example files 90 → 95) — stdlib-only
   quant hand-roll references: RSI + z-score composite, return-correlation matrix, Kelly
   sizing, performance/risk metrics, and pairs spread & z-score. Each is an educational

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -2,6 +2,43 @@
 
 ## [1.26.0] - 2026-07-13
 > Korea (KRX) stock support — released lockstep with `programgarden-core` 1.18.0.
+### Fixed
+- **auto-iterate 가 종목 순회를 망가뜨리던 결함 4건** (`executor.py`). validate/deep_validate/
+  dry-run 은 전부 초록이라 게이트로는 잡히지 않았고, 실 LS 실행으로만 확인됐다.
+  - **`MarketDataNode` 의 N² 중복 조회** — auto-iterate 는 `{{ item }}` 을 종목당 1건으로
+    해소하는데, 실행기가 단수 `config.symbol` 을 보지 않고 `_input_<id>.symbols`(전체 배열)를
+    먼저 읽어 iteration 마다 전 종목을 재조회했다. 실측: 예제 07 4종목→16건 / 10 5→25 /
+    28 5→25 / 08 30종목→LS 폭주 후 job cancelled. `HistoricalDataNode` 는 이미 단수 우선이라
+    정상이었고, 그 패턴에 맞췄다.
+  - **auto-iterate 소스가 엣지 선언 순서로 정해짐** (무조건 `break`) — 계좌 엣지가 먼저 선언된
+    워크플로우에서 `PositionSizingNode` 가 **계좌 보유종목을 신규 매수 후보로 순회**했다
+    (실측: 예제 16/28 이 워크플로우에 없는 보유종목을 처리 — 잔고가 충분했다면 실주문).
+    명시한 `from_port`(예: `logic.passed_symbols`)조차 앞선 엣지에 가려 무시됐다.
+    → 모든 incoming 엣지를 훑어 [명시 `from_port` > `symbols` 포트 > 첫 출력] 우선순위로 고르고,
+      계좌 노드는 순회 소스에서 배제(`NO_ITERATE_SOURCE_NODE_TYPES`).
+  - **`LogicNode` 가 auto-iterate 대상이었음** — 집합 연산 노드인데 종목별로 N회 돌며 매 회
+    전체 `passed_symbols` 를 내보내 병합 시 N². 실측: 28 이 5종목인데 25건 → 하류가 중복 순회.
+    `SymbolFilterNode` 와 같은 이유로 `NO_AUTO_ITERATE_NODE_TYPES` 에 추가.
+  - **`MarketUniverseNode` 의 거래소 오염 → 무음 유실** — pytickersymbols 의 첫 항목만 보고
+    yahoo 접미사로 거래소를 정해 DOW30 30종목 중 29개가 `FRA`(프랑크푸르트)가 됐고, 하류
+    `EXCHANGE_CODES` 가 이를 조용히 82(NASDAQ)로 폴백해 NYSE 종목이 "No data" 로 사라졌다
+    (실측: 예제 08 이 회당 30종목 중 8건만 수신). → `google` 접두사(`"NYSE:MMM"`)로 실제 상장
+    거래소를 확정한다.
+- **거래소 라벨이 정확해도 조회 실패 시 다른 원장을 재시도** (`MarketDataNodeExecutor`).
+  LS 의 거래소 코드는 실제 상장 거래소와 항상 일치하지 않는다 — WMT 는 NYSE 상장인데 81 로는
+  응답이 없고 82 로만 조회된다. 위 거래소 수정만으로는 WMT 가 오히려 유실됐다(08 이 29/30).
+  성공한 코드를 실제 거래소로 기록하며, 라벨대로 성공하면 그대로 둔다(AMEX 가 NYSE 로 덮이지 않게).
+- **`_merge_iterate_results` 의 `array_fields` 에 `symbols`/`symbol_results` 누락** — auto-iterate
+  N회 중 마지막 1회만 살아남았다.
+- **`deep_validate` fixture 가 실경로와 다른 symbols 를 사용** — 게이트가 라이브와 갈라지던 지점.
+- **예제 81/85 의 HKEX 선물이 만기 경과 월물** (`HMHM26`=6월물, `HMHJ26`=4월물) — `historical` 이
+  빈 응답이라 전략 전체가 무신호였다. 실전 키로 월물 유효성을 실측해 9월물(`HMHU26`/`HMCEU26`,
+  21봉)로 교체. 85 는 "만기 경과분을 `ExclusionListNode` 로 거른다"는 교육 포인트를 유지.
+
+  실 LS 실증 (주문 노드 제거 사본): 07 `values` 16→**4** / 10 25→**5** / 28 25→**5** /
+  08 240건·`cancelled` → **30건·`completed`**(거래소 `FRA`→`NYSE`, 유실 0) /
+  16 `sizing` 이 계좌 보유종목→**워치리스트** 순회 / 86 0건(`symbols` 필수 에러)→**1건** /
+  81·85 `historical` 빈 응답→**실제 봉 데이터**.
 ### Changed
 - **Bumped `programgarden-core` dependency `^1.16.0` → `^1.18.0`** — pulls in the
   `OverseasFuturesMarketDataNode.values` OutputPort fix. The deployed core 1.17.0 exposed

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,6 +1,27 @@
 ## [Unreleased]
 
 ## [1.26.0] - 2026-07-13
+### Added
+- **`FuturesContractNode` executor** — queries the LS futures contract master (o3101) at run time
+  and emits the live contract symbol for each requested underlying. Expired months are filtered out
+  explicitly (never trusted to be absent from the master), an unknown underlying raises with the list
+  of codes LS actually lists (no silent empty list), and the node is registered in
+  `NO_AUTO_ITERATE_NODE_TYPES` (it *produces* the array). A `deep_validate` fixture lets it pass the
+  gate with no network. All 16 futures examples were converted off hardcoded months onto this node.
+
+### Fixed
+- **`OverseasFuturesSymbolQueryNode` emitted the Korean exchange name in `exchange`.** LS returns
+  `ExchNm='홍콩거래소'`; that value flowed into the order path as the `ExchCode` parameter. `exchange`
+  now carries the registry code (`HKEX`) and the Korean label moved to `exchange_name`.
+- **`futures_exchange` was a no-op.** It was passed to o3101 as `gubun`, which does not filter by
+  exchange (measured: gubun 0/1/2/6 all return the same 89 rows). The exchange is now matched
+  client-side against `ExchCd`.
+- **Expired contracts were passed downstream.** The futures master branch now drops any contract
+  month earlier than the current one.
+- `OverseasFuturesSymbolQueryNode` / `OverseasStockSymbolQueryNode` / `KoreaStockSymbolQueryNode`
+  added to `NO_AUTO_ITERATE_NODE_TYPES` — with an upstream array they re-ran the whole master query
+  once per item.
+
 > Korea (KRX) stock support — released lockstep with `programgarden-core` 1.18.0.
 ### Fixed
 - **auto-iterate 가 종목 순회를 망가뜨리던 결함 4건** (`executor.py`). validate/deep_validate/

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -18,6 +18,11 @@
   client-side against `ExchCd`.
 - **Expired contracts were passed downstream.** The futures master branch now drops any contract
   month earlier than the current one.
+- **An unavailable exchange returned a silent empty universe.** Overseas-futures entitlement is
+  per exchange, so a `futures_exchange` the account does not carry has no rows in the master. That
+  now raises with the exchanges LS actually returned, instead of an empty list that makes every
+  downstream node a no-op while the workflow reports success. `FuturesContractNode` also accepts the
+  sibling node's enum form (`"6"` = HKEX) and names the exchange as the cause when it is the cause.
 - `OverseasFuturesSymbolQueryNode` / `OverseasStockSymbolQueryNode` / `KoreaStockSymbolQueryNode`
   added to `NO_AUTO_ITERATE_NODE_TYPES` — with an upstream array they re-ran the whole master query
   once per item.

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -5,11 +5,14 @@
 ### Fixed
 - **auto-iterate 가 종목 순회를 망가뜨리던 결함 4건** (`executor.py`). validate/deep_validate/
   dry-run 은 전부 초록이라 게이트로는 잡히지 않았고, 실 LS 실행으로만 확인됐다.
-  - **`MarketDataNode` 의 N² 중복 조회** — auto-iterate 는 `{{ item }}` 을 종목당 1건으로
-    해소하는데, 실행기가 단수 `config.symbol` 을 보지 않고 `_input_<id>.symbols`(전체 배열)를
-    먼저 읽어 iteration 마다 전 종목을 재조회했다. 실측: 예제 07 4종목→16건 / 10 5→25 /
-    28 5→25 / 08 30종목→LS 폭주 후 job cancelled. `HistoricalDataNode` 는 이미 단수 우선이라
-    정상이었고, 그 패턴에 맞췄다.
+  - **`MarketDataNode` 의 N² 중복 조회** — auto-iterate 는 종목당 1회씩 노드를 돌리는데,
+    실행기가 `_input_<id>.symbols`(=상류가 넘긴 **전체 배열**)를 읽어 iteration 마다 전 종목을
+    재조회했다. 실측: 예제 07 4종목→16건 / 10 5→25 / 28 5→25 / 08 30종목→LS 폭주 후 job
+    cancelled. `HistoricalDataNode` 는 이미 단수 우선이라 정상이었고, 그 패턴에 맞췄다.
+    → **iteration 컨텍스트로 막는다**: auto-iterate 중이면 이번 아이템 1건만 조회한다.
+    `{{ item }}` 리터럴 유무와 무관하다 — 노드 가이드가 권장하는 "Watchlist → MarketData"
+    배선(리터럴 없이 엣지만, **곧 챗봇 산출물**)에는 `config.symbol` 이 없어서, 리터럴에만
+    의존하면 그 모양이 그대로 N² 로 남기 때문이다(실측: 리터럴 없는 3종목 배선 → values 9건 = 3²).
   - **auto-iterate 소스가 엣지 선언 순서로 정해짐** (무조건 `break`) — 계좌 엣지가 먼저 선언된
     워크플로우에서 `PositionSizingNode` 가 **계좌 보유종목을 신규 매수 후보로 순회**했다
     (실측: 예제 16/28 이 워크플로우에 없는 보유종목을 처리 — 잔고가 충분했다면 실주문).

--- a/src/programgarden/examples/workflows/00-workflow-guide.md
+++ b/src/programgarden/examples/workflows/00-workflow-guide.md
@@ -782,29 +782,37 @@ T+1 야간:  KST 18:15-04:00(+1) (HKT 17:15-03:00+1)
 | Schedule 만 (TradingHoursFilter 없음) | 거래 불필요 (백테스트, 리포트) | 84 |
 | LogicNode + 3개 TradingHoursFilter OR | 세 세션 모두 정확히 표현 필요 시 | (예제 없음, future work) |
 
-### 13.3 월물 명명 규칙
+### 13.3 월물은 **절대 하드코딩하지 않는다** — `FuturesContractNode`
 
-```
-HM[CE] + 월코드 + 연도2자리
-  │      │       │
-  │      │       └─ 26 = 2026
-  │      └─ F=1월, G=2월, H=3월, J=4월, K=5월, M=6월,
-  │         N=7월, Q=8월, U=9월, V=10월, X=11월, Z=12월
-  └─ HMH = Mini Hang Seng, HMCE = Mini HSCEI
+🔴 **선물 워크플로우에 월물 종목코드를 직접 적으면 만기가 지나는 순간 조용히 죽는다.**
+LS 는 만기 경과 종목에 과거봉도 현재가도 주지 않고 **에러도 내지 않는다** — 그냥 빈 배열이다.
+그래서 condition/sizing 이 아무 말 없이 무진입 상태가 되고, 사용자는 전략이 멈춘 줄도 모른다.
+(실제로 이 저장소의 선물 예제 16개 중 14개가 이렇게 죽어 있었다.)
+
+**정답은 실행 시점에 월물을 해소하는 것이다.** `FuturesContractNode` 가 그 일을 한다 —
+LS 종목마스터(o3101)를 조회해 **지금 상장된 월물**을 골라준다. 시간이 지나면 다음 월물로 자동으로 넘어간다.
+
+```json
+{ "id": "contract", "type": "FuturesContractNode",
+  "base_products": ["HMH", "HMCE"], "contract_selection": "front", "futures_exchange": "HKEX" }
 ```
 
-**예**: `HMHJ26` = Mini Hang Seng **2026년 4월물**
+- `base_products` — **기초자산 코드**(월물 코드가 아니다):
+  `HMH`=미니 항셍, `HMCE`=미니 H주(HSCEI), `HSI`=항셍, `HTI`=항셍테크, `HCEI`=H주, `MCA`=MSCI 중국A50
+- `contract_selection` — `front`(근월물·기본) / `next`(차월물, 롤오버 대상) / `quarterly`(3·6·9·12월 중 최근접)
+- 출력 `symbols` 는 **WatchlistNode 와 똑같은** `[{exchange, symbol}]` 이라 하류 배선이 그대로다:
+  `contract → OverseasFuturesHistoricalDataNode(symbol: "{{ item }}")` 처럼 auto-iterate 로 받는다.
+  백테스트/AI 노드처럼 auto-iterate 대상이 아닌 곳은 `{{ nodes.contract.symbols[0].symbol }}` 로 받는다.
+- 상류에 **선물 브로커 노드**가 있어야 한다 (o3101 은 LS 세션이 필요하다).
+
+참고 — 월물 코드 표기(LS 가 알려주므로 직접 조립할 일은 없다):
+`HMH`/`HMCE` + 월코드(F=1월 G=2월 H=3월 J=4월 K=5월 M=6월 N=7월 Q=8월 U=9월 V=10월 X=11월 Z=12월) + 연도 2자리.
+예: `HMHN26` = 미니 항셍 2026년 **7월물**.
 
 **틱 가치**: HMH/HMCE 미니선물 모두 약 10 HKD/tick (~1.3 USD).
 
-**Roll-over**: 분기물(H/M/U/Z)이 가장 유동성 풍부. 만기 임박 시 다음 월물로 교체. 자동화는
-ExclusionListNode 정적 블랙리스트 (예제 85) 또는 향후 LS 캘린더 연동.
-
-> ⚠️ **예제 월물은 시간이 지나면 만료됩니다.** 만기 경과 월물은 `OverseasFuturesHistoricalDataNode`
-> 가 **에러 없이 빈 `time_series`** 를 반환 → 다운스트림 condition/sizing 이 silent 하게 무진입.
-> 예제 81-85 는 작성 시점 기준 live 월물(2026 기준 `HMHM26`/`HMCEM26`, 6월물 M)을 사용하며,
-> 실행 시점이 만기를 지났다면 `OverseasFuturesSymbolQueryNode` 로 현재 front month 를 확인해
-> Watchlist 심볼을 갱신하세요. (2026-05-29 검증: J월물 만료 → M월물 roll-forward)
+**Roll-over**: 분기물(H/M/U/Z)이 가장 유동성이 풍부하다 — `contract_selection: "quarterly"` 로 고르면 된다.
+근월물을 쓰다가 만기 직전에 차월물로 갈아타려면 `next` 를 쓴 노드를 하나 더 두면 된다.
 
 ### 13.4 신규 예제 81-85 (HKEX 풀세트)
 

--- a/src/programgarden/examples/workflows/04-market-futures-quote.json
+++ b/src/programgarden/examples/workflows/04-market-futures-quote.json
@@ -1,7 +1,7 @@
 {
   "id": "04-market-futures-quote",
   "name": "해외선물 시세 조회",
-  "description": "해외선물 현재 시세 조회 (Mini Hang Seng, Mini H-Shares)",
+  "description": "해외선물 현재 시세 조회 (미니 H주 — 실행 시점에 근월물로 자동 해소)",
   "nodes": [
     {
       "id": "start",
@@ -22,16 +22,24 @@
       }
     },
     {
-      "id": "market",
-      "type": "OverseasFuturesMarketDataNode",
-      "symbols": [
-        {
-          "symbol": "HMCEG26",
-          "exchange": "HKEX"
-        }
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": [
+        "HMCE"
       ],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {
         "x": 500,
+        "y": 200
+      }
+    },
+    {
+      "id": "market",
+      "type": "OverseasFuturesMarketDataNode",
+      "symbol": "{{ item }}",
+      "position": {
+        "x": 750,
         "y": 200
       }
     }
@@ -40,6 +48,14 @@
     {
       "from": "start",
       "to": "broker"
+    },
+    {
+      "from": "broker",
+      "to": "contract"
+    },
+    {
+      "from": "contract",
+      "to": "market"
     },
     {
       "from": "broker",

--- a/src/programgarden/examples/workflows/04-market-futures-quote.md
+++ b/src/programgarden/examples/workflows/04-market-futures-quote.md
@@ -1,6 +1,6 @@
 # Overseas Futures Market Data
 
-Overseas futures current market data query (Mini Hang Seng, Mini H-Shares)
+Overseas futures current market data query (Mini H-Shares). The contract month is never hardcoded — `FuturesContractNode` resolves the currently listed front month at execution time, so the workflow keeps working after every expiry.
 
 ## Workflow Structure
 
@@ -9,9 +9,13 @@ graph LR
     start(["Start"])
     broker(["Broker
 (Overseas Futures)"])
+    contract["FuturesContract
+(HMCE front month)"]
     market["MarketData
 (Overseas Futures)"]
     start --> broker
+    broker --> contract
+    contract --> market
     broker --> market
 ```
 
@@ -21,12 +25,17 @@ graph LR
 |----|------|------|
 | start | StartNode | Workflow start |
 | broker | OverseasFuturesBrokerNode | Overseas futures broker connection (paper trading, HKEX) |
+| contract | FuturesContractNode | Resolves the listed front-month contract of HMCE (Mini H-Shares) at execution time |
 | market | OverseasFuturesMarketDataNode | Overseas futures market data query |
 
 ## Key Settings
 
 - **broker**: Paper trading mode
-- **market**: HMCEG26
+- **contract**: `base_products: ["HMCE"]` (underlying product code — not a month-coded symbol), `contract_selection: "front"`, `futures_exchange: "HKEX"`
+- **market**: `symbol: "{{ item }}"` — the engine auto-iterates the `symbols` output of **contract** ([{exchange, symbol}]), one contract at a time
+
+> 만기가 지난 월물을 하드코딩하면 LS 는 빈 배열만 돌려주고 에러도 내지 않아 워크플로우가 조용히 죽습니다.
+> **contract** 노드가 실행 시점에 상장 중인 근월물로 자동 해소하므로 만기와 무관하게 계속 동작합니다.
 
 ## Required Credentials
 
@@ -37,4 +46,6 @@ graph LR
 ## Data Flow
 
 1. **start** (StartNode) --> **broker** (OverseasFuturesBrokerNode)
+1. **broker** (OverseasFuturesBrokerNode) --> **contract** (FuturesContractNode) — the o3101 master query needs an LS session
+1. **contract** (FuturesContractNode) --> **market** (OverseasFuturesMarketDataNode)
 1. **broker** (OverseasFuturesBrokerNode) --> **market** (OverseasFuturesMarketDataNode)

--- a/src/programgarden/examples/workflows/06-historical-futures-data.json
+++ b/src/programgarden/examples/workflows/06-historical-futures-data.json
@@ -1,7 +1,7 @@
 {
   "id": "06-historical-futures-data",
   "name": "해외선물 과거 데이터 조회",
-  "description": "해외선물 30일 과거 데이터 조회 (Mini Hang Seng)",
+  "description": "해외선물 30일 과거 데이터 조회 (미니 H주 — 실행 시점에 근월물로 자동 해소)",
   "nodes": [
     {
       "id": "start",
@@ -22,17 +22,27 @@
       }
     },
     {
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": [
+        "HMCE"
+      ],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
+      "position": {
+        "x": 500,
+        "y": 200
+      }
+    },
+    {
       "id": "historical",
       "type": "OverseasFuturesHistoricalDataNode",
-      "symbol": {
-        "symbol": "HMCEG26",
-        "exchange": "HKEX"
-      },
+      "symbol": "{{ item }}",
       "start_date": "{{ date.ago(30, format='yyyymmdd') }}",
       "end_date": "{{ date.today(format='yyyymmdd') }}",
       "interval": "1d",
       "position": {
-        "x": 500,
+        "x": 750,
         "y": 200
       }
     }
@@ -41,6 +51,14 @@
     {
       "from": "start",
       "to": "broker"
+    },
+    {
+      "from": "broker",
+      "to": "contract"
+    },
+    {
+      "from": "contract",
+      "to": "historical"
     },
     {
       "from": "broker",

--- a/src/programgarden/examples/workflows/06-historical-futures-data.md
+++ b/src/programgarden/examples/workflows/06-historical-futures-data.md
@@ -1,6 +1,6 @@
 # Overseas Futures Historical Data
 
-Overseas futures 30-day historical data query (Mini Hang Seng)
+Overseas futures 30-day historical data query (Mini H-Shares). The contract month is never hardcoded — `FuturesContractNode` resolves the currently listed front month at execution time, so the workflow keeps working after every expiry.
 
 ## Workflow Structure
 
@@ -9,9 +9,13 @@ graph LR
     start(["Start"])
     broker(["Broker
 (Overseas Futures)"])
+    contract["FuturesContract
+(HMCE front month)"]
     historical["Historical
 (Overseas Futures)"]
     start --> broker
+    broker --> contract
+    contract --> historical
     broker --> historical
 ```
 
@@ -21,11 +25,17 @@ graph LR
 |----|------|------|
 | start | StartNode | Workflow start |
 | broker | OverseasFuturesBrokerNode | Overseas futures broker connection (paper trading, HKEX) |
+| contract | FuturesContractNode | Resolves the listed front-month contract of HMCE (Mini H-Shares) at execution time |
 | historical | OverseasFuturesHistoricalDataNode | Overseas futures historical data query |
 
 ## Key Settings
 
 - **broker**: Paper trading mode
+- **contract**: `base_products: ["HMCE"]` (underlying product code — not a month-coded symbol), `contract_selection: "front"`, `futures_exchange: "HKEX"`
+- **historical**: `symbol: "{{ item }}"` — the engine auto-iterates the `symbols` output of **contract** ([{exchange, symbol}]), one contract at a time
+
+> 만기가 지난 월물을 하드코딩하면 LS 는 빈 배열만 돌려주고 에러도 내지 않아 워크플로우가 조용히 죽습니다.
+> **contract** 노드가 실행 시점에 상장 중인 근월물로 자동 해소하므로 만기와 무관하게 계속 동작합니다.
 
 ## Required Credentials
 
@@ -36,4 +46,6 @@ graph LR
 ## Data Flow
 
 1. **start** (StartNode) --> **broker** (OverseasFuturesBrokerNode)
+1. **broker** (OverseasFuturesBrokerNode) --> **contract** (FuturesContractNode) — the o3101 master query needs an LS session
+1. **contract** (FuturesContractNode) --> **historical** (OverseasFuturesHistoricalDataNode)
 1. **broker** (OverseasFuturesBrokerNode) --> **historical** (OverseasFuturesHistoricalDataNode)

--- a/src/programgarden/examples/workflows/14-order-futures-new.json
+++ b/src/programgarden/examples/workflows/14-order-futures-new.json
@@ -22,6 +22,19 @@
       }
     },
     {
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": [
+        "HMCE"
+      ],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
+      "position": {
+        "x": 450,
+        "y": 60
+      }
+    },
+    {
       "id": "account",
       "type": "OverseasFuturesAccountNode",
       "position": {
@@ -35,8 +48,8 @@
       "side": "buy",
       "order_type": "limit",
       "order": {
-        "symbol": "HMCEG26",
-        "exchange": "HKEX",
+        "symbol": "{{ nodes.contract.symbols[0].symbol }}",
+        "exchange": "{{ nodes.contract.symbols[0].exchange }}",
         "quantity": 1,
         "price": 9500.0
       },
@@ -53,10 +66,18 @@
     },
     {
       "from": "broker",
+      "to": "contract"
+    },
+    {
+      "from": "broker",
       "to": "account"
     },
     {
       "from": "account",
+      "to": "new_order"
+    },
+    {
+      "from": "contract",
       "to": "new_order"
     }
   ],

--- a/src/programgarden/examples/workflows/14-order-futures-new.md
+++ b/src/programgarden/examples/workflows/14-order-futures-new.md
@@ -2,6 +2,11 @@
 
 Test overseas futures new order with OverseasFuturesNewOrderNode
 
+The contract symbol is never hardcoded: FuturesContractNode resolves the underlying product
+(HMCE = Mini H-Shares) to the **currently listed front month** at execution time, so the workflow
+keeps working after every expiry.
+(월물 종목코드를 적어두지 않는다 — 실행 시점에 현재 상장된 근월물로 자동 해소되므로 만기가 지나도 계속 동작한다.)
+
 ## Workflow Structure
 
 ```mermaid
@@ -9,13 +14,17 @@ graph LR
     start(["Start"])
     broker(["Broker
 (Overseas Futures)"])
+    contract["Contract
+(Futures front month)"]
     account["Account
 (Overseas Futures)"]
     new_order[["NewOrder
 (Overseas Futures)"]]
     start --> broker
+    broker --> contract
     broker --> account
     account --> new_order
+    contract --> new_order
 ```
 
 ## Node List
@@ -24,13 +33,15 @@ graph LR
 |----|------|------|
 | start | StartNode | Workflow start |
 | broker | OverseasFuturesBrokerNode | Overseas futures broker connection (paper trading, HKEX) |
+| contract | FuturesContractNode | Resolves base product HMCE (Mini H-Shares) to the currently listed front-month contract (o3101) |
 | account | OverseasFuturesAccountNode | Overseas futures account balance/position query |
 | new_order | OverseasFuturesNewOrderNode | Overseas futures new order |
 
 ## Key Settings
 
 - **broker**: Paper trading mode
-- **new_order**: side=`buy`
+- **contract**: `base_products=["HMCE"]`, `contract_selection="front"`, `futures_exchange="HKEX"` — requires the futures broker upstream (the o3101 master query needs an LS session)
+- **new_order**: side=`buy`, order_type=`limit`, symbol/exchange bound to `{{ nodes.contract.symbols[0].symbol }}` / `{{ nodes.contract.symbols[0].exchange }}`
 
 ## Required Credentials
 
@@ -41,5 +52,7 @@ graph LR
 ## Data Flow
 
 1. **start** (StartNode) --> **broker** (OverseasFuturesBrokerNode)
+1. **broker** (OverseasFuturesBrokerNode) --> **contract** (FuturesContractNode)
 1. **broker** (OverseasFuturesBrokerNode) --> **account** (OverseasFuturesAccountNode)
 1. **account** (OverseasFuturesAccountNode) --> **new_order** (OverseasFuturesNewOrderNode)
+1. **contract** (FuturesContractNode) --> **new_order** (OverseasFuturesNewOrderNode)

--- a/src/programgarden/examples/workflows/16-risk-position-sizing.json
+++ b/src/programgarden/examples/workflows/16-risk-position-sizing.json
@@ -56,7 +56,7 @@
       "type": "PositionSizingNode",
       "symbol": "{{ item }}",
       "balance": "{{ nodes.account.balance.orderable_amount }}",
-      "market_data": "{{ nodes.market.value }}",
+      "market_data": "{{ nodes.market.values }}",
       "method": "fixed_percent",
       "max_percent": 10.0,
       "position": {

--- a/src/programgarden/examples/workflows/28-strategy-rsi-full.json
+++ b/src/programgarden/examples/workflows/28-strategy-rsi-full.json
@@ -122,7 +122,7 @@
       "type": "PositionSizingNode",
       "symbol": "{{ item }}",
       "balance": "{{ nodes.account.balance.orderable_amount }}",
-      "market_data": "{{ nodes.market.value }}",
+      "market_data": "{{ nodes.market.values }}",
       "method": "fixed_percent",
       "max_percent": 10.0,
       "position": {

--- a/src/programgarden/examples/workflows/39-realtime-futures-tick.json
+++ b/src/programgarden/examples/workflows/39-realtime-futures-tick.json
@@ -1,7 +1,7 @@
 {
   "id": "39-realtime-futures-tick",
   "name": "해외선물 실시간 틱 (모의투자)",
-  "description": "해외선물 모의투자 모드에서 실시간 OVC 틱 데이터 수신 확인. HKEX 항셍지수 선물 2월물 (HMCEG26) 구독. 모의투자는 홍콩거래소만 지원.",
+  "description": "해외선물 모의투자 모드에서 실시간 OVC 틱 데이터 수신 확인. HKEX 미니 H주 선물 근월물을 실행 시점에 자동 해소하여 구독. 모의투자는 홍콩거래소만 지원.",
   "nodes": [
     {
       "id": "start",
@@ -22,14 +22,13 @@
       }
     },
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {
-          "exchange": "HKEX",
-          "symbol": "HMCEG26"
-        }
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": [
+        "HMCE"
       ],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {
         "x": 500,
         "y": 200
@@ -38,6 +37,7 @@
     {
       "id": "realtime",
       "type": "OverseasFuturesRealMarketDataNode",
+      "symbol": "{{ item }}",
       "stay_connected": true,
       "position": {
         "x": 750,
@@ -72,10 +72,10 @@
     },
     {
       "from": "broker",
-      "to": "watchlist"
+      "to": "contract"
     },
     {
-      "from": "watchlist",
+      "from": "contract",
       "to": "realtime"
     },
     {

--- a/src/programgarden/examples/workflows/39-realtime-futures-tick.md
+++ b/src/programgarden/examples/workflows/39-realtime-futures-tick.md
@@ -1,6 +1,6 @@
 # Overseas Futures Real-time Tick (Paper Trading)
 
-Verify real-time OVC tick data reception in overseas futures paper trading mode. Subscribe to HKEX Hang Seng Index futures Feb contract (HMCEG26). Paper trading supports HKEX only.
+해외선물 모의투자 모드에서 실시간 OVC 틱 데이터 수신을 확인하는 워크플로우입니다. 종목코드를 직접 적지 않고 **FuturesContractNode** 가 기초자산(HMCE = 미니 H주)의 **현재 상장 월물을 실행 시점에 근월물로 자동 해소**하므로, 만기가 지나도 워크플로우가 멈추지 않고 다음 월물로 넘어갑니다. 모의투자는 홍콩거래소(HKEX)만 지원합니다.
 
 ## Workflow Structure
 
@@ -9,14 +9,14 @@ graph LR
     start(["Start"])
     broker(["Broker
 (Overseas Futures)"])
-    watchlist["Watchlist"]
+    contract["FuturesContract"]
     realtime["RealMarket
 (Overseas Futures)"]
     throttle(["Throttle"])
     display[/"TableDisplay"/]
     start --> broker
-    broker --> watchlist
-    watchlist --> realtime
+    broker --> contract
+    contract --> realtime
     realtime --> throttle
     throttle --> display
 ```
@@ -27,7 +27,7 @@ graph LR
 |----|------|------|
 | start | StartNode | Workflow start |
 | broker | OverseasFuturesBrokerNode | Overseas futures broker connection (paper trading, HKEX) |
-| watchlist | WatchlistNode | Define watchlist symbols |
+| contract | FuturesContractNode | Resolve the currently listed contract from the underlying product code |
 | realtime | OverseasFuturesRealMarketDataNode | Overseas futures real-time market data |
 | throttle | ThrottleNode | Execution rate limiting |
 | display | TableDisplayNode | Table display output |
@@ -35,7 +35,8 @@ graph LR
 ## Key Settings
 
 - **broker**: Paper trading mode
-- **watchlist**: HMCEG26
+- **contract**: `base_products: ["HMCE"]` (미니 H주), `contract_selection: "front"` (근월물), `futures_exchange: "HKEX"` — 실행할 때마다 LS 종목마스터(o3101)를 조회해 현재 상장된 근월물 종목코드로 해소합니다. 월물 코드는 저장하지 않습니다.
+- **realtime**: `symbol: "{{ item }}"` — contract 가 내보내는 종목을 한 건씩 auto-iterate 로 받습니다.
 
 ## Required Credentials
 
@@ -46,7 +47,7 @@ graph LR
 ## Data Flow
 
 1. **start** (StartNode) --> **broker** (OverseasFuturesBrokerNode)
-1. **broker** (OverseasFuturesBrokerNode) --> **watchlist** (WatchlistNode)
-1. **watchlist** (WatchlistNode) --> **realtime** (OverseasFuturesRealMarketDataNode)
+1. **broker** (OverseasFuturesBrokerNode) --> **contract** (FuturesContractNode)
+1. **contract** (FuturesContractNode) --> **realtime** (OverseasFuturesRealMarketDataNode)
 1. **realtime** (OverseasFuturesRealMarketDataNode) --> **throttle** (ThrottleNode)
 1. **throttle** (ThrottleNode) --> **display** (TableDisplayNode)

--- a/src/programgarden/examples/workflows/47-sr-level-touch.json
+++ b/src/programgarden/examples/workflows/47-sr-level-touch.json
@@ -1,7 +1,7 @@
 {
   "id": "47-sr-level-touch",
   "name": "S/R 레벨 감지 + 터치 판별 (해외선물 모의투자)",
-  "description": "SupportResistanceLevels로 과거 데이터에서 지지/저항 레벨 감지 후, LevelTouch로 레벨 터치/돌파 판별. 단일 종목(Mini Hang Seng).",
+  "description": "SupportResistanceLevels로 과거 데이터에서 지지/저항 레벨 감지 후, LevelTouch로 레벨 터치/돌파 판별. 단일 기초자산(미니 H주). 월물은 실행 시점에 근월물로 자동 해소됩니다.",
   "nodes": [
     {
       "id": "start",
@@ -14,12 +14,18 @@
       "paper_trading": true
     },
     {
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": [
+        "HMCE"
+      ],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX"
+    },
+    {
       "id": "hist",
       "type": "OverseasFuturesHistoricalDataNode",
-      "symbol": {
-        "symbol": "HMCEH26",
-        "exchange": "HKEX"
-      },
+      "symbol": "{{ item }}",
       "start_date": "{{ date.ago(120, format='yyyymmdd') }}",
       "end_date": "{{ date.today(format='yyyymmdd') }}",
       "interval": "1d"
@@ -99,6 +105,14 @@
     {
       "from": "start",
       "to": "broker"
+    },
+    {
+      "from": "broker",
+      "to": "contract"
+    },
+    {
+      "from": "contract",
+      "to": "hist"
     },
     {
       "from": "broker",

--- a/src/programgarden/examples/workflows/47-sr-level-touch.md
+++ b/src/programgarden/examples/workflows/47-sr-level-touch.md
@@ -1,6 +1,8 @@
 # S/R Level Detection + Touch Check (Overseas Futures Paper Trading)
 
-Detect support/resistance levels from historical data with SupportResistanceLevels, then determine level touch/breakout with LevelTouch. Single symbol (Mini Hang Seng).
+Detect support/resistance levels from historical data with SupportResistanceLevels, then determine level touch/breakout with LevelTouch. Single underlying (Mini H-Shares).
+
+> 월물(만기) 종목코드를 워크플로우에 적어두지 않습니다. `contract` 노드가 **실행 시점에** 기초자산(미니 H주)의 현재 상장된 **근월물로 자동 해소**하므로, 만기가 지나도 예제가 조용히 멈추지 않습니다.
 
 ## Workflow Structure
 
@@ -9,6 +11,8 @@ graph LR
     start(["Start"])
     broker(["Broker
 (Overseas Futures)"])
+    contract(["FuturesContract
+(front month)"])
     hist["Historical
 (Overseas Futures)"]
     detect_levels{"Condition
@@ -19,6 +23,8 @@ graph LR
     sr_table[/"TableDisplay"/]
     touch_table[/"TableDisplay"/]
     start --> broker
+    broker --> contract
+    contract --> hist
     broker --> hist
     hist --> detect_levels
     hist --> touch_check
@@ -34,7 +40,8 @@ graph LR
 |----|------|------|
 | start | StartNode | Workflow start |
 | broker | OverseasFuturesBrokerNode | Overseas futures broker connection (paper trading, HKEX) |
-| hist | OverseasFuturesHistoricalDataNode | Overseas futures historical data query |
+| contract | FuturesContractNode | Resolves the underlying (HMCE) to the currently listed front-month contract at run time |
+| hist | OverseasFuturesHistoricalDataNode | Overseas futures historical data query (auto-iterates over `contract.symbols`) |
 | detect_levels | ConditionNode | Condition check (plugin-based) |
 | touch_check | ConditionNode | Condition check (plugin-based) |
 | if_buy | IfNode | Conditional branch (if/else) |
@@ -44,6 +51,8 @@ graph LR
 ## Key Settings
 
 - **broker**: Paper trading mode
+- **contract**: base_products=["HMCE"] (Mini H-Shares), contract_selection=front, futures_exchange=HKEX
+- **hist**: symbol=`{{ item }}` — one run per symbol emitted by `contract`
 - **detect_levels**: Plugin `SupportResistanceLevels`
 - **detect_levels**: lookback=60, swing_strength=3, cluster_tolerance=0.015, min_cluster_size=2
 - **touch_check**: Plugin `LevelTouch`
@@ -59,6 +68,8 @@ graph LR
 ## Data Flow
 
 1. **start** (StartNode) --> **broker** (OverseasFuturesBrokerNode)
+1. **broker** (OverseasFuturesBrokerNode) --> **contract** (FuturesContractNode)
+1. **contract** (FuturesContractNode) --> **hist** (OverseasFuturesHistoricalDataNode)
 1. **broker** (OverseasFuturesBrokerNode) --> **hist** (OverseasFuturesHistoricalDataNode)
 1. **hist** (OverseasFuturesHistoricalDataNode) --> **detect_levels** (ConditionNode)
 1. **hist** (OverseasFuturesHistoricalDataNode) --> **touch_check** (ConditionNode)

--- a/src/programgarden/examples/workflows/57-futures-paper-backtest-heavy.json
+++ b/src/programgarden/examples/workflows/57-futures-paper-backtest-heavy.json
@@ -1,7 +1,7 @@
 {
   "id": "57-futures-paper-backtest-heavy",
   "name": "해외선물 모의투자 멀티 전략 종목별 백테스트 (메모리 스트레스)",
-  "description": "HKEX 해외선물 4종목 × 6개월 데이터 × 3전략(TSMOM/RSI/TurtleBreakout)을 종목별로 분리하여 12개 백테스트(4종목×3전략) + 벤치마크 비교 + 조건부 주문. 37노드 메모리 부하 테스트용.",
+  "description": "HKEX 해외선물 4개 기초자산(미니 H주/미니 항셍/항셍테크/H주) × 6개월 데이터 × 3전략(TSMOM/RSI/TurtleBreakout)을 종목별로 분리하여 12개 백테스트(4종목×3전략) + 벤치마크 비교 + 조건부 주문. 월물은 FuturesContractNode 가 실행 시점에 근월물로 자동 해소한다. 메모리 부하 테스트용.",
   "nodes": [
     {
       "id": "start",
@@ -51,47 +51,51 @@
       }
     },
     {
-      "id": "exclusion",
-      "type": "ExclusionListNode",
-      "symbols": [
-        {
-          "exchange": "HKEX",
-          "symbol": "HSIM26",
-          "reason": "유동성 부족 월물"
-        },
-        {
-          "exchange": "HKEX",
-          "symbol": "HHIM26",
-          "reason": "변동성 과다"
-        }
+      "id": "excl_contract",
+      "type": "FuturesContractNode",
+      "base_products": [
+        "HSI",
+        "HCEI"
       ],
-      "default_reason": "리스크 관리",
+      "contract_selection": "next",
+      "futures_exchange": "HKEX",
       "position": {
         "x": 750,
         "y": 250
       }
     },
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
+      "id": "exclusion",
+      "type": "ExclusionListNode",
       "symbols": [
         {
-          "symbol": "HMCEM26",
-          "exchange": "HKEX"
+          "exchange": "{{ nodes.excl_contract.symbols[0].exchange }}",
+          "symbol": "{{ nodes.excl_contract.symbols[0].symbol }}",
+          "reason": "유동성 부족 월물 (항셍 차월물)"
         },
         {
-          "symbol": "MHIM26",
-          "exchange": "HKEX"
-        },
-        {
-          "symbol": "HTIM26",
-          "exchange": "HKEX"
-        },
-        {
-          "symbol": "HCEM26",
-          "exchange": "HKEX"
+          "exchange": "{{ nodes.excl_contract.symbols[1].exchange }}",
+          "symbol": "{{ nodes.excl_contract.symbols[1].symbol }}",
+          "reason": "변동성 과다 (H주 차월물)"
         }
       ],
+      "default_reason": "리스크 관리",
+      "position": {
+        "x": 950,
+        "y": 220
+      }
+    },
+    {
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": [
+        "HMCE",
+        "HMH",
+        "HTI",
+        "HCEI"
+      ],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {
         "x": 950,
         "y": 400
@@ -190,7 +194,7 @@
     {
       "id": "backtest_tsmom_s0",
       "type": "BacktestEngineNode",
-      "strategy_name": "TSMOM Momentum — HMCEM26",
+      "strategy_name": "TSMOM Momentum — {{ nodes.contract.symbols[0].symbol }}",
       "items": {
         "from": "{{ nodes.tsmom_cond.values[0].time_series }}",
         "extract": {
@@ -226,7 +230,7 @@
     {
       "id": "backtest_tsmom_s1",
       "type": "BacktestEngineNode",
-      "strategy_name": "TSMOM Momentum — MHIM26",
+      "strategy_name": "TSMOM Momentum — {{ nodes.contract.symbols[1].symbol }}",
       "items": {
         "from": "{{ nodes.tsmom_cond.values[1].time_series }}",
         "extract": {
@@ -262,7 +266,7 @@
     {
       "id": "backtest_tsmom_s2",
       "type": "BacktestEngineNode",
-      "strategy_name": "TSMOM Momentum — HTIM26",
+      "strategy_name": "TSMOM Momentum — {{ nodes.contract.symbols[2].symbol }}",
       "items": {
         "from": "{{ nodes.tsmom_cond.values[2].time_series }}",
         "extract": {
@@ -298,7 +302,7 @@
     {
       "id": "backtest_tsmom_s3",
       "type": "BacktestEngineNode",
-      "strategy_name": "TSMOM Momentum — HCEM26",
+      "strategy_name": "TSMOM Momentum — {{ nodes.contract.symbols[3].symbol }}",
       "items": {
         "from": "{{ nodes.tsmom_cond.values[3].time_series }}",
         "extract": {
@@ -334,7 +338,7 @@
     {
       "id": "backtest_rsi_s0",
       "type": "BacktestEngineNode",
-      "strategy_name": "RSI Mean Reversion — HMCEM26",
+      "strategy_name": "RSI Mean Reversion — {{ nodes.contract.symbols[0].symbol }}",
       "items": {
         "from": "{{ nodes.rsi_cond.values[0].time_series }}",
         "extract": {
@@ -370,7 +374,7 @@
     {
       "id": "backtest_rsi_s1",
       "type": "BacktestEngineNode",
-      "strategy_name": "RSI Mean Reversion — MHIM26",
+      "strategy_name": "RSI Mean Reversion — {{ nodes.contract.symbols[1].symbol }}",
       "items": {
         "from": "{{ nodes.rsi_cond.values[1].time_series }}",
         "extract": {
@@ -406,7 +410,7 @@
     {
       "id": "backtest_rsi_s2",
       "type": "BacktestEngineNode",
-      "strategy_name": "RSI Mean Reversion — HTIM26",
+      "strategy_name": "RSI Mean Reversion — {{ nodes.contract.symbols[2].symbol }}",
       "items": {
         "from": "{{ nodes.rsi_cond.values[2].time_series }}",
         "extract": {
@@ -442,7 +446,7 @@
     {
       "id": "backtest_rsi_s3",
       "type": "BacktestEngineNode",
-      "strategy_name": "RSI Mean Reversion — HCEM26",
+      "strategy_name": "RSI Mean Reversion — {{ nodes.contract.symbols[3].symbol }}",
       "items": {
         "from": "{{ nodes.rsi_cond.values[3].time_series }}",
         "extract": {
@@ -478,7 +482,7 @@
     {
       "id": "backtest_turtle_s0",
       "type": "BacktestEngineNode",
-      "strategy_name": "Turtle Breakout — HMCEM26",
+      "strategy_name": "Turtle Breakout — {{ nodes.contract.symbols[0].symbol }}",
       "items": {
         "from": "{{ nodes.turtle_cond.values[0].time_series }}",
         "extract": {
@@ -514,7 +518,7 @@
     {
       "id": "backtest_turtle_s1",
       "type": "BacktestEngineNode",
-      "strategy_name": "Turtle Breakout — MHIM26",
+      "strategy_name": "Turtle Breakout — {{ nodes.contract.symbols[1].symbol }}",
       "items": {
         "from": "{{ nodes.turtle_cond.values[1].time_series }}",
         "extract": {
@@ -550,7 +554,7 @@
     {
       "id": "backtest_turtle_s2",
       "type": "BacktestEngineNode",
-      "strategy_name": "Turtle Breakout — HTIM26",
+      "strategy_name": "Turtle Breakout — {{ nodes.contract.symbols[2].symbol }}",
       "items": {
         "from": "{{ nodes.turtle_cond.values[2].time_series }}",
         "extract": {
@@ -586,7 +590,7 @@
     {
       "id": "backtest_turtle_s3",
       "type": "BacktestEngineNode",
-      "strategy_name": "Turtle Breakout — HCEM26",
+      "strategy_name": "Turtle Breakout — {{ nodes.contract.symbols[3].symbol }}",
       "items": {
         "from": "{{ nodes.turtle_cond.values[3].time_series }}",
         "extract": {
@@ -877,14 +881,18 @@
     },
     {
       "from": "broker",
+      "to": "excl_contract"
+    },
+    {
+      "from": "excl_contract",
       "to": "exclusion"
     },
     {
       "from": "broker",
-      "to": "watchlist"
+      "to": "contract"
     },
     {
-      "from": "watchlist",
+      "from": "contract",
       "to": "historical"
     },
     {
@@ -1096,7 +1104,7 @@
   "notes": [
     {
       "id": "note_overview",
-      "content": "## 해외선물 멀티 전략 종목별 백테스트 워크플로우\n\nHKEX 선물 4종목 × 6개월 일봉 × 3전략을 종목별로 분리한 12개(4×3) 백테스트.\n메모리 스트레스 테스트용 (37노드, 51엣지).\n\n**대상**: HMCEM26, MHIM26, HTIM26, HCEM26 (HKEX 선물)\n**모드**: 모의투자 (paper_trading=true)\n**데이터**: 180일 일봉 OHLCV\n**전략**: TSMOM / RSI / TurtleBreakout (각 종목별 독립 백테스트)\n\n> 해외선물 모의투자는 HKEX만 지원 (CME 불가)",
+      "content": "## 해외선물 멀티 전략 종목별 백테스트 워크플로우\n\nHKEX 선물 4종목 × 6개월 일봉 × 3전략을 종목별로 분리한 12개(4×3) 백테스트.\n메모리 스트레스 테스트용 (39노드, 54엣지).\n\n**대상 기초자산**: HMCE(미니 H주) / HMH(미니 항셍) / HTI(항셍테크) / HCEI(H주)\n**월물**: 하드코딩하지 않는다. `contract`(FuturesContractNode) 가 실행 시점에 LS 종목마스터를 조회해 **현재 상장된 근월물**로 자동 해소하므로 만기가 지나도 예제가 죽지 않는다.\n**모드**: 모의투자 (paper_trading=true)\n**데이터**: 180일 일봉 OHLCV\n**전략**: TSMOM / RSI / TurtleBreakout (각 종목별 독립 백테스트)\n\n> 해외선물 모의투자는 HKEX만 지원 (CME 불가)",
       "color": 1,
       "width": 380,
       "height": 260,
@@ -1129,7 +1137,7 @@
     },
     {
       "id": "note_dag",
-      "content": "## DAG 실행 흐름\n\n```\nStart → Schedule → TradingHours → Broker\n  ├→ Account ─────────────┐\n  ├→ ExclusionList         │\n  └→ Watchlist (4종목)     │\n      └→ Historical (×4)  │\n          ├→ TSMOM ──→ BT×4 ┐\n          ├→ RSI ────→ BT×4 ┤\n          └→ Turtle ─→ BT×4 ┘\n              └→ Benchmark (12 전략 랭킹)\n                  ├→ Charts\n                  └→ Summary\n          └→ Logic → If(잔고)\n              └→ Portfolio\n                  └→ Sizing → Order\n```",
+      "content": "## DAG 실행 흐름\n\n```\nStart → Schedule → TradingHours → Broker\n  ├→ Account\n  ├→ ExclContract (차월물) → ExclusionList\n  └→ Contract (기초자산 4 → 근월물 4)\n      └→ Historical (×4)\n          ├→ TSMOM ──→ BT×4 ┐\n          ├→ RSI ────→ BT×4 ┤\n          └→ Turtle ─→ BT×4 ┘\n              └→ Benchmark (12 전략 랭킹)\n                  ├→ Charts\n                  └→ Summary\n          └→ Logic → If(잔고)\n              └→ Portfolio\n                  └→ Sizing → Order\n```\n\n월물 코드는 어디에도 하드코딩되지 않는다 — Contract/ExclContract 가 실행 시점에 해소한다.",
       "color": 7,
       "width": 340,
       "height": 320,

--- a/src/programgarden/examples/workflows/57-futures-paper-backtest-heavy.md
+++ b/src/programgarden/examples/workflows/57-futures-paper-backtest-heavy.md
@@ -1,23 +1,26 @@
 # Overseas Futures Paper Trading Multi-Strategy Per-Symbol Backtest (Memory Stress)
 
-HKEX overseas futures 4 symbols × 6-month data × 3 strategies (TSMOM/RSI/TurtleBreakout), split per symbol into 12 independent backtests (4 symbols × 3 strategies) + benchmark comparison + conditional order. 37-node memory stress test.
+HKEX overseas futures 4 underlyings × 6-month data × 3 strategies (TSMOM/RSI/TurtleBreakout), split per symbol into 12 independent backtests (4 symbols × 3 strategies) + benchmark comparison + conditional order. The contract month is never hardcoded — `FuturesContractNode` resolves the currently listed front month at execution time, so the workflow keeps working after every expiry. 39-node memory stress test.
 
 > ## Overseas Futures Multi-Strategy Per-Symbol Backtest Workflow
 
-HKEX futures 4 symbols × 6-month daily bars × 3 strategies, run as 12 per-symbol backtests (4×3).
-Memory stress test (37 nodes, 51 edges).
+HKEX futures 4 underlyings × 6-month daily bars × 3 strategies, run as 12 per-symbol backtests (4×3).
+Memory stress test (39 nodes, 54 edges).
 
-**Target**: HMCEM26, MHIM26, HTIM26, HCEM26 (HKEX futures)
+**Target underlyings**: HMCE (Mini H-Shares), HMH (Mini Hang Seng), HTI (Hang Seng TECH), HCEI (H-Share) — HKEX
+**Contract month**: resolved at execution time by the `contract` node (`FuturesContractNode`, front month); no month-coded symbol appears anywhere in the workflow
 **Mode**: Paper trading (paper_trading=true)
 **Data**: 180-day daily bars OHLCV
 **Strategy**: TSMOM / RSI / TurtleBreakout (one independent backtest per symbol)
+
+> **contract** 노드가 실행 시점에 LS 종목마스터를 조회해 상장 중인 근월물로 자동 해소하므로, 만기가 지나도 예제가 조용히 죽지 않습니다.
 
 ## Per-Symbol Backtest Restructure (why and how)
 
 A backtest must be **per-symbol** and must consume the **strategy plugin's per-candle annotated series**, not the raw historical output.
 
-- The `historical` node auto-iterates over the 4-symbol watchlist, so its `value` port is a **list** of `{symbol, exchange, time_series}` entries. Binding a single backtest to `{{ nodes.historical.value.time_series }}` accesses `.time_series` on that list, which yields nothing → "items 처리 결과가 비어있습니다" → empty backtest. Likewise binding `signal` to `{{ nodes.<cond>.result.signal }}` reads a merged list of booleans → `None`.
-- Each `ConditionNode` (TSMOM / RSI / TurtleBreakout) emits a `values` array, one entry per symbol, in **watchlist (auto-iterate) order**, even when a symbol has insufficient data (`time_series: []`). So `nodes.<cond>.values[i]` is index-aligned with the watchlist.
+- The `historical` node auto-iterates over the 4 contracts emitted by `contract.symbols`, so its `value` port is a **list** of `{symbol, exchange, time_series}` entries. Binding a single backtest to `{{ nodes.historical.value.time_series }}` accesses `.time_series` on that list, which yields nothing → "items 처리 결과가 비어있습니다" → empty backtest. Likewise binding `signal` to `{{ nodes.<cond>.result.signal }}` reads a merged list of booleans → `None`.
+- Each `ConditionNode` (TSMOM / RSI / TurtleBreakout) emits a `values` array, one entry per symbol, in **contract (auto-iterate) order**, even when a symbol has insufficient data (`time_series: []`). So `nodes.<cond>.values[i]` is index-aligned with `contract.base_products[i]` (i.e. `contract.symbols[i]`).
 
 Therefore each strategy is expanded into **4 per-symbol BacktestEngineNode** instances (12 total). For symbol index `i` under condition node `COND`:
 
@@ -85,10 +88,10 @@ Total estimated peak: historical data + 12 backtest trades + 12 equity curves.
 
 ```
 Start → Schedule → TradingHours → Broker
-  ├→ Account ─────────────┐
-  ├→ ExclusionList         │
-  └→ Watchlist (4 symbols) │
-      └→ Historical (×4)   │
+  ├→ Account
+  ├→ ExclContract (next month) → ExclusionList
+  └→ Contract (4 underlyings → 4 front months)
+      └→ Historical (×4)
           ├→ TSMOM ──→ BT×4 ┐
           ├→ RSI ────→ BT×4 ┤
           └→ Turtle ─→ BT×4 ┘
@@ -109,8 +112,9 @@ graph LR
     trading_hours{{"TradingHours"}}
     broker(["Broker (Overseas Futures)"])
     account["Account (Overseas Futures)"]
+    excl_contract["FuturesContract (HSI/HCEI next month)"]
     exclusion["ExclusionList"]
-    watchlist["Watchlist"]
+    contract["FuturesContract (HMCE/HMH/HTI/HCEI front month)"]
     historical["Historical (Overseas Futures)"]
     tsmom_cond{"Condition (TSMOM)"}
     rsi_cond{"Condition (RSI)"}
@@ -136,9 +140,10 @@ graph LR
     schedule --> trading_hours
     trading_hours --> broker
     broker --> account
-    broker --> exclusion
-    broker --> watchlist
-    watchlist --> historical
+    broker --> excl_contract
+    excl_contract --> exclusion
+    broker --> contract
+    contract --> historical
     historical --> tsmom_cond
     historical --> rsi_cond
     historical --> turtle_cond
@@ -178,15 +183,16 @@ graph LR
 | trading_hours | TradingHoursFilterNode | Trading hours filter |
 | broker | OverseasFuturesBrokerNode | Overseas futures broker connection (paper trading, HKEX) |
 | account | OverseasFuturesAccountNode | Overseas futures account balance/position query |
-| exclusion | ExclusionListNode | Exclusion list management |
-| watchlist | WatchlistNode | Define watchlist symbols (HMCEM26, MHIM26, HTIM26, HCEM26) |
-| historical | OverseasFuturesHistoricalDataNode | Overseas futures historical data query (auto-iterates 4 symbols) |
+| excl_contract | FuturesContractNode | Resolves the **next**-month (roll-target, thinner) contracts of HSI / HCEI at execution time — feeds the exclusion list |
+| exclusion | ExclusionListNode | Exclusion list management (symbols come from `excl_contract`, never hardcoded) |
+| contract | FuturesContractNode | Resolves the listed **front**-month contracts of HMCE / HMH / HTI / HCEI at execution time; `symbols` output has the same shape as a watchlist ([{exchange, symbol}]) |
+| historical | OverseasFuturesHistoricalDataNode | Overseas futures historical data query (auto-iterates the 4 resolved contracts) |
 | tsmom_cond | ConditionNode | `TimeSeriesMomentum` plugin — annotates per-candle `signal` ∈ {long,short,neutral} |
 | rsi_cond | ConditionNode | RSI plugin — annotates per-candle `signal`/`side` |
 | turtle_cond | ConditionNode | TurtleBreakout plugin — annotates per-candle `entry_signal`/`exit_signal` |
-| backtest_tsmom_s0..s3 | BacktestEngineNode | TSMOM per-symbol backtest (one per watchlist index) |
-| backtest_rsi_s0..s3 | BacktestEngineNode | RSI per-symbol backtest (one per watchlist index) |
-| backtest_turtle_s0..s3 | BacktestEngineNode | Turtle per-symbol backtest (one per watchlist index) |
+| backtest_tsmom_s0..s3 | BacktestEngineNode | TSMOM per-symbol backtest (one per `contract` index) |
+| backtest_rsi_s0..s3 | BacktestEngineNode | RSI per-symbol backtest (one per `contract` index) |
+| backtest_turtle_s0..s3 | BacktestEngineNode | Turtle per-symbol backtest (one per `contract` index) |
 | benchmark | BenchmarkCompareNode | Benchmark comparison across all 12 equity curves (ranking_metric=sharpe) |
 | tsmom_table | TableDisplayNode | TSMOM per-symbol signal table |
 | rsi_table | TableDisplayNode | RSI oversold table |
@@ -205,15 +211,16 @@ graph LR
 ## Key Settings
 
 - **broker**: Paper trading mode (HKEX only)
-- **exclusion**: HSIM26, HHIM26
-- **watchlist**: HMCEM26 (index 0), MHIM26 (1), HTIM26 (2), HCEM26 (3)
+- **excl_contract**: `base_products: ["HSI", "HCEI"]`, `contract_selection: "next"`, `futures_exchange: "HKEX"`
+- **exclusion**: `{{ nodes.excl_contract.symbols[0].symbol }}` (Hang Seng next month — thin liquidity), `{{ nodes.excl_contract.symbols[1].symbol }}` (H-Share next month — excess volatility). ExclusionListNode is not auto-iterated, so it reads the resolved symbols by index.
+- **contract**: `base_products: ["HMCE", "HMH", "HTI", "HCEI"]` (underlying product codes — never month-coded symbols), `contract_selection: "front"`, `futures_exchange: "HKEX"`. Index order defines the per-symbol backtest indices: HMCE (index 0), HMH (1), HTI (2), HCEI (3)
 - **tsmom_cond**: Plugin `TSMOM` — lookback=60, volatility_lookback=20, threshold=0.0, volatility_target=0.15, direction=long
 - **rsi_cond**: Plugin `RSI` — period=14, threshold=30, direction=below
 - **turtle_cond**: Plugin `TurtleBreakout` — entry_period=20, exit_period=10, atr_period=14, direction=both
 - **backtest_tsmom_s\***: from `nodes.tsmom_cond.values[i].time_series`, signal maps long→buy / short→sell (no side); ATR-based sizing, allow_short
 - **backtest_rsi_s\***: from `nodes.rsi_cond.values[i].time_series`, signal=`row.signal`, side=`row.side`; fixed-percent sizing
 - **backtest_turtle_s\***: from `nodes.turtle_cond.values[i].time_series`, signal maps long_entry→buy / long_exit→sell (no side); ATR-based sizing, allow_short
-- **benchmark**: ranking_metric=`sharpe`, 12 equity-curve strategies, distinct strategy_name per symbol (e.g. "TSMOM Momentum — HMCEM26")
+- **benchmark**: ranking_metric=`sharpe`, 12 equity-curve strategies, distinct strategy_name per symbol — the label carries the **resolved** contract, e.g. `"TSMOM Momentum — {{ nodes.contract.symbols[0].symbol }}"`
 - **logic**: `any`
 - **if_balance**: `{{ nodes.account.balance.orderable_amount }}` >= `50000`
 - **new_order**: side=`buy`
@@ -227,8 +234,9 @@ graph LR
 ## Data Flow
 
 1. **start** → **schedule** → **trading_hours** → **broker**
-1. **broker** → **account** / **exclusion** / **watchlist**
-1. **watchlist** → **historical** (auto-iterates 4 symbols)
+1. **broker** → **account** / **excl_contract** / **contract** (both FuturesContractNodes need the LS session — the o3101 master query)
+1. **excl_contract** → **exclusion** (next-month HSI / HCEI contracts, resolved at run time)
+1. **contract** → **historical** (auto-iterates the 4 resolved front-month contracts)
 1. **historical** → **tsmom_cond** / **rsi_cond** / **turtle_cond**
 1. **tsmom_cond** → **backtest_tsmom_s0..s3** (one per symbol)
 1. **rsi_cond** → **backtest_rsi_s0..s3** (one per symbol)

--- a/src/programgarden/examples/workflows/61-hkex-futures-bot.json
+++ b/src/programgarden/examples/workflows/61-hkex-futures-bot.json
@@ -37,12 +37,11 @@
     },
 
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {"symbol": "HMHJ26", "exchange": "HKEX"},
-        {"symbol": "HMCEJ26", "exchange": "HKEX"}
-      ],
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": ["HMH", "HMCE"],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {"x": 800, "y": 100}
     },
     {
@@ -130,9 +129,10 @@
     {"from": "schedule", "to": "trading_hours"},
 
     {"from": "trading_hours", "to": "account"},
-    {"from": "trading_hours", "to": "watchlist"},
+    {"from": "trading_hours", "to": "contract"},
+    {"from": "broker", "to": "contract"},
 
-    {"from": "watchlist", "to": "historical"},
+    {"from": "contract", "to": "historical"},
     {"from": "historical", "to": "bollinger"},
 
     {"from": "bollinger", "to": "filter_buy"},
@@ -164,7 +164,7 @@
   "notes": [
     {
       "id": "note_strategy",
-      "content": "## HKEX 미니선물 역추세 봇 (모의투자)\n\n**전략**: 볼린저밴드(20,2) 평균회귀\n\n**매수(롱)**: 미니항셍·미니H주 볼린저 하단 터치\n  → 과매도 = 롱 1계약\n  → 보유 포지션 제외\n\n**청산**: 보유 포지션 전량 반대매매\n\n**주기**: 30분 (평일 09:15-16:30 HKT)\n\n**종목**: HMHJ26 (미니항셍 4월), HMCEJ26 (미니H주 4월)\n**틱가치**: 10 HKD (~$1.3)",
+      "content": "## HKEX 미니선물 역추세 봇 (모의투자)\n\n**전략**: 볼린저밴드(20,2) 평균회귀\n\n**매수(롱)**: 미니항셍·미니H주 볼린저 하단 터치\n  → 과매도 = 롱 1계약\n  → 보유 포지션 제외\n\n**청산**: 보유 포지션 전량 반대매매\n\n**주기**: 30분 (평일 09:15-16:30 HKT)\n\n**종목**: 미니항셍(HMH), 미니H주(HMCE)\n  → 월물은 실행 시점에 근월물로 자동 해소 (만기 무관)\n**틱가치**: 10 HKD (~$1.3)",
       "color": 5,
       "width": 360,
       "height": 300,

--- a/src/programgarden/examples/workflows/61-hkex-futures-bot.md
+++ b/src/programgarden/examples/workflows/61-hkex-futures-bot.md
@@ -14,7 +14,8 @@ Mini Hang Seng / Mini H-Shares 2-symbol Bollinger Band mean reversion. Long entr
 
 **Interval**: 30 min (weekdays 09:15-16:30 HKT)
 
-**Symbols**: HMHJ26 (Mini Hang Seng Apr), H
+**Symbols**: Mini Hang Seng (HMH), Mini H-Shares (HMCE)
+  → 월물(계약월)은 실행 시점에 근월물로 자동 해소된다 — 만기가 지나도 워크플로우가 죽지 않는다
 
 ## Workflow Structure
 
@@ -27,7 +28,8 @@ graph LR
     trading_hours{{"TradingHours"}}
     account["Account
 (Overseas Futures)"]
-    watchlist["Watchlist"]
+    contract["FuturesContract
+(front month)"]
     historical["Historical
 (Overseas Futures)"]
     bollinger{"Condition
@@ -44,8 +46,9 @@ graph LR
     broker --> schedule
     schedule --> trading_hours
     trading_hours --> account
-    trading_hours --> watchlist
-    watchlist --> historical
+    trading_hours --> contract
+    broker --> contract
+    contract --> historical
     historical --> bollinger
     bollinger --> filter_buy
     account --> filter_buy
@@ -64,7 +67,7 @@ graph LR
 | schedule | ScheduleNode | Schedule trigger (cron) |
 | trading_hours | TradingHoursFilterNode | Trading hours filter |
 | account | OverseasFuturesAccountNode | Overseas futures account balance/position query |
-| watchlist | WatchlistNode | Define watchlist symbols |
+| contract | FuturesContractNode | Resolve base products (HMH, HMCE) to the currently listed front-month contracts at run time |
 | historical | OverseasFuturesHistoricalDataNode | Overseas futures historical data query |
 | bollinger | ConditionNode | Condition check (plugin-based) |
 | filter_buy | SymbolFilterNode | Symbol filter (intersection/difference/union) |
@@ -78,7 +81,7 @@ graph LR
 - **broker**: Paper trading mode
 - **schedule**: cron `*/30 * * * 1-5` (timezone: Asia/Hong_Kong)
 - **trading_hours**: 09:15~16:30 (Asia/Hong_Kong)
-- **watchlist**: HMHJ26, HMCEJ26
+- **contract**: base_products=`["HMH", "HMCE"]` (미니항셍/미니H주), contract_selection=`front`, futures_exchange=`HKEX` — 월물은 실행 시점에 근월물로 자동 해소된다(하드코딩 없음)
 - **bollinger**: Plugin `BollingerBands`
 - **bollinger**: period=20, std_dev=2.0, position=below_lower
 - **buy_order**: side=`buy`
@@ -97,8 +100,9 @@ graph LR
 1. **broker** (OverseasFuturesBrokerNode) --> **schedule** (ScheduleNode)
 1. **schedule** (ScheduleNode) --> **trading_hours** (TradingHoursFilterNode)
 1. **trading_hours** (TradingHoursFilterNode) --> **account** (OverseasFuturesAccountNode)
-1. **trading_hours** (TradingHoursFilterNode) --> **watchlist** (WatchlistNode)
-1. **watchlist** (WatchlistNode) --> **historical** (OverseasFuturesHistoricalDataNode)
+1. **trading_hours** (TradingHoursFilterNode) --> **contract** (FuturesContractNode)
+1. **broker** (OverseasFuturesBrokerNode) --> **contract** (FuturesContractNode)
+1. **contract** (FuturesContractNode) --> **historical** (OverseasFuturesHistoricalDataNode)
 1. **historical** (OverseasFuturesHistoricalDataNode) --> **bollinger** (ConditionNode)
 1. **bollinger** (ConditionNode) --> **filter_buy** (SymbolFilterNode)
 1. **account** (OverseasFuturesAccountNode) --> **filter_buy** (SymbolFilterNode)

--- a/src/programgarden/examples/workflows/62-rsi-futures-bot.json
+++ b/src/programgarden/examples/workflows/62-rsi-futures-bot.json
@@ -28,12 +28,11 @@
     },
 
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {"symbol": "HMHJ26", "exchange": "HKEX"},
-        {"symbol": "HMCEJ26", "exchange": "HKEX"}
-      ],
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": ["HMH", "HMCE"],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {"x": 600, "y": 100}
     },
     {
@@ -116,9 +115,10 @@
     {"from": "broker", "to": "schedule"},
 
     {"from": "schedule", "to": "account"},
-    {"from": "schedule", "to": "watchlist"},
+    {"from": "schedule", "to": "contract"},
+    {"from": "broker", "to": "contract"},
 
-    {"from": "watchlist", "to": "historical"},
+    {"from": "contract", "to": "historical"},
     {"from": "historical", "to": "rsi"},
 
     {"from": "rsi", "to": "filter_buy"},
@@ -141,7 +141,7 @@
   "notes": [
     {
       "id": "note_strategy",
-      "content": "## RSI 과매도 해외선물 봇 (모의투자)\n\n**전략**: RSI(14) 과매도 역추세\n\n**매수(롱)**: RSI < 30 과매도 종목\n  -> 미보유 종목만 롱 1계약\n\n**청산**: 보유 포지션 전량 반대매매\n\n**주기**: 1분마다 (TradingHoursFilter 없음)\n\n**종목**: HMHJ26 (미니항셍 4월), HMCEJ26 (미니H주 4월)",
+      "content": "## RSI 과매도 해외선물 봇 (모의투자)\n\n**전략**: RSI(14) 과매도 역추세\n\n**매수(롱)**: RSI < 30 과매도 종목\n  -> 미보유 종목만 롱 1계약\n\n**청산**: 보유 포지션 전량 반대매매\n\n**주기**: 1분마다 (TradingHoursFilter 없음)\n\n**종목**: 미니 항셍(HMH), 미니 H주(HMCE)\n  -> FuturesContractNode 가 실행 시점에 근월물로 자동 해소 (월물 하드코딩 없음 = 만기가 지나도 안 죽는다)",
       "color": 3,
       "width": 340,
       "height": 260,

--- a/src/programgarden/examples/workflows/62-rsi-futures-bot.md
+++ b/src/programgarden/examples/workflows/62-rsi-futures-bot.md
@@ -13,7 +13,7 @@ HKEX mini futures RSI(14) oversold (<=30) long entry, liquidate held positions e
 
 **Interval**: Every 1 min (no TradingHoursFilter)
 
-**Symbols**: HMHJ26 (Mini Hang Seng Apr), HMCEJ26 (Mini H-Shares 
+**종목**: 미니 항셍(HMH), 미니 H주(HMCE) — `FuturesContractNode` 가 실행 시점에 LS 종목마스터를 조회해 **근월물로 자동 해소**한다. 월물 코드를 하드코딩하지 않으므로 만기가 지나도 워크플로우가 죽지 않는다.
 
 ## Workflow Structure
 
@@ -25,7 +25,8 @@ graph LR
     schedule{{"Schedule"}}
     account["Account
 (Overseas Futures)"]
-    watchlist["Watchlist"]
+    contract["FuturesContract
+(front month)"]
     historical["Historical
 (Overseas Futures)"]
     rsi{"Condition
@@ -40,8 +41,9 @@ graph LR
     start --> broker
     broker --> schedule
     schedule --> account
-    schedule --> watchlist
-    watchlist --> historical
+    schedule --> contract
+    broker --> contract
+    contract --> historical
     historical --> rsi
     rsi --> filter_buy
     account --> filter_buy
@@ -58,7 +60,7 @@ graph LR
 | broker | OverseasFuturesBrokerNode | Overseas futures broker connection (paper trading, HKEX) |
 | schedule | ScheduleNode | Schedule trigger (cron) |
 | account | OverseasFuturesAccountNode | Overseas futures account balance/position query |
-| watchlist | WatchlistNode | Define watchlist symbols |
+| contract | FuturesContractNode | 기초자산(HMH/HMCE) → 현재 상장 근월물 해소 (o3101, 실행 시점) |
 | historical | OverseasFuturesHistoricalDataNode | Overseas futures historical data query |
 | rsi | ConditionNode | Condition check (plugin-based) |
 | filter_buy | SymbolFilterNode | Symbol filter (intersection/difference/union) |
@@ -70,7 +72,7 @@ graph LR
 
 - **broker**: Paper trading mode
 - **schedule**: cron `*/1 * * * *` (timezone: Asia/Hong_Kong)
-- **watchlist**: HMHJ26, HMCEJ26
+- **contract**: base_products=`["HMH", "HMCE"]`, contract_selection=`front`, futures_exchange=`HKEX` (월물은 실행 시점에 해소)
 - **rsi**: Plugin `RSI`
 - **rsi**: period=14, threshold=30, direction=below
 - **buy_order**: side=`buy`
@@ -87,8 +89,9 @@ graph LR
 1. **start** (StartNode) --> **broker** (OverseasFuturesBrokerNode)
 1. **broker** (OverseasFuturesBrokerNode) --> **schedule** (ScheduleNode)
 1. **schedule** (ScheduleNode) --> **account** (OverseasFuturesAccountNode)
-1. **schedule** (ScheduleNode) --> **watchlist** (WatchlistNode)
-1. **watchlist** (WatchlistNode) --> **historical** (OverseasFuturesHistoricalDataNode)
+1. **schedule** (ScheduleNode) --> **contract** (FuturesContractNode)
+1. **broker** (OverseasFuturesBrokerNode) --> **contract** (FuturesContractNode)
+1. **contract** (FuturesContractNode) --> **historical** (OverseasFuturesHistoricalDataNode)
 1. **historical** (OverseasFuturesHistoricalDataNode) --> **rsi** (ConditionNode)
 1. **rsi** (ConditionNode) --> **filter_buy** (SymbolFilterNode)
 1. **account** (OverseasFuturesAccountNode) --> **filter_buy** (SymbolFilterNode)

--- a/src/programgarden/examples/workflows/73-auto-buy-bollinger-lower.json
+++ b/src/programgarden/examples/workflows/73-auto-buy-bollinger-lower.json
@@ -21,12 +21,11 @@
       "position": {"x": 450, "y": 500}
     },
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {"symbol": "HMHJ26", "exchange": "HKEX"},
-        {"symbol": "HMCEJ26", "exchange": "HKEX"}
-      ],
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": ["HMH", "HMCE"],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {"x": 450, "y": 100}
     },
     {
@@ -92,8 +91,8 @@
   "edges": [
     {"from": "start", "to": "broker"},
     {"from": "broker", "to": "account"},
-    {"from": "broker", "to": "watchlist"},
-    {"from": "watchlist", "to": "historical"},
+    {"from": "broker", "to": "contract"},
+    {"from": "contract", "to": "historical"},
     {"from": "historical", "to": "bollinger"},
     {"from": "bollinger", "to": "filter_not_held"},
     {"from": "account", "to": "filter_not_held"},
@@ -121,7 +120,7 @@
   "notes": [
     {
       "id": "note_strategy",
-      "content": "## 볼린저 하단 자동 매수\n\n**전략**: 볼린저밴드(20,2) 평균회귀\n**진입**: 하단 터치 → 롱 1계약\n**거래소**: HKEX 미니선물 (모의)\n\n**파이프라인**:\n1. Watchlist → 감시 종목 2개\n2. Historical → 60일 일봉 auto-iterate\n3. BollingerBands → below_lower 필터\n4. SymbolFilter → 기보유 제외 (중복 매수 방지)\n5. NewOrder(market, qty=1) → auto-iterate 매수\n6. Telegram → 체결 건별 알림\n\n**안전장치**:\n- paper_trading=true (모의투자)\n- resilience.fallback=skip (주문 실패시 다음 종목)\n- SymbolFilter로 중복 매수 차단",
+      "content": "## 볼린저 하단 자동 매수\n\n**전략**: 볼린저밴드(20,2) 평균회귀\n**진입**: 하단 터치 → 롱 1계약\n**거래소**: HKEX 미니선물 (모의)\n\n**파이프라인**:\n1. FuturesContract → 미니 항셍(HMH) · 미니 H주(HMCE) 근월물 자동 해소\n2. Historical → 60일 일봉 auto-iterate\n3. BollingerBands → below_lower 필터\n4. SymbolFilter → 기보유 제외 (중복 매수 방지)\n5. NewOrder(market, qty=1) → auto-iterate 매수\n6. Telegram → 체결 건별 알림\n\n**안전장치**:\n- paper_trading=true (모의투자)\n- resilience.fallback=skip (주문 실패시 다음 종목)\n- SymbolFilter로 중복 매수 차단\n- 월물 코드 하드코딩 없음 → 만기가 지나도 예제가 죽지 않음",
       "color": 3,
       "width": 360,
       "height": 320,

--- a/src/programgarden/examples/workflows/73-auto-buy-bollinger-lower.md
+++ b/src/programgarden/examples/workflows/73-auto-buy-bollinger-lower.md
@@ -2,21 +2,25 @@
 
 > **시나리오**: "볼린저밴드 하단에 닿은 선물 종목 있으면 알아서 매수하고, 체결되면 텔레그램으로 알려줘."
 
+**대상**: 미니 항셍(HMH), 미니 H주(HMCE)
+  → 월물(계약월)은 실행 시점에 근월물로 자동 해소된다 — 만기가 지나도 워크플로우가 죽지 않는다
+
 ## 흐름
 
 ```
-Start → Broker(paper) ─┬─► Watchlist → Historical → BollingerBands(below_lower) ─┐
-                       │                                                          ▼
-                       └─► Account ─────────────────────────────► SymbolFilter (차집합)
-                                                                        │
-                                                              buy_order → Telegram
+Start → Broker(paper) ─┬─► FuturesContract → Historical → BollingerBands(below_lower) ─┐
+                       │                                                                ▼
+                       └─► Account ───────────────────────────────────► SymbolFilter (차집합)
+                                                                              │
+                                                                    buy_order → Telegram
 ```
 
 ## 핵심 자동화 패턴
 
 | 단계 | 목적 |
 |------|------|
-| **WatchlistNode → HistoricalData** | 종목별 auto-iterate (2종목 → 2번 실행) |
+| **FuturesContractNode** | `base_products: ["HMH", "HMCE"]` → 실행 시점에 LS 종목마스터를 조회해 현재 상장된 근월물로 해소 (`contract_selection: "front"`) |
+| **FuturesContract → HistoricalData** | 종목별 auto-iterate (2종목 → 2번 실행, `symbol: "{{ item }}"`) |
 | **ConditionNode(BollingerBands)** | `below_lower` 포지션의 종목만 `passed_symbols` 으로 통과 |
 | **SymbolFilterNode(difference)** | `passed_symbols - held_symbols` 로 미보유 신규 종목만 |
 | **NewOrderNode(auto-iterate)** | 필터링된 각 종목마다 시장가 1계약 매수 |
@@ -47,6 +51,8 @@ Start → Broker(paper) ─┬─► Watchlist → Historical → BollingerBands
 
 ## 주의사항
 
-- HKEX 미니선물 심볼 `HMHJ26` 은 **2026년 4월 만기** → 다음 달 계약(`HMHK26` 5월)으로 업데이트 필요
+- 월물 종목코드를 워크플로우에 적어두지 않는다 — `contract` 노드가 만기를 알아서 따라가므로 계약 갱신 작업이 필요 없다
+  (차월물을 쓰려면 `contract_selection: "next"`, 분기물이면 `"quarterly"`)
+- `contract` 노드는 LS 세션이 필요하므로 **브로커 → contract 엣지가 반드시 있어야 한다**
 - 주말/휴장일에는 체결 0건 (정상 동작)
 - 첫 실행 시 텔레그램 0 건일 수 있음 (BB 하단 터치 종목이 없는 경우)

--- a/src/programgarden/examples/workflows/75-day-trading-bot.json
+++ b/src/programgarden/examples/workflows/75-day-trading-bot.json
@@ -1,7 +1,7 @@
 {
   "id": "75-day-trading-bot",
   "name": "데이트레이딩 자동화: 장시작 매수 + 장마감 청산 (선물 모의)",
-  "description": "2중 스케줄로 장 시작 시 자동 진입 + 장 마감 전 전량 청산. HKEX 미니선물 모의 데이트레이딩 봇.",
+  "description": "2중 스케줄로 장 시작 시 자동 진입 + 장 마감 전 전량 청산. HKEX 미니항셍 모의 데이트레이딩 봇 (월물은 실행 시점에 근월물로 자동 해소).",
   "nodes": [
     {
       "id": "start",
@@ -26,11 +26,11 @@
       "position": {"x": 450, "y": 200}
     },
     {
-      "id": "entry_watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {"symbol": "HMHJ26", "exchange": "HKEX"}
-      ],
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": ["HMH"],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {"x": 650, "y": 200}
     },
     {
@@ -126,8 +126,9 @@
     {"from": "start", "to": "broker"},
 
     {"from": "broker", "to": "schedule_entry"},
-    {"from": "schedule_entry", "to": "entry_watchlist"},
-    {"from": "entry_watchlist", "to": "entry_historical"},
+    {"from": "schedule_entry", "to": "contract"},
+    {"from": "broker", "to": "contract"},
+    {"from": "contract", "to": "entry_historical"},
     {"from": "entry_historical", "to": "entry_momentum"},
     {"from": "entry_momentum", "to": "entry_buy_order"},
     {"from": "entry_buy_order", "to": "telegram_entry"},
@@ -158,10 +159,10 @@
   "notes": [
     {
       "id": "note_daytrading",
-      "content": "## 데이트레이딩 자동화\n\n**원칙**: 오버나이트 리스크 제거 (당일 진입/당일 청산)\n\n**2중 스케줄**:\n1. schedule_entry: 평일 09:30 HKT (장 시작)\n   → 모멘텀 양수인 종목 매수\n2. schedule_exit: 평일 15:55 HKT (장 마감 5분 전)\n   → 보유 포지션 전량 청산\n\n**DAG 구조**:\n- broker → schedule_entry → 매수 파이프라인\n- broker → schedule_exit → 청산 파이프라인\n- 두 스케줄이 독립 병렬 실행\n\n**진입 필터**: TimeSeriesMomentum(10일)\n- 단기 추세 양수면 매수\n- 추세 음수면 매수 스킵 (빈 passed_symbols)",
+      "content": "## 데이트레이딩 자동화\n\n**원칙**: 오버나이트 리스크 제거 (당일 진입/당일 청산)\n\n**2중 스케줄**:\n1. schedule_entry: 평일 09:30 HKT (장 시작)\n   → 모멘텀 양수인 종목 매수\n2. schedule_exit: 평일 15:55 HKT (장 마감 5분 전)\n   → 보유 포지션 전량 청산\n\n**DAG 구조**:\n- broker → schedule_entry → 매수 파이프라인\n- broker → schedule_exit → 청산 파이프라인\n- 두 스케줄이 독립 병렬 실행\n\n**종목**: 미니항셍(HMH)\n- contract 노드가 실행 시점에 근월물로 자동 해소 (만기 무관)\n\n**진입 필터**: TimeSeriesMomentum(10일)\n- 단기 추세 양수면 매수\n- 추세 음수면 매수 스킵 (빈 passed_symbols)",
       "color": 5,
       "width": 380,
-      "height": 360,
+      "height": 410,
       "position": {"x": 30, "y": 30}
     }
   ]

--- a/src/programgarden/examples/workflows/75-day-trading-bot.md
+++ b/src/programgarden/examples/workflows/75-day-trading-bot.md
@@ -5,16 +5,18 @@
 ## 아키텍처: 2중 스케줄 병렬
 
 ```
-                     ┌── schedule_entry(09:30) → Watchlist → Historical → TSMOM → Buy → Telegram
-Start → Broker ──────┤
+                     ┌── schedule_entry(09:30) → Contract → Historical → TSMOM → Buy → Telegram
+Start → Broker ──────┤                             ↑ (broker 세션 필요)
                      └── schedule_exit(15:55) → Account → Sell(전량) → Telegram
 ```
 
 하나의 BrokerNode 에서 두 개의 독립된 ScheduleNode 로 분기 → **병렬 실행**.
 
+`contract`(FuturesContractNode)는 실행 시점에 LS 종목마스터를 조회해 **현재 상장된 근월물로 자동 해소**한다 — 월물 코드를 예제에 적어두지 않으므로 만기가 지나도 봇이 조용히 죽지 않는다. (종목마스터 조회에 LS 세션이 필요해 `broker → contract` 엣지를 함께 연결한다.)
+
 ## 진입 로직 (09:30 HKT)
 
-1. 감시 종목 1개 (`HMHJ26`)
+1. 기초자산 1종 — 미니항셍(`HMH`) → 근월물 자동 해소
 2. 최근 20일 일봉 조회
 3. **TimeSeriesMomentum(10일)** — 10일 수익률 양수면 binary signal=1
 4. 신호 양수 시 시장가 1계약 매수
@@ -42,7 +44,8 @@ Start → Broker ──────┤
 
 ## 확장 아이디어
 
-- **여러 종목**: entry_watchlist 에 종목 추가 → 각 종목별 독립 진입
+- **여러 종목**: contract 의 `base_products` 에 기초자산 추가(예: `["HMH", "HMCE"]`) → 각 종목별 독립 진입
+- **차월물/분기물**: contract 의 `contract_selection` 을 `next` / `quarterly` 로 변경
 - **부분 청산**: 장 마감 대신 일부만 청산, 일부는 홀드
 - **진입 지연**: 09:30 대신 10:00 → 장 시작 변동성 회피
 - **TradingHoursFilter 추가**: 휴장일 자동 스킵

--- a/src/programgarden/examples/workflows/76-golden-cross-auto-buy.json
+++ b/src/programgarden/examples/workflows/76-golden-cross-auto-buy.json
@@ -30,12 +30,11 @@
       "position": {"x": 650, "y": 500}
     },
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {"symbol": "HMHJ26", "exchange": "HKEX"},
-        {"symbol": "HMCEJ26", "exchange": "HKEX"}
-      ],
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": ["HMH", "HMCE"],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {"x": 650, "y": 100}
     },
     {
@@ -102,8 +101,9 @@
     {"from": "start", "to": "broker"},
     {"from": "broker", "to": "schedule"},
     {"from": "schedule", "to": "account"},
-    {"from": "schedule", "to": "watchlist"},
-    {"from": "watchlist", "to": "historical"},
+    {"from": "schedule", "to": "contract"},
+    {"from": "broker", "to": "contract"},
+    {"from": "contract", "to": "historical"},
     {"from": "historical", "to": "ma_cross"},
     {"from": "ma_cross", "to": "filter_not_held"},
     {"from": "account", "to": "filter_not_held"},
@@ -131,10 +131,10 @@
   "notes": [
     {
       "id": "note_strategy",
-      "content": "## 골든크로스 자동 매수\n\n**전략**: 추세 추종 (MA5 x MA20)\n**시그널**:\n- 골든크로스 (golden): MA5 가 MA20 을 상향 돌파 → 매수\n- 데드크로스 (dead): MA5 가 MA20 을 하향 돌파 → 매도 (별도 워크플로우)\n\n**스케줄**: 평일 10:00 HKT 일일 체크\n- 전일 종가 기준 크로스 감지\n- 장 시작 후 30분 뒤 진입 (변동성 안정화)\n\n**MA 기간 조정**:\n- 초단기: MA3/MA10 (더 민감, 더 많은 신호)\n- 단기 (기본): MA5/MA20\n- 중기: MA10/MA50\n- 장기: MA50/MA200 (황금교차)\n\n**주의**:\n- MA 크로스는 후행 지표 → 추세 전환을 지연 반영\n- 횡보장에선 잦은 가짜 신호\n- 강한 추세장에서 가장 효과적",
+      "content": "## 골든크로스 자동 매수\n\n**전략**: 추세 추종 (MA5 x MA20)\n**시그널**:\n- 골든크로스 (golden): MA5 가 MA20 을 상향 돌파 → 매수\n- 데드크로스 (dead): MA5 가 MA20 을 하향 돌파 → 매도 (별도 워크플로우)\n\n**스케줄**: 평일 10:00 HKT 일일 체크\n- 전일 종가 기준 크로스 감지\n- 장 시작 후 30분 뒤 진입 (변동성 안정화)\n\n**종목**: 미니 항셍(HMH), 미니 H주(HMCE)\n  -> FuturesContractNode 가 실행 시점에 근월물로 자동 해소 (월물 하드코딩 없음 = 만기가 지나도 안 죽는다)\n\n**MA 기간 조정**:\n- 초단기: MA3/MA10 (더 민감, 더 많은 신호)\n- 단기 (기본): MA5/MA20\n- 중기: MA10/MA50\n- 장기: MA50/MA200 (황금교차)\n\n**주의**:\n- MA 크로스는 후행 지표 → 추세 전환을 지연 반영\n- 횡보장에선 잦은 가짜 신호\n- 강한 추세장에서 가장 효과적",
       "color": 6,
       "width": 380,
-      "height": 380,
+      "height": 440,
       "position": {"x": 30, "y": 30}
     }
   ]

--- a/src/programgarden/examples/workflows/76-golden-cross-auto-buy.md
+++ b/src/programgarden/examples/workflows/76-golden-cross-auto-buy.md
@@ -5,12 +5,29 @@
 ## 흐름
 
 ```
-Schedule(일 1회) ─┬─► Watchlist → Historical → MACross(golden) ─┐
-                  │                                              ▼
-                  └─► Account ─────────────────► SymbolFilter (미보유만)
-                                                        │
-                                                   Buy → Telegram
+Schedule(일 1회) ─┬─► FuturesContract → Historical → MACross(golden) ─┐
+                  │   (Broker → contract 도 연결)                      ▼
+                  └─► Account ─────────────────────► SymbolFilter (미보유만)
+                                                            │
+                                                       Buy → Telegram
 ```
+
+## 대상 종목
+
+**미니 항셍(HMH), 미니 H주(HMCE)** — `FuturesContractNode` 가 실행 시점에 LS 종목마스터를 조회해 **근월물로 자동 해소**한다. 월물 코드를 하드코딩하지 않으므로 만기가 지나도 워크플로우가 죽지 않는다.
+
+```json
+{
+  "id": "contract",
+  "type": "FuturesContractNode",
+  "base_products": ["HMH", "HMCE"],
+  "contract_selection": "front",
+  "futures_exchange": "HKEX"
+}
+```
+
+`contract` 는 `symbols` 를 내보내고, 하류의 `historical` 이 `"symbol": "{{ item }}"` 로 종목별 자동 반복 조회한다.
+종목마스터 조회(o3101)에는 LS 세션이 필요하므로 **Broker → contract** 엣지가 반드시 있어야 한다.
 
 ## 골든크로스란?
 

--- a/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.json
+++ b/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.json
@@ -3,13 +3,23 @@
   "name": "HKEX 다종목 RSI+Bollinger 복합 진입 (모의투자)",
   "description": "Mini Hang Seng + Mini HSCEI 두 종목을 30분 간격으로 평일 KST 데이세션 동안 스캔. RSI 과매도 AND Bollinger 하단 터치 두 조건이 모두 충족된 종목에 한해 ATR 기반 사이징으로 limit 매수. HKEX 모의투자(시장가 불가) 제약 + A-3 auto-iterate spacing 회귀 가드.",
   "nodes": [
-    {"id": "start", "type": "StartNode", "position": {"x": 50, "y": 320}},
+    {
+      "id": "start",
+      "type": "StartNode",
+      "position": {
+        "x": 50,
+        "y": 320
+      }
+    },
     {
       "id": "broker",
       "type": "OverseasFuturesBrokerNode",
       "credential_id": "broker_cred",
       "paper_trading": true,
-      "position": {"x": 220, "y": 320}
+      "position": {
+        "x": 220,
+        "y": 320
+      }
     },
     {
       "id": "schedule",
@@ -18,7 +28,10 @@
       "timezone": "Asia/Seoul",
       "enabled": true,
       "max_duration_hours": 720,
-      "position": {"x": 400, "y": 320}
+      "position": {
+        "x": 400,
+        "y": 320
+      }
     },
     {
       "id": "trading_hours",
@@ -26,18 +39,35 @@
       "start": "10:15",
       "end": "17:30",
       "timezone": "Asia/Seoul",
-      "days": ["mon", "tue", "wed", "thu", "fri"],
-      "position": {"x": 600, "y": 320}
+      "days": [
+        "mon",
+        "tue",
+        "wed",
+        "thu",
+        "fri"
+      ],
+      "position": {
+        "x": 600,
+        "y": 320
+      }
     },
-
     {
       "id": "watchlist",
       "type": "WatchlistNode",
       "symbols": [
-        {"symbol": "HMHM26", "exchange": "HKEX"},
-        {"symbol": "HMCEM26", "exchange": "HKEX"}
+        {
+          "symbol": "HMHU26",
+          "exchange": "HKEX"
+        },
+        {
+          "symbol": "HMCEU26",
+          "exchange": "HKEX"
+        }
       ],
-      "position": {"x": 820, "y": 120}
+      "position": {
+        "x": 820,
+        "y": 120
+      }
     },
     {
       "id": "historical",
@@ -46,7 +76,10 @@
       "start_date": "{{ date.ago(60, format='yyyymmdd') }}",
       "end_date": "{{ date.today(format='yyyymmdd') }}",
       "interval": "1d",
-      "position": {"x": 1050, "y": 120}
+      "position": {
+        "x": 1050,
+        "y": 120
+      }
     },
     {
       "id": "rsi_condition",
@@ -66,7 +99,10 @@
         "threshold": 30,
         "direction": "below"
       },
-      "position": {"x": 1300, "y": 40}
+      "position": {
+        "x": 1300,
+        "y": 40
+      }
     },
     {
       "id": "bollinger_condition",
@@ -86,7 +122,10 @@
         "std_dev": 2.0,
         "position": "below_lower"
       },
-      "position": {"x": 1300, "y": 200}
+      "position": {
+        "x": 1300,
+        "y": 200
+      }
     },
     {
       "id": "logic",
@@ -102,13 +141,18 @@
           "passed_symbols": "{{ nodes.bollinger_condition.passed_symbols }}"
         }
       ],
-      "position": {"x": 1550, "y": 120}
+      "position": {
+        "x": 1550,
+        "y": 120
+      }
     },
-
     {
       "id": "account",
       "type": "OverseasFuturesAccountNode",
-      "position": {"x": 820, "y": 520}
+      "position": {
+        "x": 820,
+        "y": 520
+      }
     },
     {
       "id": "filter_buy",
@@ -116,7 +160,10 @@
       "operation": "difference",
       "input_a": "{{ nodes.logic.passed_symbols }}",
       "input_b": "{{ nodes.account.held_symbols }}",
-      "position": {"x": 1780, "y": 320}
+      "position": {
+        "x": 1780,
+        "y": 320
+      }
     },
     {
       "id": "if_candidates",
@@ -124,7 +171,10 @@
       "left": "{{ nodes.filter_buy.symbols }}",
       "operator": "is_not_empty",
       "right": null,
-      "position": {"x": 2000, "y": 320}
+      "position": {
+        "x": 2000,
+        "y": 320
+      }
     },
     {
       "id": "no_entry_notice",
@@ -136,13 +186,19 @@
         "held": "{{ nodes.account.held_symbols }}",
         "status": "no_entry"
       },
-      "position": {"x": 2220, "y": 520}
+      "position": {
+        "x": 2220,
+        "y": 520
+      }
     },
     {
       "id": "market_data",
       "type": "OverseasFuturesMarketDataNode",
       "symbol": "{{ item }}",
-      "position": {"x": 2220, "y": 200}
+      "position": {
+        "x": 2220,
+        "y": 200
+      }
     },
     {
       "id": "sizing",
@@ -153,7 +209,10 @@
       "method": "atr_based",
       "max_percent": 5.0,
       "atr_risk_percent": 1.0,
-      "position": {"x": 2220, "y": 320}
+      "position": {
+        "x": 2220,
+        "y": 320
+      }
     },
     {
       "id": "buy_order",
@@ -162,56 +221,140 @@
       "order_type": "limit",
       "order": "{{ nodes.sizing.order }}",
       "resilience": {
-        "fallback": {"mode": "skip"}
+        "fallback": {
+          "mode": "skip"
+        }
       },
-      "position": {"x": 2450, "y": 320}
+      "position": {
+        "x": 2450,
+        "y": 320
+      }
     },
     {
       "id": "telegram",
       "type": "TelegramNode",
       "credential_id": "telegram_cred",
       "template": "🎯 HKEX 진입 ({{ nodes.filter_buy.count }}종목): {{ nodes.filter_buy.symbols }} (RSI<30 AND Bollinger 하단, limit 매수)",
-      "position": {"x": 2680, "y": 320}
+      "position": {
+        "x": 2680,
+        "y": 320
+      }
     }
   ],
   "edges": [
-    {"from": "start", "to": "broker"},
-    {"from": "broker", "to": "schedule"},
-    {"from": "schedule", "to": "trading_hours"},
-
-    {"from": "trading_hours", "to": "watchlist"},
-    {"from": "watchlist", "to": "historical"},
-    {"from": "historical", "to": "rsi_condition"},
-    {"from": "historical", "to": "bollinger_condition"},
-    {"from": "rsi_condition", "to": "logic"},
-    {"from": "bollinger_condition", "to": "logic"},
-
-    {"from": "trading_hours", "to": "account"},
-    {"from": "logic", "to": "filter_buy"},
-    {"from": "account", "to": "filter_buy"},
-    {"from": "filter_buy", "to": "if_candidates"},
-    {"from": "if_candidates", "to": "no_entry_notice", "from_port": "false"},
-    {"from": "filter_buy", "to": "market_data"},
-    {"from": "market_data", "to": "sizing"},
-    {"from": "account", "to": "sizing"},
-    {"from": "sizing", "to": "buy_order"},
-    {"from": "buy_order", "to": "telegram"}
+    {
+      "from": "start",
+      "to": "broker"
+    },
+    {
+      "from": "broker",
+      "to": "schedule"
+    },
+    {
+      "from": "schedule",
+      "to": "trading_hours"
+    },
+    {
+      "from": "trading_hours",
+      "to": "watchlist"
+    },
+    {
+      "from": "watchlist",
+      "to": "historical"
+    },
+    {
+      "from": "historical",
+      "to": "rsi_condition"
+    },
+    {
+      "from": "historical",
+      "to": "bollinger_condition"
+    },
+    {
+      "from": "rsi_condition",
+      "to": "logic"
+    },
+    {
+      "from": "bollinger_condition",
+      "to": "logic"
+    },
+    {
+      "from": "trading_hours",
+      "to": "account"
+    },
+    {
+      "from": "logic",
+      "to": "filter_buy"
+    },
+    {
+      "from": "account",
+      "to": "filter_buy"
+    },
+    {
+      "from": "filter_buy",
+      "to": "if_candidates"
+    },
+    {
+      "from": "if_candidates",
+      "to": "no_entry_notice",
+      "from_port": "false"
+    },
+    {
+      "from": "filter_buy",
+      "to": "market_data"
+    },
+    {
+      "from": "market_data",
+      "to": "sizing"
+    },
+    {
+      "from": "account",
+      "to": "sizing"
+    },
+    {
+      "from": "sizing",
+      "to": "buy_order"
+    },
+    {
+      "from": "buy_order",
+      "to": "telegram"
+    }
   ],
   "credentials": [
     {
       "credential_id": "broker_cred",
       "type": "broker_ls_overseas_futures",
       "data": [
-        {"key": "appkey", "value": "", "type": "password", "label": "App Key"},
-        {"key": "appsecret", "value": "", "type": "password", "label": "App Secret"}
+        {
+          "key": "appkey",
+          "value": "",
+          "type": "password",
+          "label": "App Key"
+        },
+        {
+          "key": "appsecret",
+          "value": "",
+          "type": "password",
+          "label": "App Secret"
+        }
       ]
     },
     {
       "credential_id": "telegram_cred",
       "type": "telegram",
       "data": [
-        {"key": "bot_token", "value": "", "type": "password", "label": "Bot Token"},
-        {"key": "chat_id", "value": "", "type": "text", "label": "Chat ID"}
+        {
+          "key": "bot_token",
+          "value": "",
+          "type": "password",
+          "label": "Bot Token"
+        },
+        {
+          "key": "chat_id",
+          "value": "",
+          "type": "text",
+          "label": "Chat ID"
+        }
       ]
     }
   ],
@@ -222,7 +365,10 @@
       "color": 5,
       "width": 380,
       "height": 320,
-      "position": {"x": 30, "y": 30}
+      "position": {
+        "x": 30,
+        "y": 30
+      }
     },
     {
       "id": "note_constraints",
@@ -230,7 +376,10 @@
       "color": 1,
       "width": 380,
       "height": 360,
-      "position": {"x": 440, "y": 30}
+      "position": {
+        "x": 440,
+        "y": 30
+      }
     }
   ]
 }

--- a/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.json
+++ b/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.json
@@ -149,7 +149,7 @@
       "type": "PositionSizingNode",
       "symbol": "{{ item }}",
       "balance": "{{ nodes.account.balance }}",
-      "market_data": "{{ nodes.market_data.value }}",
+      "market_data": "{{ nodes.market_data.values }}",
       "method": "atr_based",
       "max_percent": 5.0,
       "atr_risk_percent": 1.0,

--- a/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.json
+++ b/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.json
@@ -52,18 +52,14 @@
       }
     },
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {
-          "symbol": "HMHU26",
-          "exchange": "HKEX"
-        },
-        {
-          "symbol": "HMCEU26",
-          "exchange": "HKEX"
-        }
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": [
+        "HMH",
+        "HMCE"
       ],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {
         "x": 820,
         "y": 120
@@ -256,10 +252,14 @@
     },
     {
       "from": "trading_hours",
-      "to": "watchlist"
+      "to": "contract"
     },
     {
-      "from": "watchlist",
+      "from": "broker",
+      "to": "contract"
+    },
+    {
+      "from": "contract",
       "to": "historical"
     },
     {
@@ -361,7 +361,7 @@
   "notes": [
     {
       "id": "note_strategy",
-      "content": "## HKEX 다종목 RSI+Bollinger 복합 진입 (모의투자)\n\n**전략**: RSI(14,30) 과매도 AND Bollinger(20,2) 하단 터치\n\n**종목**: HMHM26 (Mini Hang Seng 6월), HMCEM26 (Mini HSCEI 6월)\n\n**주문 유형**: limit (HKEX 모의투자는 시장가 불가)\n\n**거래시간**: 평일 KST 10:15-17:30 (HKEX 데이세션). T+1 야간 / 점심 휴장은 본 예제 미포함.\n\n**사이징**: ATR 기반 (계좌 최대 5% / 종목당 1% 위험)\n\n**필터**: 이미 보유 중인 월물은 SymbolFilter difference 로 제외",
+      "content": "## HKEX 다종목 RSI+Bollinger 복합 진입 (모의투자)\n\n**전략**: RSI(14,30) 과매도 AND Bollinger(20,2) 하단 터치\n\n**종목**: 미니 항셍(HMH), 미니 H주(HMCE) — `FuturesContractNode` 가 실행 시점에 **근월물로 자동 해소**합니다 (월물 코드 하드코딩 없음).\n\n**주문 유형**: limit (HKEX 모의투자는 시장가 불가)\n\n**거래시간**: 평일 KST 10:15-17:30 (HKEX 데이세션). T+1 야간 / 점심 휴장은 본 예제 미포함.\n\n**사이징**: ATR 기반 (계좌 최대 5% / 종목당 1% 위험)\n\n**필터**: 이미 보유 중인 월물은 SymbolFilter difference 로 제외",
       "color": 5,
       "width": 380,
       "height": 320,
@@ -372,7 +372,7 @@
     },
     {
       "id": "note_constraints",
-      "content": "## HKEX 모의투자 제약 ⚠️\n\n1. **시장가 불가** → 모든 주문 `order_type=limit` + price 필수\n2. **거래소**: HKEX 만 지원 (LS 모의)\n3. **통화**: HKD (KRW 환산은 별도)\n4. **거래시간 (KST)**:\n   - 데이 1부: 10:15-13:00\n   - 점심 휴장: 13:00-14:00\n   - 데이 2부: 14:00-17:30\n   - 저녁 휴장: 17:30-18:15\n   - T+1 야간: 18:15-04:00(+1)\n5. **월물**: 분기물 H/M/U/Z, 만기 임박 시 다음 월물로 roll-over 필요 (예제 85 참조)\n\n자세히는 `00-workflow-guide.md` HKEX 섹션.",
+      "content": "## HKEX 모의투자 제약 ⚠️\n\n1. **시장가 불가** → 모든 주문 `order_type=limit` + price 필수\n2. **거래소**: HKEX 만 지원 (LS 모의)\n3. **통화**: HKD (KRW 환산은 별도)\n4. **거래시간 (KST)**:\n   - 데이 1부: 10:15-13:00\n   - 점심 휴장: 13:00-14:00\n   - 데이 2부: 14:00-17:30\n   - 저녁 휴장: 17:30-18:15\n   - T+1 야간: 18:15-04:00(+1)\n5. **월물**: `FuturesContractNode` 가 실행 시점에 상장 월물을 조회해 근월물을 고르므로 만기가 지나도 자동으로 다음 월물로 넘어갑니다 (월물 하드코딩 금지 — 만기 경과 종목은 LS 가 에러 없이 빈 배열만 반환)\n\n자세히는 `00-workflow-guide.md` HKEX 섹션.",
       "color": 1,
       "width": 380,
       "height": 360,

--- a/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.md
+++ b/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.md
@@ -46,7 +46,7 @@ flowchart LR
     start([StartNode]) --> broker[OverseasFuturesBrokerNode<br/>paper_trading=true]
     broker --> schedule[ScheduleNode<br/>*/30 * * * 1-5 KST]
     schedule --> hours[TradingHoursFilterNode<br/>10:15-17:30 KST]
-    hours --> watchlist[WatchlistNode<br/>HMHM26, HMCEM26]
+    hours --> watchlist[WatchlistNode<br/>HMHU26, HMCEU26]
     watchlist --> historical[HistoricalDataNode<br/>60d 1d auto-iterate]
     historical --> rsi[ConditionNode RSI<br/>period=14 threshold=30]
     historical --> boll[ConditionNode Bollinger<br/>period=20 std_dev=2.0]
@@ -73,7 +73,7 @@ flowchart LR
 | `start` / `broker` | 진입점 + 모의 브로커 | `paper_trading=true` |
 | `schedule` | 30분 간격 cron | `*/30 * * * 1-5`, `timezone=Asia/Seoul` |
 | `trading_hours` | KST 데이세션 게이트 | `10:15-17:30`, mon-fri |
-| `watchlist` | 후보 종목 | HMHM26, HMCEM26 |
+| `watchlist` | 후보 종목 | HMHU26, HMCEU26 (2026/09물) |
 | `historical` | 60일 일봉 (auto-iterate per symbol) | `interval=1d` |
 | `rsi_condition` | RSI 과매도 | `period=14, threshold=30, direction=below` |
 | `bollinger_condition` | 볼린저 하단 | `period=20, std_dev=2.0, position=below_lower` |
@@ -155,8 +155,10 @@ strip 한 read-only 변환) 로 실 LS 해외선물 모의 appkey (`APPKEY_FUTUR
 
 > ⚠️ **월물 만기 주의**: 최초 작성 시 4월물(`HMHJ26`/`HMCEJ26`) 사용 → 2026-05-29 시점
 > 이미 만기 경과로 historical 이 **빈 배열**(silent) 반환. live 6월물(`HMHM26`/`HMCEM26`)
-> 로 roll-forward 하여 해결. 선물 예제는 만기마다 월물 갱신 필요 — `00-workflow-guide.md`
-> HKEX 섹션 참조.
+> 로 roll-forward 하여 해결. **2026-07-13 재발** — 6월물도 만기 경과로 다시 빈 배열이 되어
+> 9월물(`HMHU26`/`HMCEU26`, 실측 21봉)로 roll-forward 했다.
+> 선물 예제는 만기마다 월물 갱신 필요 — `00-workflow-guide.md` HKEX 섹션 참조.
+> (근본 해결은 근월물 자동 선택이나, 현재 SDK 에 해당 기능이 없어 하드코딩이 불가피하다.)
 
 ### L4 — mock 주문 1건 (✅ 라이브 PASS, 2026-06-01)
 
@@ -237,3 +239,7 @@ poetry run python examples/programmer_example/test_hkex_81_l4_order.py --confirm
   게이트 silent 봉쇄 버그로 확인 → LogicNode 바인딩 올바른 관례로 교정 (commit `1b615da5`)
 - 2026-05-31: LogicNode 다종목 auto-iterate AND 교집합 코어 버그 수정 (executor.py, commit
   `3bb5d284`) — 바인딩-only 수정이 못 잡던 더 깊은 결함. `validate()` errors 0 / warn 0.
+- 2026-07-13: 6월물 만기 경과로 historical 이 다시 빈 배열 → **9월물(HMHU26/HMCEU26)**
+  roll-forward (실전 키로 월물 유효성 실측: 6월물 0봉 / 9월물 21봉). 아울러 실행기의
+  auto-iterate 결함 4건을 수정 — `LogicNode` 가 auto-iterate 대상이라 `passed_symbols` 가
+  N² 로 부풀던 것 포함(이 예제도 영향). 상세는 `CHANGELOG.md` 1.26.0 Fixed 참조.

--- a/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.md
+++ b/src/programgarden/examples/workflows/81-hkex-multi-symbol-rsi-bollinger.md
@@ -12,6 +12,9 @@
 미니항셍·미니H주 두 종목을 30분마다 스캔. **RSI 과매도 AND Bollinger 하단 터치**
 두 조건이 동시에 충족된 종목에 한해 ATR 기반 사이징으로 **limit 매수**.
 
+- **종목 지정**: `FuturesContractNode` 에 **기초자산 코드**(`HMH`=미니 항셍, `HMCE`=미니 H주)만 적습니다.
+  실제 월물 종목코드는 **실행 시점에 LS 종목마스터(o3101)를 조회해 근월물로 자동 해소**되므로,
+  만기가 지나도 워크플로우가 조용히 죽지 않고 자동으로 다음 월물을 따라갑니다.
 - **RSI**: period=14, threshold=30, direction=below (과매도)
 - **Bollinger**: period=20, std_dev=2.0, position=below_lower (하단 이탈)
 - **Logic**: `operator: all` — 두 조건 모두 통과한 종목만 진입
@@ -26,12 +29,12 @@
 | 제약 | 본 예제 반영 |
 |------|-------------|
 | 시장가 주문 불가 | 모든 NewOrderNode `order_type: "limit"` 강제 |
-| 거래소: HKEX 만 | Watchlist 두 종목 모두 `exchange: HKEX` |
+| 거래소: HKEX 만 | `FuturesContractNode.futures_exchange: "HKEX"` — 해소되는 월물 모두 HKEX |
 | 통화: HKD | balance/price 는 HKD 단위 (KRW 환산 시 별도 환율 노드 필요) |
 | 거래시간 (KST) | TradingHoursFilter `10:15-17:30 Asia/Seoul` (데이세션만) |
 | 점심 휴장 13:00-14:00 KST | 본 예제 단일 윈도우 — 점심 시 cron 발사도 다음 사이클에서 자연 진입 |
 | T+1 야간 18:15-04:00(+1) | 본 예제 미포함 — 보유 포지션 모니터링은 예제 82 참조 |
-| 월물 만기 / Roll-over | 본 예제 분기물 M(6월) 사용. 만기 임박 roll-over 자동화는 예제 85 참조 |
+| 월물 만기 / Roll-over | `FuturesContractNode` (`contract_selection: "front"`) 가 실행 시점마다 근월물을 다시 고름 — 별도 roll-over 불필요 |
 
 > `TradingHoursFilterNode` 는 현재 단일 윈도우만 지원합니다 (multi-window / wrap-around 미지원).
 > HKEX 야간세션·점심 휴장까지 정확히 표현하려면 LogicNode 3개 OR 패턴 또는 노드 확장이 필요합니다.
@@ -46,8 +49,9 @@ flowchart LR
     start([StartNode]) --> broker[OverseasFuturesBrokerNode<br/>paper_trading=true]
     broker --> schedule[ScheduleNode<br/>*/30 * * * 1-5 KST]
     schedule --> hours[TradingHoursFilterNode<br/>10:15-17:30 KST]
-    hours --> watchlist[WatchlistNode<br/>HMHU26, HMCEU26]
-    watchlist --> historical[HistoricalDataNode<br/>60d 1d auto-iterate]
+    hours --> contract[FuturesContractNode<br/>HMH, HMCE / front]
+    broker --> contract
+    contract --> historical[HistoricalDataNode<br/>60d 1d auto-iterate]
     historical --> rsi[ConditionNode RSI<br/>period=14 threshold=30]
     historical --> boll[ConditionNode Bollinger<br/>period=20 std_dev=2.0]
     rsi --> logic[LogicNode<br/>operator=all]
@@ -73,8 +77,8 @@ flowchart LR
 | `start` / `broker` | 진입점 + 모의 브로커 | `paper_trading=true` |
 | `schedule` | 30분 간격 cron | `*/30 * * * 1-5`, `timezone=Asia/Seoul` |
 | `trading_hours` | KST 데이세션 게이트 | `10:15-17:30`, mon-fri |
-| `watchlist` | 후보 종목 | HMHU26, HMCEU26 (2026/09물) |
-| `historical` | 60일 일봉 (auto-iterate per symbol) | `interval=1d` |
+| `contract` | 후보 종목 (기초자산 → 근월물 자동 해소) | `base_products=["HMH","HMCE"]`, `contract_selection=front`, `futures_exchange=HKEX` — 브로커 엣지 필수 (o3101 은 LS 세션 사용) |
+| `historical` | 60일 일봉 (auto-iterate per symbol) | `interval=1d`, `symbol={{ item }}` |
 | `rsi_condition` | RSI 과매도 | `period=14, threshold=30, direction=below` |
 | `bollinger_condition` | 볼린저 하단 | `period=20, std_dev=2.0, position=below_lower` |
 | `logic` | AND 결합 | `operator=all` — RSI 와 Bollinger 모두 통과한 symbol 만 출력 |
@@ -129,7 +133,7 @@ print('recs:', [x.rule_id for x in r.static_recommendations])
 poetry run pytest tests/test_examples_validation.py::TestWorkflowDryRunCycle::test_workflow_dry_run_cycle[81-hkex-multi-symbol-rsi-bollinger] -v
 ```
 
-→ `status: completed, errors_count: 0`. Auto-iterate (Watchlist → Historical → RSI → Bollinger → Logic) 전 체인 정상.
+→ `status: completed, errors_count: 0`. Auto-iterate (contract → Historical → RSI → Bollinger → Logic) 전 체인 정상.
 
 ### L3 — 실 모의계좌 시세 read (2026-05-29 최초 ✅ / 2026-05-30 deb80456 재검증 ✅)
 
@@ -140,8 +144,8 @@ strip 한 read-only 변환) 로 실 LS 해외선물 모의 appkey (`APPKEY_FUTUR
 |------|------|
 | `account.balance` | ✅ 통화별 잔고 수신 (HKD 1,000,130 등) |
 | `account.positions` | `[]` (무포지션, 정상) |
-| `historical.value` | ✅ HMHM26 / HMCEM26 실 OHLC(20260331~) time_series 정상 수신 |
-| `rsi_condition.passed_symbols` | ✅ 과매도 통과 (2026-05-30 재검: HMCEM26 RSI 20.87 / price 8363) |
+| `historical.value` | ✅ 미니 항셍 / 미니 H주 (당시 근월물) 실 OHLC time_series 정상 수신 |
+| `rsi_condition.passed_symbols` | ✅ 과매도 통과 (2026-05-30 재검: 미니 H주 RSI 20.87 / price 8363) |
 | `bollinger_condition.passed_symbols` | `[]` (현 시점 하단 미터치 — 실 시장 상태, 정상) |
 | `logic` (AND) | 교집합 없음 → 무진입 → `no_entry_notice` 분기 |
 | **errors** | **0** (양 실행 모두) |
@@ -153,12 +157,12 @@ strip 한 read-only 변환) 로 실 LS 해외선물 모의 appkey (`APPKEY_FUTUR
 > 코어 버그까지 수정(commit `3bb5d284`)했다. 현재 `validate()` = **errors 0 / warn 0**.
 > (무진입 path `{{ item }}` sizing 경로는 후보 0 일 때만 도는 정상 분기.)
 
-> ⚠️ **월물 만기 주의**: 최초 작성 시 4월물(`HMHJ26`/`HMCEJ26`) 사용 → 2026-05-29 시점
-> 이미 만기 경과로 historical 이 **빈 배열**(silent) 반환. live 6월물(`HMHM26`/`HMCEM26`)
-> 로 roll-forward 하여 해결. **2026-07-13 재발** — 6월물도 만기 경과로 다시 빈 배열이 되어
-> 9월물(`HMHU26`/`HMCEU26`, 실측 21봉)로 roll-forward 했다.
-> 선물 예제는 만기마다 월물 갱신 필요 — `00-workflow-guide.md` HKEX 섹션 참조.
-> (근본 해결은 근월물 자동 선택이나, 현재 SDK 에 해당 기능이 없어 하드코딩이 불가피하다.)
+> ✅ **월물 만기 — 근본 해결됨 (2026-07-13)**: 이 예제는 과거 월물 코드를 하드코딩했다가
+> 만기가 지날 때마다 두 번 조용히 죽었다 (4월물 → 2026-05-29 빈 배열, 6월물 → 2026-07-13 빈 배열).
+> LS 는 만기 경과 종목에 과거봉도 현재가도 주지 않으면서 **에러조차 내지 않기** 때문에
+> 워크플로우가 실패하지 않고 그냥 아무 것도 하지 않는 상태가 된다 — 가장 위험한 실패 방식이다.
+> 이제 `FuturesContractNode` 가 **실행할 때마다** LS 종목마스터(o3101)에서 상장 월물을 조회해
+> 근월물을 고르므로, 월물 갱신이 더 이상 필요 없다. 예제에는 기초자산 코드(`HMH`/`HMCE`)만 남는다.
 
 ### L4 — mock 주문 1건 (✅ 라이브 PASS, 2026-06-01)
 
@@ -189,11 +193,11 @@ poetry run python examples/programmer_example/test_hkex_81_l4_order.py --confirm
 
 **라이브 실행 결과** (2026-06-01 장중, host-Claude 직접 발사 + 사용자 승인 override):
 명령 `poetry run python examples/programmer_example/test_hkex_81_l4_order.py --confirm`,
-대상 HMHM26 (Mini Hang Seng 2026.06), qty 1.
+대상 미니 항셍 (Mini Hang Seng, 당시 근월물), qty 1.
 
 | 단계 | 노드 | 결과 |
 |------|------|------|
-| [1] | `market_data` | HMHM26 현재가 **25,297** → BUY limit **24,032** (-5%, 미체결 유도) |
+| [1] | `market_data` | 현재가 **25,297** → BUY limit **24,032** (-5%, 미체결 유도) |
 | [2] | `new_order` | `order_result.success=true`, status=`submitted`, **order_id=1076** |
 | [3] | `open_orders` | 미체결 **1건** (order_id 1076, filled_quantity=0, remaining_quantity=1) → 미체결 확인 OK |
 | [4] | `cancel_order` | `cancel_result.success=true` (order_id 1076 cancelled) |
@@ -208,14 +212,18 @@ poetry run python examples/programmer_example/test_hkex_81_l4_order.py --confirm
 
 ## 🔍 학습 포인트
 
-1. **다종목 auto-iterate**: Watchlist (2개) → Historical 이 자동으로 종목당 1회 실행.
+1. **만기에 강한 선물 종목 지정**: 월물 코드를 적지 않고 기초자산 코드만 적으면
+   `FuturesContractNode` 가 실행 시점에 근월물로 해소한다. 출력 `symbols` 는
+   WatchlistNode 와 동일한 `[{exchange, symbol}]` 계약이라 하류 배선은 그대로다.
+   단, o3101 조회에 LS 세션이 필요하므로 **브로커 → contract 엣지가 반드시 있어야 한다.**
+2. **다종목 auto-iterate**: contract (2종목) → Historical 이 자동으로 종목당 1회 실행.
    ConditionNode 도 동일하게 종목당 평가 → LogicNode 가 교집합 산출.
-2. **복합 조건**: RSI + Bollinger 같은 momentum/volatility 결합으로 false positive 감소.
-3. **HKEX limit-only 패턴**: NewOrderNode `order_type=limit` + `order={{ nodes.sizing.order }}`
+3. **복합 조건**: RSI + Bollinger 같은 momentum/volatility 결합으로 false positive 감소.
+4. **HKEX limit-only 패턴**: NewOrderNode `order_type=limit` + `order={{ nodes.sizing.order }}`
    (sizing 출력에 price 포함).
-4. **A-3 회귀 가드**: 다종목 NewOrderNode auto-iterate 시 per-item spacing 이 자동 적용
+5. **A-3 회귀 가드**: 다종목 NewOrderNode auto-iterate 시 per-item spacing 이 자동 적용
    (`_rate_limit.min_interval_sec`).
-5. **resilience skip**: 사이징 결과가 비어있거나 API 일시 오류 시 주문 skip — 다음 사이클에 재시도.
+6. **resilience skip**: 사이징 결과가 비어있거나 API 일시 오류 시 주문 skip — 다음 사이클에 재시도.
 
 ---
 
@@ -232,14 +240,19 @@ poetry run python examples/programmer_example/test_hkex_81_l4_order.py --confirm
 ## 📝 변경 이력
 
 - 2026-05-28: 신규 추가 (`feat/hkex-futures-examples`)
-- 2026-05-29: L3 호스트 검증 — 만기 경과 4월물 → live 6월물(HMHM26/HMCEM26) roll-forward,
+- 2026-05-29: L3 호스트 검증 — 만기 경과 4월물 → live 6월물로 roll-forward,
   무진입 경로에 `if_candidates` IfNode(is_not_empty) + `no_entry_notice` 게이트 추가
   (market_data 빈입력 hard error 제거)
 - 2026-05-30: 호스트 라이브 재검증 전 체인 errors=0; logic `is_condition_met` warn 이 진입
   게이트 silent 봉쇄 버그로 확인 → LogicNode 바인딩 올바른 관례로 교정 (commit `1b615da5`)
 - 2026-05-31: LogicNode 다종목 auto-iterate AND 교집합 코어 버그 수정 (executor.py, commit
   `3bb5d284`) — 바인딩-only 수정이 못 잡던 더 깊은 결함. `validate()` errors 0 / warn 0.
-- 2026-07-13: 6월물 만기 경과로 historical 이 다시 빈 배열 → **9월물(HMHU26/HMCEU26)**
-  roll-forward (실전 키로 월물 유효성 실측: 6월물 0봉 / 9월물 21봉). 아울러 실행기의
+- 2026-07-13: 6월물 만기 경과로 historical 이 다시 빈 배열 → 9월물로 roll-forward
+  (실전 키로 월물 유효성 실측: 6월물 0봉 / 9월물 21봉). 아울러 실행기의
   auto-iterate 결함 4건을 수정 — `LogicNode` 가 auto-iterate 대상이라 `passed_symbols` 가
   N² 로 부풀던 것 포함(이 예제도 영향). 상세는 `CHANGELOG.md` 1.26.0 Fixed 참조.
+- 2026-07-13: **월물 하드코딩 근본 제거** — `WatchlistNode`(HMH·HMCE 9월물 고정)를
+  `FuturesContractNode`(`base_products=["HMH","HMCE"]`, `contract_selection=front`,
+  `futures_exchange=HKEX`)로 교체하고 `broker → contract` 엣지 추가(o3101 이 LS 세션 사용).
+  이제 만기가 지나도 실행 시점에 근월물이 자동 선택되므로 roll-forward 작업이 사라진다.
+  전략·조건·스케줄·노드 수는 그대로 (심볼 출처만 교체). `validate()` errors 0 / warnings 0.

--- a/src/programgarden/examples/workflows/82-hkex-realtime-stop-loss.json
+++ b/src/programgarden/examples/workflows/82-hkex-realtime-stop-loss.json
@@ -1,7 +1,7 @@
 {
   "id": "82-hkex-realtime-stop-loss",
   "name": "HKEX 실시간 손절 자동매매 (모의투자)",
-  "description": "HKEX 미니선물 단일 보유 포지션의 실시간 가격을 구독하고, ThrottleNode 로 tick rate 를 5초 단위로 안정화한 뒤 IfNode 로 stop_price 이하 도달 시 limit 매도. HKEX 모의투자 시장가 불가 / Connection Rule A-2 (realtime→order 직결 금지 / ThrottleNode 필수) / balance partial-failure 메타데이터 처리를 모두 회귀 가드.",
+  "description": "HKEX 미니 항셍 선물 단일 보유 포지션의 실시간 가격을 구독하고, ThrottleNode 로 tick rate 를 5초 단위로 안정화한 뒤 IfNode 로 stop_price 이하 도달 시 limit 매도. 종목은 FuturesContractNode 가 실행 시점에 근월물로 자동 해소. HKEX 모의투자 시장가 불가 / Connection Rule A-2 (realtime→order 직결 금지 / ThrottleNode 필수) / balance partial-failure 메타데이터 처리를 모두 회귀 가드.",
   "nodes": [
     {"id": "start", "type": "StartNode", "position": {"x": 50, "y": 320}},
     {
@@ -13,11 +13,11 @@
     },
 
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {"symbol": "HMHM26", "exchange": "HKEX"}
-      ],
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": ["HMH"],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {"x": 420, "y": 200}
     },
     {
@@ -102,8 +102,8 @@
   "edges": [
     {"from": "start", "to": "broker"},
 
-    {"from": "broker", "to": "watchlist"},
-    {"from": "watchlist", "to": "realtime"},
+    {"from": "broker", "to": "contract"},
+    {"from": "contract", "to": "realtime"},
     {"from": "realtime", "to": "throttle"},
     {"from": "throttle", "to": "if_stop"},
 
@@ -136,7 +136,7 @@
   "notes": [
     {
       "id": "note_strategy",
-      "content": "## HKEX 실시간 손절 자동매매 (모의투자)\n\n**시나리오**: 단일 보유 포지션 HMHM26 (Mini Hang Seng 6월). 실시간 tick 을 ThrottleNode (5초) 로 안정화하고, current_price ≤ 20000 HKD 도달 시 즉시 limit 매도로 청산.\n\n**주문 유형**: limit (HKEX 모의투자 시장가 불가). price 는 현재 tick price 그대로 사용 → 빠른 체결.\n\n**가동 시간**: 24시간 연속 (T+1 야간세션 포함). 데이세션 휴장 시 tick 자체가 안 오므로 자연 일시정지.\n\n**balance partial-failure 처리**: AccountNode 는 잔고 TR 이 일부 실패해도 raise 하지 않고 positions 만 채워 `balance._partial_failure`/`orderable_amount=None` 메타데이터로 완료한다(silent 0 흡수 차단). 따라서 이 노드의 `resilience.fallback.mode=skip` 자체는 발동되지 않으며(중단이 없으므로), 부분 실패 인지·대응은 다운스트림 소비자(PositionSizingNode→`BalanceUnavailableError` / IfNode→`ConditionEvaluationError`)의 몫이다. 본 예제는 static stop 만 사용하므로 실질 영향은 없다.",
+      "content": "## HKEX 실시간 손절 자동매매 (모의투자)\n\n**시나리오**: 단일 보유 포지션 미니 항셍(Mini Hang Seng) 선물. FuturesContractNode (`base_products=[\"HMH\"]`, `contract_selection=front`) 가 실행 시점에 LS 종목마스터를 조회해 **현재 상장된 근월물**로 자동 해소하므로 만기가 지나도 예제가 죽지 않는다. 실시간 tick 을 ThrottleNode (5초) 로 안정화하고, current_price ≤ 20000 HKD 도달 시 즉시 limit 매도로 청산.\n\n**주문 유형**: limit (HKEX 모의투자 시장가 불가). price 는 현재 tick price 그대로 사용 → 빠른 체결.\n\n**가동 시간**: 24시간 연속 (T+1 야간세션 포함). 데이세션 휴장 시 tick 자체가 안 오므로 자연 일시정지.\n\n**balance partial-failure 처리**: AccountNode 는 잔고 TR 이 일부 실패해도 raise 하지 않고 positions 만 채워 `balance._partial_failure`/`orderable_amount=None` 메타데이터로 완료한다(silent 0 흡수 차단). 따라서 이 노드의 `resilience.fallback.mode=skip` 자체는 발동되지 않으며(중단이 없으므로), 부분 실패 인지·대응은 다운스트림 소비자(PositionSizingNode→`BalanceUnavailableError` / IfNode→`ConditionEvaluationError`)의 몫이다. 본 예제는 static stop 만 사용하므로 실질 영향은 없다.",
       "color": 5,
       "width": 400,
       "height": 280,

--- a/src/programgarden/examples/workflows/82-hkex-realtime-stop-loss.md
+++ b/src/programgarden/examples/workflows/82-hkex-realtime-stop-loss.md
@@ -13,7 +13,7 @@
 5초 단위로 안정화한 뒤, **IfNode** 가 `current_price <= stop_price` 도달 시
 **limit 매도**로 청산.
 
-- **종목**: HMHM26 (Mini Hang Seng 6월) — 단일 시범 보유
+- **종목**: 미니 항셍(Mini Hang Seng) 선물 — 단일 시범 보유. 월물 코드를 적어두지 않고 **FuturesContractNode** 가 실행 시점에 LS 종목마스터를 조회해 **현재 상장된 근월물**로 자동 해소한다(만기가 지나도 예제가 조용히 죽지 않음)
 - **stop_price**: 20,000 HKD (정적 상수, 데모용)
 - **주문**: `side=sell`, `order_type=limit`, `price={{ throttle.data.current_price }}`
 - **체결 후**: Telegram 즉시 알림
@@ -42,8 +42,8 @@
 flowchart LR
     start([StartNode]) --> broker[OverseasFuturesBrokerNode<br/>paper_trading=true]
 
-    broker --> watchlist[WatchlistNode<br/>HMHM26]
-    watchlist --> realtime[OverseasFuturesRealMarketData<br/>stay_connected=true]
+    broker --> contract[FuturesContractNode<br/>base_products=HMH<br/>contract_selection=front]
+    contract --> realtime[OverseasFuturesRealMarketData<br/>symbol={{ item }}<br/>stay_connected=true]
     realtime --> throttle[ThrottleNode<br/>mode=latest interval=5s]
     throttle --> ifstop{IfNode<br/>current_price <= 20000?}
 
@@ -63,7 +63,7 @@ flowchart LR
 | 노드 | 역할 | 핵심 설정 |
 |------|------|-----------|
 | `start` / `broker` | 진입 + 모의 브로커 | `paper_trading=true` |
-| `watchlist` | 보유 종목 1개 | HMHM26 |
+| `contract` | 보유 종목 1개 (근월물 자동 해소) | `base_products=["HMH"]` (미니 항셍), `contract_selection=front`, `futures_exchange=HKEX` |
 | `realtime` | tick 구독 | `symbol={{ item }}`, `stay_connected=true` |
 | `throttle` | tick rate 안정화 | `mode=latest, interval_sec=5.0, pass_first=true` |
 | `if_stop` | stop 조건 분기 | `left={{ throttle.data.current_price }}, operator=<=, right=20000.0` |
@@ -133,6 +133,7 @@ L4: stop_price 를 의도적으로 시장가 위로 설정해 매도 1건 트리
 3. **balance partial-failure**: AccountNode 의 `_partial_failure` flag + `orderable_amount=None` 가 silent 0 흡수를 차단. resilience skip 으로 워크플로우 중단 없이 다음 사이클 복구.
 4. **HKEX limit-only**: realtime tick price 를 그대로 limit price 로 사용 — 빠른 체결.
 5. **24시간 가동**: TradingHoursFilter 제거. tick 자체가 휴장 시 안 오므로 자연 idle. ThrottleNode `mode=latest` 가 stale tick 발사 방지.
+6. **월물 하드코딩 금지**: 선물 종목코드를 예제에 박아두면 만기 후 LS 가 빈 데이터를 에러 없이 돌려줘 워크플로우가 조용히 죽는다. `FuturesContractNode` 가 기초자산 코드(`HMH`)만 받아 실행 시점의 근월물로 해소하고, `symbols` 출력이 WatchlistNode 와 동일 계약이라 하류는 `{{ item }}` 그대로 auto-iterate 로 소비한다.
 
 ---
 
@@ -148,3 +149,4 @@ L4: stop_price 를 의도적으로 시장가 위로 설정해 매도 1건 트리
 ## 📝 변경 이력
 
 - 2026-05-28: 신규 추가 (`feat/hkex-futures-examples`)
+- 2026-07-13: `watchlist`(WatchlistNode — 미니 항셍 월물 코드 하드코딩) → `contract`(FuturesContractNode, `base_products=["HMH"]`) 교체. 만기 종속성 제거 — 실행 시점에 근월물로 자동 해소.

--- a/src/programgarden/examples/workflows/83-hkex-ai-risk-report.json
+++ b/src/programgarden/examples/workflows/83-hkex-ai-risk-report.json
@@ -1,7 +1,7 @@
 {
   "id": "83-hkex-ai-risk-report",
   "name": "HKEX AI 리스크 매니저 일일 리포트 (모의투자)",
-  "description": "매 거래일 KST 18:30 (HKEX 데이세션 마감 직후) AIAgentNode 가 risk_manager 프리셋으로 HMHM26 / HMCEM26 두 종목의 60일 historical + 계좌 포지션을 Tool 로 조회하여 종목별 리스크 레벨과 추천 stop_loss 를 structured JSON 으로 생성. Telegram 으로 발송.",
+  "description": "매 거래일 KST 18:30 (HKEX 데이세션 마감 직후) AIAgentNode 가 risk_manager 프리셋으로 미니 항셍(HMH) / 미니 H주(HMCE) 두 종목의 60일 historical + 계좌 포지션을 Tool 로 조회하여 종목별 리스크 레벨과 추천 stop_loss 를 structured JSON 으로 생성. Telegram 으로 발송. 월물은 FuturesContractNode 가 실행 시점에 근월물로 자동 해소.",
   "nodes": [
     {"id": "start", "type": "StartNode", "position": {"x": 50, "y": 320}},
     {
@@ -32,12 +32,11 @@
     },
 
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {"symbol": "HMHM26", "exchange": "HKEX"},
-        {"symbol": "HMCEM26", "exchange": "HKEX"}
-      ],
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": ["HMH", "HMCE"],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {"x": 600, "y": 140}
     },
     {
@@ -62,7 +61,7 @@
       "id": "risk_agent",
       "type": "AIAgentNode",
       "preset": "risk_manager",
-      "user_prompt": "Today is {{ date.today() }}. Analyze the current HKEX futures portfolio (HMHM26 Mini Hang Seng, HMCEM26 Mini HSCEI). Call the account and historical data tools to gather positions, average prices, and the last 60 trading days. For each held symbol, output a structured assessment: current risk_level (low/medium/high), volatility-based suggested_stop_loss in HKD, and one-sentence reasoning. Limit response to 300 words total.",
+      "user_prompt": "Today is {{ date.today() }}. Analyze the current HKEX futures portfolio: Mini Hang Seng front-month ({{ nodes.contract.symbols[0].symbol }}) and Mini H-Shares front-month ({{ nodes.contract.symbols[1].symbol }}), both on exchange HKEX. Call the account and historical data tools to gather positions, average prices, and the last 60 trading days. For each held symbol, output a structured assessment: current risk_level (low/medium/high), volatility-based suggested_stop_loss in HKD, and one-sentence reasoning. Limit response to 300 words total.",
       "output_format": "structured",
       "output_schema": {
         "positions": {
@@ -105,8 +104,9 @@
     {"from": "start", "to": "llm"},
     {"from": "broker", "to": "schedule"},
 
-    {"from": "schedule", "to": "watchlist"},
-    {"from": "watchlist", "to": "historical"},
+    {"from": "schedule", "to": "contract"},
+    {"from": "broker", "to": "contract"},
+    {"from": "contract", "to": "historical"},
 
     {"from": "schedule", "to": "account"},
 
@@ -145,7 +145,7 @@
   "notes": [
     {
       "id": "note_strategy",
-      "content": "## HKEX AI 리스크 매니저 일일 리포트\n\n**시나리오**: 매 거래일 KST 18:30 (HKEX 데이세션 마감 직후) AIAgentNode 가 risk_manager 프리셋으로 portfolio 리스크 평가.\n\n**도구**: AccountNode + HistoricalDataNode 두 개를 tool 엣지로 연결 — agent 가 직접 호출.\n\n**구조화 출력**: output_format=structured + output_schema 로 종목별 risk_level / suggested_stop_loss / reasoning 강제. Pydantic 검증.\n\n**보호**: cooldown_sec=60 + max_total_tokens=40000 — 토큰 폭주 방지.\n\n**Stateless**: 매 실행 독립. 대화 기억 없음 (Tool 로 매번 최신 데이터 조회).",
+      "content": "## HKEX AI 리스크 매니저 일일 리포트\n\n**시나리오**: 매 거래일 KST 18:30 (HKEX 데이세션 마감 직후) AIAgentNode 가 risk_manager 프리셋으로 portfolio 리스크 평가.\n\n**종목**: 미니 항셍(HMH) + 미니 H주(HMCE)\n  -> FuturesContractNode 가 실행 시점에 근월물로 자동 해소 (월물 하드코딩 없음 = 만기가 지나도 안 죽는다)\n\n**도구**: AccountNode + HistoricalDataNode 두 개를 tool 엣지로 연결 — agent 가 직접 호출.\n\n**구조화 출력**: output_format=structured + output_schema 로 종목별 risk_level / suggested_stop_loss / reasoning 강제. Pydantic 검증.\n\n**보호**: cooldown_sec=60 + max_total_tokens=40000 — 토큰 폭주 방지.\n\n**Stateless**: 매 실행 독립. 대화 기억 없음 (Tool 로 매번 최신 데이터 조회).",
       "color": 5,
       "width": 400,
       "height": 300,

--- a/src/programgarden/examples/workflows/83-hkex-ai-risk-report.md
+++ b/src/programgarden/examples/workflows/83-hkex-ai-risk-report.md
@@ -1,7 +1,7 @@
 # 83. HKEX AI 리스크 매니저 일일 리포트 (모의투자)
 
 > **카테고리**: HKEX 해외선물 모의투자 / AI Agent / Schedule + Tool 엣지 + structured output
-> **시장**: HKEX (Mini Hang Seng + Mini HSCEI)
+> **시장**: HKEX (미니 항셍 HMH + 미니 H주 HMCE — 근월물 자동 해소)
 > **모드**: 모의투자 (`paper_trading=true`)
 > **주기**: 평일 KST 18:30 (HKEX 데이세션 마감 직후) 1회
 
@@ -10,10 +10,11 @@
 ## 🎯 시나리오 요약
 
 매 거래일 HKEX 데이세션 마감 직후 (KST 18:30), **AIAgentNode** 가 `risk_manager` 프리셋으로
-HMHM26 / HMCEM26 두 종목의 60일 historical 캔들 + 현재 계좌 포지션을 **Tool 엣지**로 조회하여
+미니 항셍(HMH) / 미니 H주(HMCE) 두 종목의 60일 historical 캔들 + 현재 계좌 포지션을 **Tool 엣지**로 조회하여
 종목별 `risk_level` (low/medium/high) + 변동성 기반 `suggested_stop_loss` + 한 줄 reasoning 을
 **structured JSON** 으로 생성. Telegram 으로 요약 발송 + TableDisplayNode 콘솔 렌더링.
 
+- **종목**: `FuturesContractNode` 가 실행 시점에 LS 종목마스터를 조회해 **근월물로 자동 해소** (월물 코드 하드코딩 없음 → 만기가 지나도 죽지 않음)
 - **LLM**: gpt-4o, temperature=0.3 (저변동), max_tokens=1200
 - **Tools (tool 엣지)**: AccountNode, HistoricalDataNode
 - **Output**: `output_format=structured` + `output_schema` (positions[] + summary)
@@ -43,8 +44,9 @@ flowchart LR
     start --> llm[LLMModelNode<br/>gpt-4o T=0.3]
 
     broker --> schedule[ScheduleNode<br/>30 18 * * 1-5 KST]
-    schedule --> watchlist[WatchlistNode<br/>HMHM26, HMCEM26]
-    watchlist --> historical[HistoricalDataNode<br/>60d 1d auto-iterate]
+    schedule --> contract[FuturesContractNode<br/>base_products=HMH, HMCE<br/>front 근월물 자동 해소]
+    broker --> contract
+    contract --> historical[HistoricalDataNode<br/>60d 1d auto-iterate]
 
     schedule --> account[OverseasFuturesAccountNode<br/>resilience.skip]
 
@@ -65,8 +67,8 @@ flowchart LR
 | `start` / `broker` | 진입 + 모의 브로커 | `paper_trading=true` |
 | `schedule` | daily 트리거 | `cron=30 18 * * 1-5, timezone=Asia/Seoul` |
 | `llm` | LLM 연결 | `model=gpt-4o, temperature=0.3, max_tokens=1200` |
-| `watchlist` | 분석 후보 종목 | HMHM26, HMCEM26 |
-| `historical` | 60일 일봉 (auto-iterate per symbol) | `interval=1d` |
+| `contract` | 분석 후보 종목 (근월물 자동 해소) | `base_products=["HMH","HMCE"], contract_selection=front, futures_exchange=HKEX` — 브로커 → contract 엣지 필수 (LS 세션 필요) |
+| `historical` | 60일 일봉 (auto-iterate per symbol) | `symbol={{ item }}, interval=1d` |
 | `account` | 현재 포지션 + balance | `resilience.fallback.mode=skip` |
 | `risk_agent` | AI 리스크 매니저 | `preset=risk_manager, output_format=structured, output_schema={positions,summary}, max_tool_calls=6, cooldown_sec=60, max_total_tokens=40000` |
 | `report_table` | positions 표 출력 | `data={{ risk_agent.response.positions }}` |
@@ -124,6 +126,7 @@ L4: 본 예제는 주문 노드 없음. 별도 트리거 불필요.
 3. **structured output**: `output_format=structured` + `output_schema` 로 Pydantic 검증. response 는 dict — `{{ nodes.agent.response.positions }}` / `{{ nodes.agent.response.summary }}` dot notation 으로 downstream 분기.
 4. **realtime → AIAgent 차단**: AIAgentNode `_connection_rules` 가 RealMarketData 등 직결을 ERROR 로 차단. 본 예제는 Schedule + Historical/Account 만 → 안전.
 5. **비용 가드**: `max_total_tokens=40000` + `cooldown_sec=60` 으로 silent 토큰 폭주 차단.
+6. **월물 하드코딩 금지**: `FuturesContractNode` 가 실행 시점에 종목마스터를 조회해 기초자산(HMH/HMCE)의 근월물을 해소 → 만기가 지나도 예제가 조용히 죽지 않음. auto-iterate 소비자(`historical`)는 `symbol={{ item }}` 로 받고, auto-iterate 대상이 아닌 `risk_agent` 의 프롬프트는 `{{ nodes.contract.symbols[0].symbol }}` 인덱스 표현식으로 해소된 종목을 주입한다.
 
 ---
 
@@ -138,3 +141,4 @@ L4: 본 예제는 주문 노드 없음. 별도 트리거 불필요.
 ## 📝 변경 이력
 
 - 2026-05-28: 신규 추가 (`feat/hkex-futures-examples`)
+- 2026-07-13: `WatchlistNode`(월물 코드 하드코딩) → `FuturesContractNode`(`base_products=["HMH","HMCE"]`, front) 로 교체. 만기 경과 월물로 인한 무증상 실패(빈 데이터) 제거.

--- a/src/programgarden/examples/workflows/84-hkex-backtest-schedule-report.json
+++ b/src/programgarden/examples/workflows/84-hkex-backtest-schedule-report.json
@@ -1,7 +1,7 @@
 {
   "id": "84-hkex-backtest-schedule-report",
   "name": "HKEX 백테스트 아침 일일 리포트 (모의투자)",
-  "description": "매 거래일 KST 08:00 (HKEX 데이세션 시작 전) BacktestEngine 으로 HMHM26 / HMCEM26 두 종목 × RSI / Bollinger 두 전략을 종목별(2x2=4개 백테스트)로 백테스트 → BenchmarkCompareNode 로 4개 equity_curve Sharpe / MDD 비교 → SummaryDisplay 콘솔 + Telegram 아침 알림. 각 백테스트는 ConditionNode 의 per-candle annotated series(values[i].time_series, row.signal)를 소비.",
+  "description": "매 거래일 KST 08:00 (HKEX 데이세션 시작 전) BacktestEngine 으로 미니 항셍(HMH) / 미니 H주(HMCE) 두 기초자산의 근월물 × RSI / Bollinger 두 전략을 종목별(2x2=4개 백테스트)로 백테스트 → BenchmarkCompareNode 로 4개 equity_curve Sharpe / MDD 비교 → SummaryDisplay 콘솔 + Telegram 아침 알림. 종목코드는 FuturesContractNode 가 실행 시점에 LS 종목마스터(o3101)를 조회해 근월물로 자동 해소하므로 만기가 지나도 죽지 않는다. 각 백테스트는 ConditionNode 의 per-candle annotated series(values[i].time_series, row.signal)를 소비.",
   "nodes": [
     {"id": "start", "type": "StartNode", "position": {"x": 50, "y": 380}},
     {
@@ -22,12 +22,11 @@
     },
 
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {"symbol": "HMHM26", "exchange": "HKEX"},
-        {"symbol": "HMCEM26", "exchange": "HKEX"}
-      ],
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": ["HMH", "HMCE"],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {"x": 600, "y": 380}
     },
     {
@@ -84,7 +83,7 @@
     {
       "id": "backtest_rsi_hmhm",
       "type": "BacktestEngineNode",
-      "strategy_name": "HKEX RSI Mean Reversion — HMHM26",
+      "strategy_name": "HKEX RSI Mean Reversion — {{ nodes.contract.symbols[0].symbol }}",
       "items": {
         "from": "{{ nodes.rsi_cond.values[0].time_series }}",
         "extract": {
@@ -117,7 +116,7 @@
     {
       "id": "backtest_rsi_hmce",
       "type": "BacktestEngineNode",
-      "strategy_name": "HKEX RSI Mean Reversion — HMCEM26",
+      "strategy_name": "HKEX RSI Mean Reversion — {{ nodes.contract.symbols[1].symbol }}",
       "items": {
         "from": "{{ nodes.rsi_cond.values[1].time_series }}",
         "extract": {
@@ -150,7 +149,7 @@
     {
       "id": "backtest_boll_hmhm",
       "type": "BacktestEngineNode",
-      "strategy_name": "HKEX Bollinger Reversion — HMHM26",
+      "strategy_name": "HKEX Bollinger Reversion — {{ nodes.contract.symbols[0].symbol }}",
       "items": {
         "from": "{{ nodes.boll_cond.values[0].time_series }}",
         "extract": {
@@ -183,7 +182,7 @@
     {
       "id": "backtest_boll_hmce",
       "type": "BacktestEngineNode",
-      "strategy_name": "HKEX Bollinger Reversion — HMCEM26",
+      "strategy_name": "HKEX Bollinger Reversion — {{ nodes.contract.symbols[1].symbol }}",
       "items": {
         "from": "{{ nodes.boll_cond.values[1].time_series }}",
         "extract": {
@@ -245,8 +244,9 @@
   "edges": [
     {"from": "start", "to": "broker"},
     {"from": "broker", "to": "schedule"},
-    {"from": "schedule", "to": "watchlist"},
-    {"from": "watchlist", "to": "historical"},
+    {"from": "schedule", "to": "contract"},
+    {"from": "broker", "to": "contract"},
+    {"from": "contract", "to": "historical"},
 
     {"from": "historical", "to": "rsi_cond"},
     {"from": "historical", "to": "boll_cond"},

--- a/src/programgarden/examples/workflows/84-hkex-backtest-schedule-report.md
+++ b/src/programgarden/examples/workflows/84-hkex-backtest-schedule-report.md
@@ -18,9 +18,12 @@ BenchmarkCompareNode 가 Sharpe 기준 ranking → SummaryDisplayNode 콘솔 + T
 (`{{ nodes.<cond>.values[i].time_series }}`) 를 소비한다. 각 캔들의 매매 시그널은
 `{{ row.signal }}` / `{{ row.side }}` 로 직접 추출된다.
 
-- **데이터**: 180일 일봉 × 2종목 (HMHM26, HMCEM26)
-- **전략 A — RSI Mean Reversion**: RSI(14, threshold=30, direction=below) + fixed_percent 10% + stop 3% / TP 8% / time stop 10d → `backtest_rsi_hmhm`, `backtest_rsi_hmce`
-- **전략 B — Bollinger Reversion**: Bollinger(20, 2.0, below_lower) + fixed_percent 10% + stop 4% / TP 10% / time stop 14d → `backtest_boll_hmhm`, `backtest_boll_hmce`
+- **종목 지정**: `FuturesContractNode` 에 **기초자산 코드**(`HMH`=미니 항셍, `HMCE`=미니 H주)만 적는다.
+  실제 월물 종목코드는 **실행 시점에 LS 종목마스터(o3101)를 조회해 근월물로 자동 해소**되므로,
+  만기가 지나도 백테스트가 빈 데이터로 조용히 죽지 않는다.
+- **데이터**: 180일 일봉 × 2종목 (미니 항셍 / 미니 H주 각 근월물)
+- **전략 A — RSI Mean Reversion**: RSI(14, threshold=30, direction=below) + fixed_percent 10% + stop 3% / TP 8% / time stop 10d → `backtest_rsi_hmhm`(미니 항셍), `backtest_rsi_hmce`(미니 H주)
+- **전략 B — Bollinger Reversion**: Bollinger(20, 2.0, below_lower) + fixed_percent 10% + stop 4% / TP 10% / time stop 14d → `backtest_boll_hmhm`(미니 항셍), `backtest_boll_hmce`(미니 H주)
 - **비용 모델**: commission 0.05% + slippage 0.1%
 - **비교**: BenchmarkCompareNode `ranking_metric=sharpe` — 4개 equity_curve 동시 ranking
 - **주문 X**: report-only 워크플로우
@@ -34,6 +37,7 @@ BenchmarkCompareNode 가 Sharpe 기준 ranking → SummaryDisplayNode 콘솔 + T
 | anti-pattern: 30일 같이 짧은 기간 | 180일 (~6개월) 사용. 1년+ 이 더 안정적이지만 HKEX 모의 데이터 범위 고려 |
 | anti-pattern: commission/slippage 0 | 0.05% + 0.1% 설정 — 현실 비용 모델링 |
 | anti-pattern: 백테스트가 raw historical 소비 | per-symbol 로 분리하고 ConditionNode 의 annotated series (`values[i].time_series`) 를 소비해야 시그널 인식. raw historical 바인딩 또는 단일 노드로 2종목 처리 시 시그널이 비어 buy-and-hold 로 silent degrade |
+| anti-pattern: 월물 종목코드 하드코딩 | `FuturesContractNode` (`contract_selection: "front"`) 가 실행 시점마다 근월물을 다시 고름. 만기 경과 종목은 LS 가 과거봉을 빈 배열로 주고 에러도 내지 않아, 하드코딩하면 백테스트가 조용히 죽는다 |
 | 동기 실행 / cycle latency | 2종목 × 180바 × 2전략 ≈ 720바 평가 (백테스트 노드 4개). 대규모 확장 시 cycle 지연 가능 |
 | 진입은 별도 워크플로우 | 본 예제는 report 전용. 실제 진입은 예제 81 (RSI+Bollinger Logic) 사용 |
 
@@ -45,16 +49,17 @@ BenchmarkCompareNode 가 Sharpe 기준 ranking → SummaryDisplayNode 콘솔 + T
 flowchart LR
     start([StartNode]) --> broker[OverseasFuturesBrokerNode<br/>paper_trading=true]
     broker --> schedule[ScheduleNode<br/>0 8 * * 1-5 KST]
-    schedule --> watchlist[WatchlistNode<br/>HMHM26, HMCEM26]
-    watchlist --> historical[HistoricalDataNode<br/>180d 1d auto-iterate]
+    schedule --> contract[FuturesContractNode<br/>HMH, HMCE / front]
+    broker --> contract
+    contract --> historical[HistoricalDataNode<br/>180d 1d auto-iterate]
 
     historical --> rsi[ConditionNode RSI<br/>values per symbol]
     historical --> boll[ConditionNode Bollinger<br/>values per symbol]
 
-    rsi --> btrsi0[BacktestEngineNode<br/>RSI — HMHM26<br/>values 0]
-    rsi --> btrsi1[BacktestEngineNode<br/>RSI — HMCEM26<br/>values 1]
-    boll --> btboll0[BacktestEngineNode<br/>Bollinger — HMHM26<br/>values 0]
-    boll --> btboll1[BacktestEngineNode<br/>Bollinger — HMCEM26<br/>values 1]
+    rsi --> btrsi0[BacktestEngineNode<br/>RSI — 미니 항셍<br/>values 0]
+    rsi --> btrsi1[BacktestEngineNode<br/>RSI — 미니 H주<br/>values 1]
+    boll --> btboll0[BacktestEngineNode<br/>Bollinger — 미니 항셍<br/>values 0]
+    boll --> btboll1[BacktestEngineNode<br/>Bollinger — 미니 H주<br/>values 1]
 
     btrsi0 --> bench[BenchmarkCompareNode<br/>ranking=sharpe<br/>4 strategies]
     btrsi1 --> bench
@@ -72,13 +77,15 @@ flowchart LR
 | 노드 | 핵심 설정 |
 |------|-----------|
 | `schedule` | `cron=0 8 * * 1-5, timezone=Asia/Seoul` |
-| `historical` | 180d 1d auto-iterate per symbol |
-| `rsi_cond` | `period=14, threshold=30, direction=below`. 종목별 annotated series 를 `values[]` 로 출력 (index 0=HMHM26, 1=HMCEM26) |
+| `contract` | 백테스트 대상 종목 (기초자산 → 근월물 자동 해소). `base_products=["HMH","HMCE"]`, `contract_selection=front`, `futures_exchange=HKEX` — **브로커 → contract 엣지 필수** (o3101 은 LS 세션 사용) |
+| `historical` | 180d 1d auto-iterate per symbol (`symbol={{ item }}` — contract 가 해소한 근월물 2건) |
+| `rsi_cond` | `period=14, threshold=30, direction=below`. 종목별 annotated series 를 `values[]` 로 출력 (index 0=미니 항셍, 1=미니 H주 — `base_products` 순서) |
 | `boll_cond` | `period=20, std_dev=2.0, position=below_lower`. 종목별 annotated series 를 `values[]` 로 출력 |
-| `backtest_rsi_hmhm` | `from={{ rsi_cond.values[0].time_series }}`, signal=`{{ row.signal }}`, side=`{{ row.side }}`. initial 100k, commission 0.0005, slippage 0.001, fixed_percent 10%, stop 3%, TP 8%, time_stop 10d |
-| `backtest_rsi_hmce` | `from={{ rsi_cond.values[1].time_series }}` (HMCEM26). RSI exit 파라미터 동일 |
-| `backtest_boll_hmhm` | `from={{ boll_cond.values[0].time_series }}` (HMHM26). stop 4%, TP 10%, time_stop 14d |
-| `backtest_boll_hmce` | `from={{ boll_cond.values[1].time_series }}` (HMCEM26). Bollinger exit 파라미터 동일 |
+| `backtest_rsi_hmhm` | 미니 항셍. `from={{ rsi_cond.values[0].time_series }}`, signal=`{{ row.signal }}`, side=`{{ row.side }}`. initial 100k, commission 0.0005, slippage 0.001, fixed_percent 10%, stop 3%, TP 8%, time_stop 10d |
+| `backtest_rsi_hmce` | 미니 H주. `from={{ rsi_cond.values[1].time_series }}`. RSI exit 파라미터 동일 |
+| `backtest_boll_hmhm` | 미니 항셍. `from={{ boll_cond.values[0].time_series }}`. stop 4%, TP 10%, time_stop 14d |
+| `backtest_boll_hmce` | 미니 H주. `from={{ boll_cond.values[1].time_series }}`. Bollinger exit 파라미터 동일 |
+| `strategy_name` (4개 공통) | 리포트 라벨에 해소된 월물이 찍히도록 `{{ nodes.contract.symbols[i].symbol }}` 사용 (예: `HKEX RSI Mean Reversion — {{ nodes.contract.symbols[0].symbol }}`). BacktestEngineNode 는 auto-iterate 대상이 아니라 `{{ item }}` 이 해소되지 않으므로 **인덱스 표현식**을 쓴다 |
 | `benchmark` | `strategies=[backtest_rsi_hmhm.equity_curve, backtest_rsi_hmce.equity_curve, backtest_boll_hmhm.equity_curve, backtest_boll_hmce.equity_curve], ranking_metric=sharpe` |
 | `summary_display` | data=`{{ benchmark.ranking }}` |
 | `telegram_morning` | 일일 ranking 알림 템플릿 |
@@ -130,18 +137,25 @@ equity_curve 40포인트, trades=8. per-candle 시그널이 정상 인식됨을 
 - `benchmark.ranking`: 4전략 차별화 ranking 정상 산출 (mock 의 빈 `[]` 와 달리 실 데이터로 채워짐).
 - **errors=0 / warnings=0**.
 
+> ⚠️ 위 L3 수치는 당시 **하드코딩된 월물**로 돌린 결과다. 그 월물은 이미 만기가 지났고,
+> LS 는 만기 경과 종목에 과거봉을 빈 배열로 주면서 **에러조차 내지 않기** 때문에
+> 백테스트가 조용히 빈 결과를 냈다. 2026-07-13 부터는 `FuturesContractNode` 가
+> 실행 시점에 근월물을 해소하므로 월물 갱신 작업 자체가 사라졌다 — 예제에는
+> 기초자산 코드(`HMH`/`HMCE`)만 남는다.
+
 L4: 본 예제는 주문 노드 없음 — 별도 트리거 불필요.
 
 ---
 
 ## 🔍 학습 포인트
 
-1. **per-symbol 백테스트 + annotated series 소비**: BacktestEngineNode 는 종목당 1개로 분리하고, raw historical 이 아니라 ConditionNode 의 per-candle annotated series `{{ nodes.<cond>.values[i].time_series }}` 를 `items.from` 으로 소비해야 한다. 각 캔들 시그널은 `{{ row.signal }}` / `{{ row.side }}` 로 직접 추출. `values` 인덱스 순서 = watchlist(auto-iterate) 순서이며, 데이터가 부족한 종목도 `time_series:[]` 로 entry 가 유지되어 인덱스 정렬이 보존된다.
+1. **per-symbol 백테스트 + annotated series 소비**: BacktestEngineNode 는 종목당 1개로 분리하고, raw historical 이 아니라 ConditionNode 의 per-candle annotated series `{{ nodes.<cond>.values[i].time_series }}` 를 `items.from` 으로 소비해야 한다. 각 캔들 시그널은 `{{ row.signal }}` / `{{ row.side }}` 로 직접 추출. `values` 인덱스 순서 = contract(auto-iterate) 순서 = `base_products` 순서이며, 데이터가 부족한 종목도 `time_series:[]` 로 entry 가 유지되어 인덱스 정렬이 보존된다.
 2. **silent buy-and-hold degrade 회피**: `_run_simulation` 은 signal 리스트가 비면 buy-and-hold 로 fallback 한다. 단일 노드로 2종목을 처리하거나 `result.signal` (merged 리스트) 을 바인딩하면 시그널이 None/빈값이 되어 모든 전략이 buy-and-hold 로 동일하게 보인다. per-symbol + `row.signal` 매핑이 비교를 유의미하게 만드는 핵심.
-3. **2종목 × 2전략 = 4 백테스트**: rsi_cond / boll_cond 각각 `values[0]`(HMHM26) / `values[1]`(HMCEM26) 로 분기 → 4개 BacktestEngineNode.
+3. **2종목 × 2전략 = 4 백테스트**: rsi_cond / boll_cond 각각 `values[0]`(미니 항셍) / `values[1]`(미니 H주) 로 분기 → 4개 BacktestEngineNode.
 4. **BenchmarkCompareNode**: 4개 equity_curve 동시 비교. `ranking_metric=sharpe` 또는 `mdd, total_return`. ranking + comparison_metrics + combined_curve 출력.
 5. **Schedule 시간대 조합**: KST 08:00 → HKEX 데이세션(KST 10:15-) 전 ~2시간 여유. 사용자가 결과 확인 후 진입 결정 가능.
 6. **report-only 패턴**: 주문 노드 없음 → 안전성 ↑. 진입은 별도 워크플로우 (81번).
+7. **만기에 강한 선물 종목 지정**: 월물 코드를 적지 않고 기초자산 코드(`HMH`/`HMCE`)만 적으면 `FuturesContractNode` 가 실행 시점에 근월물로 해소한다. 출력 `symbols` 는 WatchlistNode 와 동일한 `[{exchange, symbol}]` 형태라 하류 노드 배선은 그대로다. 단, o3101 조회에 LS 세션이 필요하므로 **브로커 → contract 엣지가 반드시 있어야 한다.** 백테스트처럼 auto-iterate 대상이 아닌 노드에서 심볼이 필요하면 `{{ nodes.contract.symbols[0].symbol }}` 인덱스 표현식을 쓴다.
 
 ---
 
@@ -157,3 +171,4 @@ L4: 본 예제는 주문 노드 없음 — 별도 트리거 불필요.
 
 - 2026-05-28: 신규 추가 (`feat/hkex-futures-examples`)
 - 2026-05-30: per-symbol 백테스트로 재구성 — 단일 노드 2개(`backtest_rsi`/`backtest_boll`)를 종목별 4개(`backtest_rsi_hmhm`/`backtest_rsi_hmce`/`backtest_boll_hmhm`/`backtest_boll_hmce`)로 분리. `items.from` 을 raw historical → ConditionNode annotated series(`values[i].time_series`)로, signal 을 `result.signal`(merged 리스트) → `row.signal` 로 교체. benchmark.strategies 4 equity_curve. silent buy-and-hold degrade 버그 수정.
+- 2026-07-13: **월물 하드코딩 근본 제거** — `WatchlistNode`(월물 2건 고정)를 `FuturesContractNode`(`base_products=["HMH","HMCE"]`, `contract_selection=front`, `futures_exchange=HKEX`)로 교체하고 `broker → contract` 엣지 추가(o3101 이 LS 세션 사용). 4개 백테스트의 `strategy_name` 월물 라벨은 `{{ nodes.contract.symbols[i].symbol }}` 인덱스 표현식으로 교체. 이제 만기가 지나도 실행 시점에 근월물이 자동 선택되므로 roll-forward 작업이 사라진다. 전략/조건/스케줄/노드 개수는 불변.

--- a/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.json
+++ b/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.json
@@ -90,6 +90,16 @@
           "symbol": "HMCEJ26",
           "exchange": "HKEX",
           "reason": "2026/04 만기 경과 — roll-over 대상 (historical 빈 응답)"
+        },
+        {
+          "symbol": "HMHG26",
+          "exchange": "HKEX",
+          "reason": "이미 만기된 2월물 (mock — 본 예제 후보풀엔 없지만 가드용)"
+        },
+        {
+          "symbol": "HMCEG26",
+          "exchange": "HKEX",
+          "reason": "이미 만기된 2월물 (mock)"
         }
       ],
       "input_symbols": "{{ nodes.watchlist.symbols }}",

--- a/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.json
+++ b/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.json
@@ -121,7 +121,7 @@
       "type": "PositionSizingNode",
       "symbol": "{{ item }}",
       "balance": "{{ nodes.account.balance }}",
-      "market_data": "{{ nodes.market_data.value }}",
+      "market_data": "{{ nodes.market_data.values }}",
       "method": "atr_based",
       "max_percent": 5.0,
       "atr_risk_percent": 1.5,

--- a/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.json
+++ b/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.json
@@ -1,7 +1,7 @@
 {
   "id": "85-hkex-screener-conditional-entry",
-  "name": "HKEX 월물 스크리너 + ATR 조건 진입 (모의투자, mock roll-over)",
-  "description": "HMHJ26 / HMHM26 / HMCEJ26 / HMCEM26 4개 월물 후보풀에서 만기 임박 월물(블랙리스트)을 ExclusionListNode 로 제외 → 180일 ATR breakout 조건 충족 종목만 필터 → 이미 보유 종목 제외 → IfNode 후보 ≥1 일 때 NewOrderNode 발사. HKEX 월물 명명 + roll-over mock 시뮬레이션 회귀 가드.",
+  "name": "HKEX 근월물 스크리너 + ATR 조건 진입 (모의투자, 월물 자동 해소)",
+  "description": "FuturesContractNode 가 실행 시점에 미니 항셍(HMH) / 미니 H주(HMCE) 의 현재 상장 근월물을 해소 → ExclusionListNode 운영 블랙리스트 통과 → 180일 ATR breakout 조건 충족 종목만 필터 → 이미 보유 종목 제외 → IfNode 후보 ≥1 일 때 NewOrderNode 발사. 월물 코드를 하드코딩하지 않으므로 만기가 지나도 다음 월물로 자동 롤오버된다.",
   "nodes": [
     {
       "id": "start",
@@ -52,26 +52,14 @@
       }
     },
     {
-      "id": "watchlist",
-      "type": "WatchlistNode",
-      "symbols": [
-        {
-          "symbol": "HMHJ26",
-          "exchange": "HKEX"
-        },
-        {
-          "symbol": "HMHU26",
-          "exchange": "HKEX"
-        },
-        {
-          "symbol": "HMCEJ26",
-          "exchange": "HKEX"
-        },
-        {
-          "symbol": "HMCEU26",
-          "exchange": "HKEX"
-        }
+      "id": "contract",
+      "type": "FuturesContractNode",
+      "base_products": [
+        "HMH",
+        "HMCE"
       ],
+      "contract_selection": "front",
+      "futures_exchange": "HKEX",
       "position": {
         "x": 820,
         "y": 200
@@ -80,29 +68,8 @@
     {
       "id": "exclusion",
       "type": "ExclusionListNode",
-      "symbols": [
-        {
-          "symbol": "HMHJ26",
-          "exchange": "HKEX",
-          "reason": "2026/04 만기 경과 — roll-over 대상 (historical 빈 응답)"
-        },
-        {
-          "symbol": "HMCEJ26",
-          "exchange": "HKEX",
-          "reason": "2026/04 만기 경과 — roll-over 대상 (historical 빈 응답)"
-        },
-        {
-          "symbol": "HMHG26",
-          "exchange": "HKEX",
-          "reason": "이미 만기된 2월물 (mock — 본 예제 후보풀엔 없지만 가드용)"
-        },
-        {
-          "symbol": "HMCEG26",
-          "exchange": "HKEX",
-          "reason": "이미 만기된 2월물 (mock)"
-        }
-      ],
-      "input_symbols": "{{ nodes.watchlist.symbols }}",
+      "symbols": [],
+      "input_symbols": "{{ nodes.contract.symbols }}",
       "default_reason": "만기/유동성 부족",
       "position": {
         "x": 1080,
@@ -261,10 +228,14 @@
     },
     {
       "from": "trading_hours",
-      "to": "watchlist"
+      "to": "contract"
     },
     {
-      "from": "watchlist",
+      "from": "broker",
+      "to": "contract"
+    },
+    {
+      "from": "contract",
       "to": "exclusion"
     },
     {
@@ -359,7 +330,7 @@
   "notes": [
     {
       "id": "note_strategy",
-      "content": "## HKEX 월물 스크리너 + ATR 조건 진입\n\n**시나리오**: 평일 KST 11:00 (HKEX 데이세션 진입 후 45분 — 초반 변동성 안정화 후) 4개 월물 후보풀 스크리닝.\n\n**후보풀**: HMH (Mini Hang Seng) J(4월) + M(6월), HMCE (Mini HSCEI) J(4월) + M(6월)\n\n4월물(J)은 이미 만기 경과(historical 빈 응답) → ExclusionList 로 제외 → 생존 후보는 live 6월물(M)뿐. 이것이 roll-over 의 실제 동작입니다.\n\n**필터링 파이프라인**:\n1. ExclusionListNode — 만기 경과/임박 월물 정적 블랙리스트 (J월물 제외)\n2. ATR ConditionNode — 14일 ATR 기반 breakout_up 시그널\n3. SymbolFilterNode (difference) — 이미 보유 월물 제외\n4. IfNode — 후보 ≥ 1 일 때만 진입 (`is_not_empty`)\n\n**사이징**: ATR 기반 (계좌 5%, 종목당 1.5% 위험)\n\n**주문**: limit (HKEX 모의투자 제약)",
+      "content": "## HKEX 근월물 스크리너 + ATR 조건 진입\n\n**시나리오**: 평일 KST 11:00 (HKEX 데이세션 진입 후 45분 — 초반 변동성 안정화 후) 미니 선물 2종 스크리닝.\n\n**후보풀**: FuturesContractNode 가 실행 시점에 해소한 **근월물** — HMH (미니 항셍), HMCE (미니 H주) 각 1건.\n\n월물 코드는 워크플로우 어디에도 적혀 있지 않습니다. 실행할 때마다 LS 종목마스터(o3101)에서 **지금 상장된 월물**을 골라오므로, 만기가 지나면 자동으로 다음 월물로 넘어갑니다.\n\n**필터링 파이프라인**:\n1. FuturesContractNode — 기초자산 → 현재 상장 근월물 해소 (만기 경과분은 애초에 나오지 않음)\n2. ExclusionListNode — 운영 블랙리스트 훅 (리스크/유동성 사유로 뺄 종목. 기본은 비어 있음)\n3. ATR ConditionNode — 14일 ATR 기반 breakout_up 시그널\n4. SymbolFilterNode (difference) — 이미 보유 월물 제외\n5. IfNode — 후보 ≥ 1 일 때만 진입 (`is_not_empty`)\n\n**사이징**: ATR 기반 (계좌 5%, 종목당 1.5% 위험)\n\n**주문**: limit (HKEX 모의투자 제약)",
       "color": 5,
       "width": 400,
       "height": 340,
@@ -370,7 +341,7 @@
     },
     {
       "id": "note_rollover",
-      "content": "## HKEX 월물 명명 규칙\n\n```\nHM[CE] + 월코드 + 연도2자리\n  │      │       │\n  │      │       └─ 26 = 2026\n  │      └─ F=1월, G=2월, H=3월, J=4월, K=5월, M=6월,\n  │         N=7월, Q=8월, U=9월, V=10월, X=11월, Z=12월\n  └─ HMH = Mini Hang Seng, HMCE = Mini HSCEI\n```\n\n**예**: HMHJ26 = Mini Hang Seng 2026년 4월물\n\n**Roll-over mock**: 만기 경과/임박 월물(본 예제는 2026/04 J월물) 을 ExclusionListNode 의 정적 `symbols` 에 추가하면 후보풀에서 자동 제외 → live 월물만 통과. 실 운영 시엔 LS 캘린더 API 연동 또는 `dynamic_symbols` 바인딩으로 자동화.",
+      "content": "## 월물 만기는 노드가 처리한다\n\n선물 종목코드에 월물을 하드코딩하면 **만기가 지나는 순간 워크플로우가 조용히 죽습니다** — LS 는 만기 경과 종목에 과거봉도 현재가도 주지 않고, 에러조차 내지 않습니다(빈 배열).\n\n**FuturesContractNode** 는 저작 시점이 아니라 **실행 시점**에 월물을 고릅니다.\n\n- `base_products`: 기초자산 코드 — HMH(미니 항셍), HMCE(미니 H주)\n- `contract_selection`: `front`(근월물·유동성 최대) / `next`(롤오버 대상) / `quarterly`(3·6·9·12월)\n- `symbols` 출력: `[{exchange, symbol}]` — WatchlistNode 와 동일한 계약이라 하류 배선은 그대로\n\n**ExclusionListNode 의 역할 변경**: 만기 차단은 이제 contract 노드가 구조적으로 해결하므로, 이 노드는 **운영 블랙리스트 훅**으로 남습니다. 종목을 넣으면 후보풀에서 빠지고, 주문 노드도 그 종목을 차단합니다.",
       "color": 1,
       "width": 420,
       "height": 360,

--- a/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.json
+++ b/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.json
@@ -3,13 +3,23 @@
   "name": "HKEX 월물 스크리너 + ATR 조건 진입 (모의투자, mock roll-over)",
   "description": "HMHJ26 / HMHM26 / HMCEJ26 / HMCEM26 4개 월물 후보풀에서 만기 임박 월물(블랙리스트)을 ExclusionListNode 로 제외 → 180일 ATR breakout 조건 충족 종목만 필터 → 이미 보유 종목 제외 → IfNode 후보 ≥1 일 때 NewOrderNode 발사. HKEX 월물 명명 + roll-over mock 시뮬레이션 회귀 가드.",
   "nodes": [
-    {"id": "start", "type": "StartNode", "position": {"x": 50, "y": 380}},
+    {
+      "id": "start",
+      "type": "StartNode",
+      "position": {
+        "x": 50,
+        "y": 380
+      }
+    },
     {
       "id": "broker",
       "type": "OverseasFuturesBrokerNode",
       "credential_id": "broker_cred",
       "paper_trading": true,
-      "position": {"x": 220, "y": 380}
+      "position": {
+        "x": 220,
+        "y": 380
+      }
     },
     {
       "id": "schedule",
@@ -18,7 +28,10 @@
       "timezone": "Asia/Seoul",
       "enabled": true,
       "max_duration_hours": 720,
-      "position": {"x": 400, "y": 380}
+      "position": {
+        "x": 400,
+        "y": 380
+      }
     },
     {
       "id": "trading_hours",
@@ -26,35 +39,66 @@
       "start": "10:15",
       "end": "17:30",
       "timezone": "Asia/Seoul",
-      "days": ["mon", "tue", "wed", "thu", "fri"],
-      "position": {"x": 600, "y": 380}
+      "days": [
+        "mon",
+        "tue",
+        "wed",
+        "thu",
+        "fri"
+      ],
+      "position": {
+        "x": 600,
+        "y": 380
+      }
     },
-
     {
       "id": "watchlist",
       "type": "WatchlistNode",
       "symbols": [
-        {"symbol": "HMHJ26", "exchange": "HKEX"},
-        {"symbol": "HMHM26", "exchange": "HKEX"},
-        {"symbol": "HMCEJ26", "exchange": "HKEX"},
-        {"symbol": "HMCEM26", "exchange": "HKEX"}
+        {
+          "symbol": "HMHJ26",
+          "exchange": "HKEX"
+        },
+        {
+          "symbol": "HMHU26",
+          "exchange": "HKEX"
+        },
+        {
+          "symbol": "HMCEJ26",
+          "exchange": "HKEX"
+        },
+        {
+          "symbol": "HMCEU26",
+          "exchange": "HKEX"
+        }
       ],
-      "position": {"x": 820, "y": 200}
+      "position": {
+        "x": 820,
+        "y": 200
+      }
     },
     {
       "id": "exclusion",
       "type": "ExclusionListNode",
       "symbols": [
-        {"symbol": "HMHJ26", "exchange": "HKEX", "reason": "2026/04 만기 경과 — roll-over 대상 (historical 빈 응답)"},
-        {"symbol": "HMCEJ26", "exchange": "HKEX", "reason": "2026/04 만기 경과 — roll-over 대상 (historical 빈 응답)"},
-        {"symbol": "HMHG26", "exchange": "HKEX", "reason": "이미 만기된 2월물 (mock — 본 예제 후보풀엔 없지만 가드용)"},
-        {"symbol": "HMCEG26", "exchange": "HKEX", "reason": "이미 만기된 2월물 (mock)"}
+        {
+          "symbol": "HMHJ26",
+          "exchange": "HKEX",
+          "reason": "2026/04 만기 경과 — roll-over 대상 (historical 빈 응답)"
+        },
+        {
+          "symbol": "HMCEJ26",
+          "exchange": "HKEX",
+          "reason": "2026/04 만기 경과 — roll-over 대상 (historical 빈 응답)"
+        }
       ],
       "input_symbols": "{{ nodes.watchlist.symbols }}",
       "default_reason": "만기/유동성 부족",
-      "position": {"x": 1080, "y": 200}
+      "position": {
+        "x": 1080,
+        "y": 200
+      }
     },
-
     {
       "id": "historical",
       "type": "OverseasFuturesHistoricalDataNode",
@@ -62,7 +106,10 @@
       "start_date": "{{ date.ago(180, format='yyyymmdd') }}",
       "end_date": "{{ date.today(format='yyyymmdd') }}",
       "interval": "1d",
-      "position": {"x": 1340, "y": 200}
+      "position": {
+        "x": 1340,
+        "y": 200
+      }
     },
     {
       "id": "atr_cond",
@@ -84,14 +131,23 @@
         "multiplier": 2.0,
         "direction": "breakout_up"
       },
-      "position": {"x": 1600, "y": 200}
+      "position": {
+        "x": 1600,
+        "y": 200
+      }
     },
-
     {
       "id": "account",
       "type": "OverseasFuturesAccountNode",
-      "resilience": {"fallback": {"mode": "skip"}},
-      "position": {"x": 820, "y": 580}
+      "resilience": {
+        "fallback": {
+          "mode": "skip"
+        }
+      },
+      "position": {
+        "x": 820,
+        "y": 580
+      }
     },
     {
       "id": "filter_candidates",
@@ -99,7 +155,10 @@
       "operation": "difference",
       "input_a": "{{ nodes.atr_cond.passed_symbols }}",
       "input_b": "{{ nodes.account.held_symbols }}",
-      "position": {"x": 1860, "y": 380}
+      "position": {
+        "x": 1860,
+        "y": 380
+      }
     },
     {
       "id": "if_has_candidate",
@@ -107,14 +166,19 @@
       "left": "{{ nodes.filter_candidates.symbols }}",
       "operator": "is_not_empty",
       "right": null,
-      "position": {"x": 2080, "y": 380}
+      "position": {
+        "x": 2080,
+        "y": 380
+      }
     },
-
     {
       "id": "market_data",
       "type": "OverseasFuturesMarketDataNode",
       "symbol": "{{ item }}",
-      "position": {"x": 2280, "y": 280}
+      "position": {
+        "x": 2280,
+        "y": 280
+      }
     },
     {
       "id": "sizing",
@@ -125,7 +189,10 @@
       "method": "atr_based",
       "max_percent": 5.0,
       "atr_risk_percent": 1.5,
-      "position": {"x": 2480, "y": 280}
+      "position": {
+        "x": 2480,
+        "y": 280
+      }
     },
     {
       "id": "buy_order",
@@ -133,17 +200,26 @@
       "side": "buy",
       "order_type": "limit",
       "order": "{{ nodes.sizing.order }}",
-      "resilience": {"fallback": {"mode": "skip"}},
-      "position": {"x": 2680, "y": 280}
+      "resilience": {
+        "fallback": {
+          "mode": "skip"
+        }
+      },
+      "position": {
+        "x": 2680,
+        "y": 280
+      }
     },
     {
       "id": "telegram_entry",
       "type": "TelegramNode",
       "credential_id": "telegram_cred",
       "template": "🆕 HKEX 스크리너 진입 ({{ nodes.filter_candidates.count }}종목): {{ nodes.filter_candidates.symbols }} (ATR breakout, limit 매수)",
-      "position": {"x": 2880, "y": 280}
+      "position": {
+        "x": 2880,
+        "y": 280
+      }
     },
-
     {
       "id": "no_candidate_notice",
       "type": "SummaryDisplayNode",
@@ -154,48 +230,119 @@
         "excluded": "{{ nodes.exclusion.excluded }}",
         "status": "no_entry"
       },
-      "position": {"x": 2280, "y": 520}
+      "position": {
+        "x": 2280,
+        "y": 520
+      }
     }
   ],
   "edges": [
-    {"from": "start", "to": "broker"},
-    {"from": "broker", "to": "schedule"},
-    {"from": "schedule", "to": "trading_hours"},
-
-    {"from": "trading_hours", "to": "watchlist"},
-    {"from": "watchlist", "to": "exclusion"},
-    {"from": "exclusion", "to": "historical", "from_port": "filtered"},
-    {"from": "historical", "to": "atr_cond"},
-
-    {"from": "trading_hours", "to": "account"},
-
-    {"from": "atr_cond", "to": "filter_candidates"},
-    {"from": "account", "to": "filter_candidates"},
-    {"from": "filter_candidates", "to": "if_has_candidate"},
-
-    {"from": "filter_candidates", "to": "market_data"},
-    {"from": "market_data", "to": "sizing"},
-    {"from": "account", "to": "sizing"},
-    {"from": "sizing", "to": "buy_order"},
-    {"from": "buy_order", "to": "telegram_entry"},
-
-    {"from": "if_has_candidate", "to": "no_candidate_notice", "from_port": "false"}
+    {
+      "from": "start",
+      "to": "broker"
+    },
+    {
+      "from": "broker",
+      "to": "schedule"
+    },
+    {
+      "from": "schedule",
+      "to": "trading_hours"
+    },
+    {
+      "from": "trading_hours",
+      "to": "watchlist"
+    },
+    {
+      "from": "watchlist",
+      "to": "exclusion"
+    },
+    {
+      "from": "exclusion",
+      "to": "historical",
+      "from_port": "filtered"
+    },
+    {
+      "from": "historical",
+      "to": "atr_cond"
+    },
+    {
+      "from": "trading_hours",
+      "to": "account"
+    },
+    {
+      "from": "atr_cond",
+      "to": "filter_candidates"
+    },
+    {
+      "from": "account",
+      "to": "filter_candidates"
+    },
+    {
+      "from": "filter_candidates",
+      "to": "if_has_candidate"
+    },
+    {
+      "from": "filter_candidates",
+      "to": "market_data"
+    },
+    {
+      "from": "market_data",
+      "to": "sizing"
+    },
+    {
+      "from": "account",
+      "to": "sizing"
+    },
+    {
+      "from": "sizing",
+      "to": "buy_order"
+    },
+    {
+      "from": "buy_order",
+      "to": "telegram_entry"
+    },
+    {
+      "from": "if_has_candidate",
+      "to": "no_candidate_notice",
+      "from_port": "false"
+    }
   ],
   "credentials": [
     {
       "credential_id": "broker_cred",
       "type": "broker_ls_overseas_futures",
       "data": [
-        {"key": "appkey", "value": "", "type": "password", "label": "App Key"},
-        {"key": "appsecret", "value": "", "type": "password", "label": "App Secret"}
+        {
+          "key": "appkey",
+          "value": "",
+          "type": "password",
+          "label": "App Key"
+        },
+        {
+          "key": "appsecret",
+          "value": "",
+          "type": "password",
+          "label": "App Secret"
+        }
       ]
     },
     {
       "credential_id": "telegram_cred",
       "type": "telegram",
       "data": [
-        {"key": "bot_token", "value": "", "type": "password", "label": "Bot Token"},
-        {"key": "chat_id", "value": "", "type": "text", "label": "Chat ID"}
+        {
+          "key": "bot_token",
+          "value": "",
+          "type": "password",
+          "label": "Bot Token"
+        },
+        {
+          "key": "chat_id",
+          "value": "",
+          "type": "text",
+          "label": "Chat ID"
+        }
       ]
     }
   ],
@@ -206,7 +353,10 @@
       "color": 5,
       "width": 400,
       "height": 340,
-      "position": {"x": 30, "y": 30}
+      "position": {
+        "x": 30,
+        "y": 30
+      }
     },
     {
       "id": "note_rollover",
@@ -214,7 +364,10 @@
       "color": 1,
       "width": 420,
       "height": 360,
-      "position": {"x": 460, "y": 30}
+      "position": {
+        "x": 460,
+        "y": 30
+      }
     }
   ]
 }

--- a/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.md
+++ b/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.md
@@ -9,14 +9,14 @@
 
 ## 🎯 시나리오 요약
 
-후보풀 4개 월물(HMHJ26 / HMHM26 / HMCEJ26 / HMCEM26)에서 만기 임박 / 만료된 월물을
+후보풀 4개 월물(HMHJ26 / HMHU26 / HMCEJ26 / HMCEU26)에서 만기 임박 / 만료된 월물을
 **ExclusionListNode** 정적 블랙리스트로 제외 → 180일 **ATR(14) breakout_up** 조건 충족
 종목만 통과 → 이미 보유 중인 월물 제외 (SymbolFilter difference) → **IfNode** 가 후보 ≥ 1
 일 때만 NewOrderNode 발사.
 
-- **후보풀**: HMHJ26 (4월, 만기 경과), HMHM26 (6월, live), HMCEJ26 (4월, 만기 경과), HMCEM26 (6월, live)
+- **후보풀**: HMHJ26 (4월, 만기 경과), HMHU26 (9월, live), HMCEJ26 (4월, 만기 경과), HMCEU26 (9월, live)
 - **블랙리스트 (roll-over)**: HMHJ26 / HMCEJ26 (2026/04 만기 경과 — historical 빈 응답) + HMHG26 / HMCEG26 (2월물 mock 가드)
-- **생존 후보**: 블랙리스트 제외 후 live 6월물(HMHM26 / HMCEM26)만 통과 → ATR 조건 평가
+- **생존 후보**: 블랙리스트 제외 후 live 9월물(HMHU26 / HMCEU26)만 통과 → ATR 조건 평가
 - **시그널**: ATR(period=14, multiplier=2.0, direction=breakout_up)
 - **사이징**: ATR 기반 (계좌 5%, 종목당 1.5% 위험)
 - **주문**: limit (HKEX 모의투자 제약)
@@ -76,7 +76,7 @@ flowchart LR
 |------|-----------|
 | `schedule` | `cron=0 11 * * 1-5, timezone=Asia/Seoul` |
 | `trading_hours` | KST 10:15-17:30 (HKEX 데이세션) |
-| `watchlist` | HMHJ26, HMHM26, HMCEJ26, HMCEM26 |
+| `watchlist` | HMHJ26, HMHU26, HMCEJ26, HMCEU26 (9월물이 live) |
 | `exclusion` | `symbols=[HMHJ26, HMCEJ26, HMHG26, HMCEG26]` (4월물 roll-over 대상 + 2월물 만기 가드, 총 4건), `input_symbols={{ watchlist.symbols }}`, `default_reason=만기/유동성 부족` |
 | `historical` | 180d 1d auto-iterate per 필터링된 symbol |
 | `atr_cond` | plugin=ATR, `period=14, multiplier=2.0, direction=breakout_up` |
@@ -132,7 +132,7 @@ no_candidate_notice 실행 (mock 환경 정상). 실 데이터에선 true 분기
 
 - **exclusion → historical 엣지 `from_port:"filtered"` 확증**: ExclusionListNode 가 만기
   4월물/2월물 4종(`HMHJ26`/`HMCEJ26`/`HMHG26`/`HMCEG26`)을 `excluded` 포트로 격리하고,
-  historical 은 생존 월물 `HMHM26`/`HMCEM26` 만 순회 (스크리너가 "걸러낸 종목"을
+  historical 은 생존 월물 `HMHU26`/`HMCEU26` 만 순회 (스크리너가 "걸러낸 종목"을
   분석하던 자기모순 봉쇄 — deb80456).
 - ATR 계산 정상 (`atr` 158.64), **errors=0**.
 
@@ -164,3 +164,7 @@ no_candidate_notice 실행 (mock 환경 정상). 실 데이터에선 true 분기
 ## 📝 변경 이력
 
 - 2026-05-28: 신규 추가 (`feat/hkex-futures-examples`)
+- 2026-07-13: 6월물 만기 경과로 historical 이 빈 배열 → 후보풀을 **9월물(HMHU26/HMCEU26)**
+  로 roll-forward (실전 키로 월물 유효성 실측: 6월물 0봉 / 9월물 21봉). 만기 경과분을
+  ExclusionListNode 로 거른다는 예제의 교육 포인트는 그대로 유지(블랙리스트 4건 불변).
+  아울러 실행기 auto-iterate 결함 4건 수정 — 상세는 `CHANGELOG.md` 1.26.0 Fixed 참조.

--- a/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.md
+++ b/src/programgarden/examples/workflows/85-hkex-screener-conditional-entry.md
@@ -1,7 +1,7 @@
-# 85. HKEX 월물 스크리너 + ATR 조건 진입 (모의투자, mock roll-over)
+# 85. HKEX 근월물 스크리너 + ATR 조건 진입 (모의투자, 월물 자동 해소)
 
-> **카테고리**: HKEX 해외선물 모의투자 / Screener + ExclusionList + ATR / IfNode 조건 진입
-> **시장**: HKEX (Mini Hang Seng + Mini HSCEI, 4개 월물 후보풀)
+> **카테고리**: HKEX 해외선물 모의투자 / Screener + ATR / IfNode 조건 진입
+> **시장**: HKEX (미니 항셍 + 미니 H주 — 기초자산 2종의 근월물)
 > **모드**: 모의투자 (`paper_trading=true`)
 > **주기**: 평일 KST 11:00 (HKEX 데이세션 시작 45분 후 — 초반 변동성 안정화)
 
@@ -9,14 +9,13 @@
 
 ## 🎯 시나리오 요약
 
-후보풀 4개 월물(HMHJ26 / HMHU26 / HMCEJ26 / HMCEU26)에서 만기 임박 / 만료된 월물을
-**ExclusionListNode** 정적 블랙리스트로 제외 → 180일 **ATR(14) breakout_up** 조건 충족
+**FuturesContractNode** 가 실행 시점에 미니 항셍(HMH) / 미니 H주(HMCE) 의 **현재 상장 근월물**을
+해소 → **ExclusionListNode** 운영 블랙리스트 통과 → 180일 **ATR(14) breakout_up** 조건 충족
 종목만 통과 → 이미 보유 중인 월물 제외 (SymbolFilter difference) → **IfNode** 가 후보 ≥ 1
 일 때만 NewOrderNode 발사.
 
-- **후보풀**: HMHJ26 (4월, 만기 경과), HMHU26 (9월, live), HMCEJ26 (4월, 만기 경과), HMCEU26 (9월, live)
-- **블랙리스트 (roll-over)**: HMHJ26 / HMCEJ26 (2026/04 만기 경과 — historical 빈 응답) + HMHG26 / HMCEG26 (2월물 mock 가드)
-- **생존 후보**: 블랙리스트 제외 후 live 9월물(HMHU26 / HMCEU26)만 통과 → ATR 조건 평가
+- **후보풀**: 기초자산 `HMH`(미니 항셍) + `HMCE`(미니 H주) 의 근월물 각 1건 — **실행 시점에 해소**
+- **월물 코드는 어디에도 적혀 있지 않다** → 만기가 지나도 다음 월물로 자동 롤오버
 - **시그널**: ATR(period=14, multiplier=2.0, direction=breakout_up)
 - **사이징**: ATR 기반 (계좌 5%, 종목당 1.5% 위험)
 - **주문**: limit (HKEX 모의투자 제약)
@@ -24,20 +23,33 @@
 
 ---
 
-## 🔄 Roll-over Mock 패턴
+## 🔄 월물 만기는 노드가 처리한다
 
-본 예제는 **정적 블랙리스트** 로 만기 처리를 시연합니다.
+선물 종목코드에 월물을 하드코딩하면 **만기가 지나는 순간 워크플로우가 조용히 죽습니다**.
+LS 는 만기 경과 종목에 과거봉도 현재가도 주지 않고, **에러조차 내지 않습니다**(빈 배열).
+그래서 이 예제는 월물을 적지 않고, 기초자산만 적습니다.
 
-| 단계 | 본 예제 (mock) | 실 운영 (future work) |
-|------|---------------|------------------|
-| 만기 캘린더 | 정적 hard-coded (HMHJ26 / HMCEJ26 / HMHG26 / HMCEG26) | LS HKEX 캘린더 API 연동 또는 calendar.json |
-| 동적 갱신 | 없음 (코드 수정) | `dynamic_symbols` 바인딩으로 매일 자동 갱신 |
-| 만기 임박 판단 | hard-coded | `expiry - today() <= 7d` 같은 표현식 |
+| | 하드코딩 (옛 방식) | FuturesContractNode (현재) |
+|---|---|---|
+| 워크플로우에 적는 것 | 월물 종목코드 | **기초자산 코드** (`HMH`, `HMCE`) |
+| 월물 결정 시점 | 저작 시점 (고정) | **실행 시점** (LS 종목마스터 o3101 조회) |
+| 만기 경과 시 | 빈 응답 → 조용히 사망 | 상장 목록에 없으므로 **자동으로 다음 월물** |
+| 관리 비용 | 만기마다 파일 수정 | 없음 |
 
-> Plan 의 초안은 FieldMappingNode 로 mock 만기일 부여를 검토했지만, FieldMappingNode 는
-> 키 이름 변경만 가능하고 새 필드 계산을 못 합니다. 대안으로 ExclusionListNode 의 정적
-> `symbols` 블랙리스트 + `input_symbols={{ watchlist.symbols }}` 패턴을 채택 — 동일한
-> roll-over 효과를 더 단순하게 표현.
+**핵심 설정**
+
+| 필드 | 값 | 의미 |
+|------|-----|------|
+| `base_products` | `["HMH", "HMCE"]` | 기초자산 코드 (월물 코드가 아님). 코드마다 1건씩 해소 |
+| `contract_selection` | `front` | 근월물 = 유동성 최대. (`next`=롤오버 대상, `quarterly`=3·6·9·12월) |
+| `futures_exchange` | `HKEX` | 거래소 필터 |
+
+출력 `symbols` 는 `[{exchange, symbol}]` 로 **WatchlistNode 와 동일한 계약**이라,
+하류(Exclusion → Historical → Condition) 배선은 그대로 둡니다.
+
+> **ExclusionListNode 의 역할 변경**: 만기 차단은 이제 contract 노드가 구조적으로 해결하므로,
+> 이 노드는 **운영 블랙리스트 훅**으로 남습니다(기본값 빈 목록 = 후보풀 그대로 통과).
+> 리스크/유동성 사유로 종목을 넣으면 후보풀에서 빠지고, 주문 노드도 그 종목을 차단합니다.
 
 ---
 
@@ -49,8 +61,9 @@ flowchart LR
     broker --> schedule[ScheduleNode<br/>0 11 * * 1-5 KST]
     schedule --> hours[TradingHoursFilterNode<br/>10:15-17:30 KST]
 
-    hours --> watchlist[WatchlistNode<br/>4 monthly futures]
-    watchlist --> exclusion[ExclusionListNode<br/>blacklist expiring + input_symbols]
+    hours --> contract[FuturesContractNode<br/>HMH + HMCE / front]
+    broker --> contract
+    contract --> exclusion[ExclusionListNode<br/>운영 블랙리스트 + input_symbols]
     exclusion --> historical[HistoricalDataNode<br/>180d 1d auto-iterate]
     historical --> atr[ConditionNode ATR<br/>period=14 breakout_up]
 
@@ -68,6 +81,8 @@ flowchart LR
     ifgate -- false --> nocand[SummaryDisplayNode<br/>no_entry]
 ```
 
+> `broker → contract` 엣지는 필수입니다 — 종목마스터(o3101) 조회에 LS 세션이 필요합니다.
+
 ---
 
 ## 🔧 노드 사양
@@ -76,32 +91,15 @@ flowchart LR
 |------|-----------|
 | `schedule` | `cron=0 11 * * 1-5, timezone=Asia/Seoul` |
 | `trading_hours` | KST 10:15-17:30 (HKEX 데이세션) |
-| `watchlist` | HMHJ26, HMHU26, HMCEJ26, HMCEU26 (9월물이 live) |
-| `exclusion` | `symbols=[HMHJ26, HMCEJ26, HMHG26, HMCEG26]` (4월물 roll-over 대상 + 2월물 만기 가드, 총 4건), `input_symbols={{ watchlist.symbols }}`, `default_reason=만기/유동성 부족` |
-| `historical` | 180d 1d auto-iterate per 필터링된 symbol |
+| `contract` | `base_products=["HMH","HMCE"]`, `contract_selection=front`, `futures_exchange=HKEX` — 실행 시점 근월물 해소 |
+| `exclusion` | `symbols=[]` (운영 블랙리스트 훅), `input_symbols={{ nodes.contract.symbols }}`, `default_reason=만기/유동성 부족` |
+| `historical` | 180d 1d auto-iterate per 필터링된 symbol (`symbol={{ item }}`) |
 | `atr_cond` | plugin=ATR, `period=14, multiplier=2.0, direction=breakout_up` |
 | `account` | resilience skip (balance partial-failure 폴백) |
 | `filter_candidates` | `operation=difference, input_a=atr.passed_symbols, input_b=account.held_symbols` |
 | `if_has_candidate` | `left=filter_candidates.symbols, operator=is_not_empty` |
 | `market_data` / `sizing` / `buy_order` | true 분기 — auto-iterate per 후보 종목 |
 | `no_candidate_notice` | false 분기 — passed_atr/held/excluded 요약 |
-
----
-
-## ⚠️ HKEX 월물 명명 (참고)
-
-```
-HM[CE] + 월코드 + 연도2자리
-  │      │       │
-  │      │       └─ 26 = 2026
-  │      └─ F=1월, G=2월, H=3월, J=4월, K=5월, M=6월,
-  │         N=7월, Q=8월, U=9월, V=10월, X=11월, Z=12월
-  └─ HMH = Mini Hang Seng, HMCE = Mini HSCEI
-```
-
-**예**: `HMHJ26` = Mini Hang Seng **2026년 4월물**
-
-분기물(H/M/U/Z) 이 가장 유동성 풍부. 월물(J/K 등)도 일부 거래.
 
 ---
 
@@ -116,27 +114,20 @@ HM[CE] + 월코드 + 연도2자리
 
 ## ✅ 검증 결과
 
-### L1 — 정적 validate
+### L1 — 정적 validate (2026-07-13 재실행 ✅)
 
-→ `is_valid: True / errors: 0 / warnings: 0 / recs: ['REC_EXTERNAL_API_RESILIENCE']`
+→ `is_valid: True / errors: 0 / warnings: 0`
 
-### L2 — dry_run cycle
+구조 체커(하드코딩 월물 잔존 / FuturesContractNode·base_products / 브로커→contract 엣지 /
+dangling 엣지·템플릿 참조 / 하류 심볼 배선) **PASS**.
 
-→ `status: completed, errors_count: 0`. ExclusionList 가 watchlist 입력에 정적 블랙리스트 적용,
-historical / atr_cond auto-iterate, filter_candidates 가 빈 결과 → IfNode 가 false 분기 →
-no_candidate_notice 실행 (mock 환경 정상). 실 데이터에선 true 분기 진입 가능.
+### L2 — 실 LS 실행 (팀장 검증 대기)
 
-### L3 — 실 모의 검증 (2026-05-30 호스트 실행 ✅ — from_port:"filtered" 라이브 확증)
+`programgarden_ai/scripts/run_example_readonly.py 85` (주문 노드 제거 사본) 으로 재실행 필요.
+확인할 것: `contract` 가 근월물 2건을 해소하는지, `exclusion.filtered` 가 그 2건을 그대로
+넘기는지, `historical` 이 종목별로 봉을 받는지(만기 경과 시 0봉이던 회귀가 사라졌는지).
 
-`examples/programmer_example/test_hkex_read_all.py` 로 실 모의 appkey 실행:
-
-- **exclusion → historical 엣지 `from_port:"filtered"` 확증**: ExclusionListNode 가 만기
-  4월물/2월물 4종(`HMHJ26`/`HMCEJ26`/`HMHG26`/`HMCEG26`)을 `excluded` 포트로 격리하고,
-  historical 은 생존 월물 `HMHU26`/`HMCEU26` 만 순회 (스크리너가 "걸러낸 종목"을
-  분석하던 자기모순 봉쇄 — deb80456).
-- ATR 계산 정상 (`atr` 158.64), **errors=0**.
-
-### L4 — mock 주문 (사용자 트리거)
+### L3 — mock 주문 (사용자 트리거)
 
 후보가 잡힐 때 NewOrder 1건 모의계좌 발사 → 체결 확인 → cancel (사용자 직접 발사).
 
@@ -144,11 +135,12 @@ no_candidate_notice 실행 (mock 환경 정상). 실 데이터에선 true 분기
 
 ## 🔍 학습 포인트
 
-1. **ExclusionListNode `input_symbols` 패턴**: 정적 blacklist + `input_symbols={{ watchlist.symbols }}` → `filtered` 출력이 watchlist - blacklist. WatchlistNode → ExclusionListNode 직결로 진입 차단 효과.
-2. **IfNode `is_not_empty` operator**: 후보 리스트 개수가 아니라 직접 `is_not_empty` 로 분기. operand 없이 단항 비교.
-3. **캐스케이딩 스킵 + 캐스케이딩 활성**: 후보 없을 때 true 분기(market/sizing/order/telegram) 전체 자동 skip. false 분기만 활성.
-4. **mock roll-over**: 만기 캘린더 인프라 없이 정적 블랙리스트만으로 patten 시연 → 실 운영 전 dry_run / E2E 검증 가능.
-5. **balance partial-failure 폴백**: AccountNode resilience skip → TR 일시 실패에도 워크플로우 안전.
+1. **월물은 하드코딩하지 않는다**: `FuturesContractNode` 가 실행 시점에 상장 월물을 해소 → 만기 경과로 인한 "빈 응답 + 무에러" 무음 사망을 구조적으로 차단.
+2. **`symbols` 포트는 WatchlistNode 와 동일 계약**: `[{exchange, symbol}]` → 하류 노드 배선을 바꾸지 않고 심볼 출처만 교체 가능.
+3. **auto-iterate 소비자는 `{{ item }}`**: Historical / MarketData 는 심볼 배열을 받으면 한 종목씩 자동 순회. 반면 ExclusionListNode 는 배열 노드라 순회하지 않고 `input_symbols` 로 리스트 전체를 받는다.
+4. **ExclusionListNode `input_symbols` 패턴**: 블랙리스트 + `input_symbols` → `filtered` 출력이 (입력 − 블랙리스트). 여기에 걸린 종목은 주문 노드에서도 차단된다.
+5. **IfNode `is_not_empty` operator**: 후보 개수가 아니라 리스트 자체로 분기. operand 없이 단항 비교.
+6. **캐스케이딩 스킵 + 캐스케이딩 활성**: 후보 없을 때 true 분기(market/sizing/order/telegram) 전체 자동 skip. false 분기만 활성.
 
 ---
 
@@ -164,7 +156,7 @@ no_candidate_notice 실행 (mock 환경 정상). 실 데이터에선 true 분기
 ## 📝 변경 이력
 
 - 2026-05-28: 신규 추가 (`feat/hkex-futures-examples`)
-- 2026-07-13: 6월물 만기 경과로 historical 이 빈 배열 → 후보풀을 **9월물(HMHU26/HMCEU26)**
-  로 roll-forward (실전 키로 월물 유효성 실측: 6월물 0봉 / 9월물 21봉). 만기 경과분을
-  ExclusionListNode 로 거른다는 예제의 교육 포인트는 그대로 유지(블랙리스트 4건 불변).
-  아울러 실행기 auto-iterate 결함 4건 수정 — 상세는 `CHANGELOG.md` 1.26.0 Fixed 참조.
+- 2026-07-13: **월물 하드코딩 제거** — WatchlistNode(월물 4건) + ExclusionListNode(만기 블랙리스트 4건)
+  을 `FuturesContractNode`(기초자산 `HMH`/`HMCE`, 근월물) 로 대체. 만기가 지나면 조용히 죽던
+  구조적 결함을 근본 해결. ExclusionListNode 는 유지하되 만기 블랙리스트가 아닌 **운영
+  블랙리스트 훅**으로 역할 변경(기본 빈 목록). 전략·조건·스케줄·노드 배선은 불변.

--- a/src/programgarden/examples/workflows/86-ai-news-sentiment-auto-trade.json
+++ b/src/programgarden/examples/workflows/86-ai-news-sentiment-auto-trade.json
@@ -101,7 +101,7 @@
       "type": "PositionSizingNode",
       "symbol": "AAPL",
       "balance": "{{ nodes.account.balance.orderable_amount }}",
-      "market_data": "{{ nodes.market.value }}",
+      "market_data": "{{ nodes.market.values }}",
       "method": "fixed_percent",
       "max_percent": 10.0,
       "position": {

--- a/src/programgarden/examples/workflows/94-korea-stock-order-rsi-buy.json
+++ b/src/programgarden/examples/workflows/94-korea-stock-order-rsi-buy.json
@@ -1,0 +1,135 @@
+{
+  "id": "94-korea-stock-order-rsi-buy",
+  "name": "국내주식 RSI 과매도 매수 주문",
+  "description": "삼성전자(005930) 일봉 RSI(14) 과매도 신호(passed_symbols) → KoreaStockMarketDataNode 현재가 → PositionSizing(주문가능금액 5%) → KoreaStockNewOrderNode 지정가 매수. 국내주식은 모의투자 미지원 — 실계좌 즉시체결.",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "StartNode",
+      "position": { "x": 50, "y": 250 }
+    },
+    {
+      "id": "broker",
+      "type": "KoreaStockBrokerNode",
+      "credential_id": "kr_broker_cred",
+      "position": { "x": 220, "y": 250 }
+    },
+    {
+      "id": "account",
+      "type": "KoreaStockAccountNode",
+      "position": { "x": 420, "y": 380 }
+    },
+    {
+      "id": "split",
+      "type": "SplitNode",
+      "items": [
+        { "symbol": "005930" }
+      ],
+      "position": { "x": 420, "y": 120 }
+    },
+    {
+      "id": "historical",
+      "type": "KoreaStockHistoricalDataNode",
+      "symbol": "{{ nodes.split.item }}",
+      "start_date": "{{ date.ago(60, format='yyyymmdd') }}",
+      "end_date": "{{ date.today(format='yyyymmdd') }}",
+      "interval": "1d",
+      "adjust": true,
+      "position": { "x": 640, "y": 120 }
+    },
+    {
+      "id": "rsi_cond",
+      "type": "ConditionNode",
+      "plugin": "RSI",
+      "items": {
+        "from": "{{ item.time_series }}",
+        "extract": {
+          "symbol": "{{ item.symbol }}",
+          "date": "{{ row.date }}",
+          "close": "{{ row.close }}"
+        }
+      },
+      "fields": {
+        "period": 14,
+        "threshold": 30,
+        "direction": "below"
+      },
+      "position": { "x": 860, "y": 120 }
+    },
+    {
+      "id": "market",
+      "type": "KoreaStockMarketDataNode",
+      "symbol": "{{ nodes.split.item }}",
+      "position": { "x": 860, "y": 320 }
+    },
+    {
+      "id": "sizing",
+      "type": "PositionSizingNode",
+      "method": "fixed_percent",
+      "max_percent": 5.0,
+      "balance": "{{ nodes.account.balance.orderable_amount }}",
+      "market_data": "{{ nodes.market.values }}",
+      "symbols": "{{ nodes.rsi_cond.passed_symbols }}",
+      "position": { "x": 1080, "y": 250 }
+    },
+    {
+      "id": "order",
+      "type": "KoreaStockNewOrderNode",
+      "side": "buy",
+      "order_type": "limit",
+      "order": "{{ nodes.sizing.order }}",
+      "position": { "x": 1300, "y": 250 }
+    },
+    {
+      "id": "order_table",
+      "type": "TableDisplayNode",
+      "title": "국내주식 주문 실행 내역",
+      "data": "{{ nodes.order.result }}",
+      "columns": [
+        "symbol",
+        "side",
+        "quantity",
+        "price",
+        "status"
+      ],
+      "limit": 10,
+      "position": { "x": 1520, "y": 250 }
+    }
+  ],
+  "edges": [
+    { "from": "start", "to": "broker" },
+    { "from": "broker", "to": "account" },
+    { "from": "broker", "to": "split" },
+    { "from": "split", "to": "historical" },
+    { "from": "broker", "to": "historical" },
+    { "from": "historical", "to": "rsi_cond" },
+    { "from": "split", "to": "market" },
+    { "from": "broker", "to": "market" },
+    { "from": "rsi_cond", "to": "sizing" },
+    { "from": "market", "to": "sizing" },
+    { "from": "account", "to": "sizing" },
+    { "from": "sizing", "to": "order" },
+    { "from": "broker", "to": "order" },
+    { "from": "order", "to": "order_table" }
+  ],
+  "credentials": [
+    {
+      "credential_id": "kr_broker_cred",
+      "type": "broker_ls_korea_stock",
+      "data": [
+        { "key": "appkey", "value": "", "type": "password", "label": "App Key" },
+        { "key": "appsecret", "value": "", "type": "password", "label": "App Secret" }
+      ]
+    }
+  ],
+  "notes": [
+    {
+      "id": "note_real",
+      "content": "## 국내주식 실주문 경고\n\nKoreaStockBrokerNode 는 모의투자(paper_trading)를 지원하지 않는다.\n국내주식 주문은 **실계좌 즉시체결**이며 되돌릴 수 없다.\n\n- 검증/학습 목적이면 주문 노드(order)를 제거하고 rsi_cond → TableDisplayNode 로 신호만 확인한다.\n- 실행 전 주문가능금액(KoreaStockAccountNode.balance.orderable_amount)과 KoreaStockMarketDataNode 현재가를 반드시 확인한다 — 지정가는 현재가 기준으로 산출된다.\n- retry 는 중복주문 방지를 위해 기본 비활성 — 켜지 말 것.",
+      "color": 1,
+      "width": 360,
+      "height": 200,
+      "position": { "x": 50, "y": 40 }
+    }
+  ]
+}

--- a/src/programgarden/examples/workflows/94-korea-stock-order-rsi-buy.json
+++ b/src/programgarden/examples/workflows/94-korea-stock-order-rsi-buy.json
@@ -20,31 +20,24 @@
       "position": { "x": 420, "y": 380 }
     },
     {
-      "id": "split",
-      "type": "SplitNode",
-      "items": [
-        { "symbol": "005930" }
-      ],
-      "position": { "x": 420, "y": 120 }
-    },
-    {
       "id": "historical",
       "type": "KoreaStockHistoricalDataNode",
-      "symbol": "{{ nodes.split.item }}",
+      "symbol": { "symbol": "005930", "exchange": "KRX" },
       "start_date": "{{ date.ago(60, format='yyyymmdd') }}",
       "end_date": "{{ date.today(format='yyyymmdd') }}",
       "interval": "1d",
       "adjust": true,
-      "position": { "x": 640, "y": 120 }
+      "position": { "x": 420, "y": 120 }
     },
     {
       "id": "rsi_cond",
       "type": "ConditionNode",
       "plugin": "RSI",
       "items": {
-        "from": "{{ item.time_series }}",
+        "from": "{{ nodes.historical.value.time_series }}",
         "extract": {
-          "symbol": "{{ item.symbol }}",
+          "symbol": "{{ nodes.historical.value.symbol }}",
+          "exchange": "KRX",
           "date": "{{ row.date }}",
           "close": "{{ row.close }}"
         }
@@ -54,13 +47,15 @@
         "threshold": 30,
         "direction": "below"
       },
-      "position": { "x": 860, "y": 120 }
+      "position": { "x": 640, "y": 120 }
     },
     {
       "id": "market",
       "type": "KoreaStockMarketDataNode",
-      "symbol": "{{ nodes.split.item }}",
-      "position": { "x": 860, "y": 320 }
+      "symbols": [
+        { "symbol": "005930", "exchange": "KRX" }
+      ],
+      "position": { "x": 640, "y": 320 }
     },
     {
       "id": "sizing",
@@ -70,7 +65,7 @@
       "balance": "{{ nodes.account.balance.orderable_amount }}",
       "market_data": "{{ nodes.market.values }}",
       "symbols": "{{ nodes.rsi_cond.passed_symbols }}",
-      "position": { "x": 1080, "y": 250 }
+      "position": { "x": 860, "y": 250 }
     },
     {
       "id": "order",
@@ -78,7 +73,7 @@
       "side": "buy",
       "order_type": "limit",
       "order": "{{ nodes.sizing.order }}",
-      "position": { "x": 1300, "y": 250 }
+      "position": { "x": 1080, "y": 250 }
     },
     {
       "id": "order_table",
@@ -93,17 +88,14 @@
         "status"
       ],
       "limit": 10,
-      "position": { "x": 1520, "y": 250 }
+      "position": { "x": 1300, "y": 250 }
     }
   ],
   "edges": [
     { "from": "start", "to": "broker" },
     { "from": "broker", "to": "account" },
-    { "from": "broker", "to": "split" },
-    { "from": "split", "to": "historical" },
     { "from": "broker", "to": "historical" },
     { "from": "historical", "to": "rsi_cond" },
-    { "from": "split", "to": "market" },
     { "from": "broker", "to": "market" },
     { "from": "rsi_cond", "to": "sizing" },
     { "from": "market", "to": "sizing" },
@@ -125,10 +117,10 @@
   "notes": [
     {
       "id": "note_real",
-      "content": "## 국내주식 실주문 경고\n\nKoreaStockBrokerNode 는 모의투자(paper_trading)를 지원하지 않는다.\n국내주식 주문은 **실계좌 즉시체결**이며 되돌릴 수 없다.\n\n- 검증/학습 목적이면 주문 노드(order)를 제거하고 rsi_cond → TableDisplayNode 로 신호만 확인한다.\n- 실행 전 주문가능금액(KoreaStockAccountNode.balance.orderable_amount)과 KoreaStockMarketDataNode 현재가를 반드시 확인한다 — 지정가는 현재가 기준으로 산출된다.\n- retry 는 중복주문 방지를 위해 기본 비활성 — 켜지 말 것.",
+      "content": "## 국내주식 실주문 경고\n\nKoreaStockBrokerNode 는 모의투자(paper_trading)를 지원하지 않는다.\n국내주식 주문은 **실계좌 즉시체결**이며 되돌릴 수 없다.\n\n- 검증/학습 목적이면 주문 노드(order)를 제거하고 rsi_cond → TableDisplayNode 로 신호만 확인한다.\n- 실행 전 주문가능금액(KoreaStockAccountNode.balance.orderable_amount)과 KoreaStockMarketDataNode 현재가를 반드시 확인한다 — 지정가는 현재가 기준으로 산출된다.\n- retry 는 중복주문 방지를 위해 기본 비활성 — 켜지 말 것.\n- 다종목으로 넓히려면 종목마다 KoreaStockHistoricalDataNode+ConditionNode 체인을 복제한다(historical 은 단일 symbol 만 받는다 — 배열/Split 로는 동작하지 않는다).",
       "color": 1,
       "width": 360,
-      "height": 200,
+      "height": 220,
       "position": { "x": 50, "y": 40 }
     }
   ]

--- a/src/programgarden/examples/workflows/94-korea-stock-order-rsi-buy.md
+++ b/src/programgarden/examples/workflows/94-korea-stock-order-rsi-buy.md
@@ -1,0 +1,66 @@
+# Korea Stock RSI Oversold Buy Order
+
+Samsung Electronics (005930) daily RSI(14) oversold signal → live KRX quote → PositionSizing (5% of orderable cash) → KoreaStockNewOrderNode limit buy. Korea stocks do NOT support paper trading — orders hit the real account immediately.
+
+## Workflow Structure
+
+```mermaid
+graph LR
+    start(["Start"])
+    broker(["Broker
+(Korea Stock)"])
+    account["Account
+(Korea Stock)"]
+    split["Split"]
+    historical["Historical
+(Korea Stock)"]
+    rsi_cond{"Condition
+(RSI)"}
+    market["MarketData
+(Korea Stock)"]
+    sizing["PositionSizing"]
+    order["NewOrder
+(Korea Stock)"]
+    order_table[/"TableDisplay"/]
+    start --> broker
+    broker --> account
+    broker --> split
+    split --> historical
+    broker --> historical
+    historical --> rsi_cond
+    split --> market
+    broker --> market
+    rsi_cond --> sizing
+    market --> sizing
+    account --> sizing
+    sizing --> order
+    broker --> order
+    order --> order_table
+```
+
+## Node List
+
+| ID | Type | Description |
+|----|------|------|
+| start | StartNode | Workflow start |
+| broker | KoreaStockBrokerNode | Korea stock broker connection (real account only) |
+| account | KoreaStockAccountNode | Orderable cash / positions |
+| split | SplitNode | Emit single symbol item {symbol: 005930} |
+| historical | KoreaStockHistoricalDataNode | 60-day adjusted daily OHLCV |
+| rsi_cond | ConditionNode (RSI) | RSI(14) < 30 oversold filter → passed_symbols |
+| market | KoreaStockMarketDataNode | Live KRX quote (current price) for sizing |
+| sizing | PositionSizingNode | fixed_percent 5% of orderable cash → order dict |
+| order | KoreaStockNewOrderNode | Limit buy (side=buy, order_type=limit) |
+| order_table | TableDisplayNode | Order execution audit log |
+
+## Required Credentials
+
+| ID | Type | Description |
+|----|------|------|
+| kr_broker_cred | broker_ls_korea_stock | LS Securities Korea Stock API (real account) |
+
+## Notes
+
+- **No paper trading**: KoreaStockBrokerNode is real-market only. To study the flow without executing, drop the `order` node and inspect `rsi_cond` via a display node.
+- The `order` dict for Korea stocks uses `{symbol, quantity, price?}` — no exchange field.
+- Retry stays disabled by default to prevent duplicate KRW-denominated orders.

--- a/src/programgarden/examples/workflows/94-korea-stock-order-rsi-buy.md
+++ b/src/programgarden/examples/workflows/94-korea-stock-order-rsi-buy.md
@@ -11,7 +11,6 @@ graph LR
 (Korea Stock)"])
     account["Account
 (Korea Stock)"]
-    split["Split"]
     historical["Historical
 (Korea Stock)"]
     rsi_cond{"Condition
@@ -24,11 +23,8 @@ graph LR
     order_table[/"TableDisplay"/]
     start --> broker
     broker --> account
-    broker --> split
-    split --> historical
     broker --> historical
     historical --> rsi_cond
-    split --> market
     broker --> market
     rsi_cond --> sizing
     market --> sizing
@@ -45,10 +41,9 @@ graph LR
 | start | StartNode | Workflow start |
 | broker | KoreaStockBrokerNode | Korea stock broker connection (real account only) |
 | account | KoreaStockAccountNode | Orderable cash / positions |
-| split | SplitNode | Emit single symbol item {symbol: 005930} |
-| historical | KoreaStockHistoricalDataNode | 60-day adjusted daily OHLCV |
+| historical | KoreaStockHistoricalDataNode | 60-day adjusted daily OHLCV for 005930 (single `symbol` object) |
 | rsi_cond | ConditionNode (RSI) | RSI(14) < 30 oversold filter → passed_symbols |
-| market | KoreaStockMarketDataNode | Live KRX quote (current price) for sizing |
+| market | KoreaStockMarketDataNode | Live KRX quote (`symbols` array → `values`) for sizing |
 | sizing | PositionSizingNode | fixed_percent 5% of orderable cash → order dict |
 | order | KoreaStockNewOrderNode | Limit buy (side=buy, order_type=limit) |
 | order_table | TableDisplayNode | Order execution audit log |
@@ -61,6 +56,8 @@ graph LR
 
 ## Notes
 
-- **No paper trading**: KoreaStockBrokerNode is real-market only. To study the flow without executing, drop the `order` node and inspect `rsi_cond` via a display node.
+- **No paper trading**: KoreaStockBrokerNode is real-market only. To study the flow without executing, drop the `order` node and inspect `sizing.orders` via a display node (live-verified: sizing emits `orders`/`order` when a symbol passes and the account can afford ≥1 share).
+- **Single-symbol pipeline**: `historical` takes a single `symbol` object (`{symbol, exchange}`) and emits `value.time_series`; `rsi_cond` reads `{{ nodes.historical.value.time_series }}`. `market` uses a `symbols` **array** and emits `values` — sizing binds `market_data = {{ nodes.market.values }}`. To widen to several tickers, replicate the `historical + rsi_cond` chain per symbol (the historical node accepts only one symbol — an array or SplitNode silently yields 0 bars live).
+- Sizing wiring (all live-verified): `symbols = {{ nodes.rsi_cond.passed_symbols }}`, `market_data = {{ nodes.market.values }}` (plural — never `.value`), `balance = {{ nodes.account.balance.orderable_amount }}` (the scalar field, not the raw dict).
 - The `order` dict for Korea stocks uses `{symbol, quantity, price?}` — no exchange field.
 - Retry stays disabled by default to prevent duplicate KRW-denominated orders.

--- a/src/programgarden/examples/workflows/95-korea-stock-strategy-condition-logic.json
+++ b/src/programgarden/examples/workflows/95-korea-stock-strategy-condition-logic.json
@@ -1,7 +1,7 @@
 {
   "id": "95-korea-stock-strategy-condition-logic",
   "name": "국내주식 복합조건 전략 (RSI + 볼린저 AND)",
-  "description": "국내주식 3종목 일봉에 RSI(14) 과매도 AND 볼린저 하단 이탈 두 조건을 병렬 평가한 뒤 LogicNode(all)로 결합해 진입 후보를 필터링. 조회·전략 전용(주문 없음).",
+  "description": "삼성전자(005930) 일봉에 RSI(14) 과매도 조건과 볼린저(20,2) 하단 이탈 조건을 병렬 평가한 뒤 LogicNode(all)로 AND 결합해 두 지표가 동시에 과매도일 때만 진입 후보로 남긴다. 조회·전략 전용(주문 없음).",
   "nodes": [
     {
       "id": "start",
@@ -15,33 +15,24 @@
       "position": { "x": 220, "y": 250 }
     },
     {
-      "id": "split",
-      "type": "SplitNode",
-      "items": [
-        { "symbol": "005930" },
-        { "symbol": "000660" },
-        { "symbol": "035720" }
-      ],
-      "position": { "x": 420, "y": 250 }
-    },
-    {
       "id": "historical",
       "type": "KoreaStockHistoricalDataNode",
-      "symbol": "{{ nodes.split.item }}",
+      "symbol": { "symbol": "005930", "exchange": "KRX" },
       "start_date": "{{ date.ago(120, format='yyyymmdd') }}",
       "end_date": "{{ date.today(format='yyyymmdd') }}",
       "interval": "1d",
       "adjust": true,
-      "position": { "x": 640, "y": 250 }
+      "position": { "x": 420, "y": 250 }
     },
     {
       "id": "rsi_cond",
       "type": "ConditionNode",
       "plugin": "RSI",
       "items": {
-        "from": "{{ item.time_series }}",
+        "from": "{{ nodes.historical.value.time_series }}",
         "extract": {
-          "symbol": "{{ item.symbol }}",
+          "symbol": "{{ nodes.historical.value.symbol }}",
+          "exchange": "KRX",
           "date": "{{ row.date }}",
           "close": "{{ row.close }}"
         }
@@ -51,16 +42,17 @@
         "threshold": 30,
         "direction": "below"
       },
-      "position": { "x": 860, "y": 140 }
+      "position": { "x": 680, "y": 140 }
     },
     {
       "id": "boll_cond",
       "type": "ConditionNode",
       "plugin": "BollingerBands",
       "items": {
-        "from": "{{ item.time_series }}",
+        "from": "{{ nodes.historical.value.time_series }}",
         "extract": {
-          "symbol": "{{ item.symbol }}",
+          "symbol": "{{ nodes.historical.value.symbol }}",
+          "exchange": "KRX",
           "date": "{{ row.date }}",
           "close": "{{ row.close }}"
         }
@@ -70,7 +62,7 @@
         "std_dev": 2.0,
         "position": "below_lower"
       },
-      "position": { "x": 860, "y": 360 }
+      "position": { "x": 680, "y": 360 }
     },
     {
       "id": "logic",
@@ -86,7 +78,7 @@
           "passed_symbols": "{{ nodes.boll_cond.passed_symbols }}"
         }
       ],
-      "position": { "x": 1100, "y": 250 }
+      "position": { "x": 940, "y": 250 }
     },
     {
       "id": "table",
@@ -94,16 +86,15 @@
       "title": "RSI 과매도 + 볼린저 하단 이탈 종목",
       "data": "{{ nodes.logic.passed_symbols }}",
       "columns": [
-        "symbol"
+        "symbol",
+        "exchange"
       ],
       "limit": 10,
-      "position": { "x": 1320, "y": 250 }
+      "position": { "x": 1180, "y": 250 }
     }
   ],
   "edges": [
     { "from": "start", "to": "broker" },
-    { "from": "broker", "to": "split" },
-    { "from": "split", "to": "historical" },
     { "from": "broker", "to": "historical" },
     { "from": "historical", "to": "rsi_cond" },
     { "from": "historical", "to": "boll_cond" },
@@ -119,6 +110,16 @@
         { "key": "appkey", "value": "", "type": "password", "label": "App Key" },
         { "key": "appsecret", "value": "", "type": "password", "label": "App Secret" }
       ]
+    }
+  ],
+  "notes": [
+    {
+      "id": "note_strategy",
+      "content": "## 복합조건 전략 메모\n\n- RSI(과매도)와 볼린저(하단 이탈) 두 지표가 **동시에** 참일 때만 LogicNode(all)이 종목을 통과시킨다(AND).\n- 한 종목에 대해 여러 지표를 결합하는 패턴이다. **여러 종목을 스크리닝**하려면 종목마다 KoreaStockHistoricalDataNode 를 복제해야 한다 — KoreaStockHistoricalDataNode 는 단일 symbol 만 받으므로 한 노드에 배열을 넣거나 SplitNode 로 순회할 수 없다(라이브에서 조용히 0건이 된다).\n- 조회·전략 전용 — 주문 노드가 없어 실행해도 체결되지 않는다.",
+      "color": 2,
+      "width": 380,
+      "height": 200,
+      "position": { "x": 420, "y": 40 }
     }
   ]
 }

--- a/src/programgarden/examples/workflows/95-korea-stock-strategy-condition-logic.json
+++ b/src/programgarden/examples/workflows/95-korea-stock-strategy-condition-logic.json
@@ -1,0 +1,124 @@
+{
+  "id": "95-korea-stock-strategy-condition-logic",
+  "name": "국내주식 복합조건 전략 (RSI + 볼린저 AND)",
+  "description": "국내주식 3종목 일봉에 RSI(14) 과매도 AND 볼린저 하단 이탈 두 조건을 병렬 평가한 뒤 LogicNode(all)로 결합해 진입 후보를 필터링. 조회·전략 전용(주문 없음).",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "StartNode",
+      "position": { "x": 50, "y": 250 }
+    },
+    {
+      "id": "broker",
+      "type": "KoreaStockBrokerNode",
+      "credential_id": "kr_broker_cred",
+      "position": { "x": 220, "y": 250 }
+    },
+    {
+      "id": "split",
+      "type": "SplitNode",
+      "items": [
+        { "symbol": "005930" },
+        { "symbol": "000660" },
+        { "symbol": "035720" }
+      ],
+      "position": { "x": 420, "y": 250 }
+    },
+    {
+      "id": "historical",
+      "type": "KoreaStockHistoricalDataNode",
+      "symbol": "{{ nodes.split.item }}",
+      "start_date": "{{ date.ago(120, format='yyyymmdd') }}",
+      "end_date": "{{ date.today(format='yyyymmdd') }}",
+      "interval": "1d",
+      "adjust": true,
+      "position": { "x": 640, "y": 250 }
+    },
+    {
+      "id": "rsi_cond",
+      "type": "ConditionNode",
+      "plugin": "RSI",
+      "items": {
+        "from": "{{ item.time_series }}",
+        "extract": {
+          "symbol": "{{ item.symbol }}",
+          "date": "{{ row.date }}",
+          "close": "{{ row.close }}"
+        }
+      },
+      "fields": {
+        "period": 14,
+        "threshold": 30,
+        "direction": "below"
+      },
+      "position": { "x": 860, "y": 140 }
+    },
+    {
+      "id": "boll_cond",
+      "type": "ConditionNode",
+      "plugin": "BollingerBands",
+      "items": {
+        "from": "{{ item.time_series }}",
+        "extract": {
+          "symbol": "{{ item.symbol }}",
+          "date": "{{ row.date }}",
+          "close": "{{ row.close }}"
+        }
+      },
+      "fields": {
+        "period": 20,
+        "std_dev": 2.0,
+        "position": "below_lower"
+      },
+      "position": { "x": 860, "y": 360 }
+    },
+    {
+      "id": "logic",
+      "type": "LogicNode",
+      "operator": "all",
+      "conditions": [
+        {
+          "is_condition_met": "{{ nodes.rsi_cond.result }}",
+          "passed_symbols": "{{ nodes.rsi_cond.passed_symbols }}"
+        },
+        {
+          "is_condition_met": "{{ nodes.boll_cond.result }}",
+          "passed_symbols": "{{ nodes.boll_cond.passed_symbols }}"
+        }
+      ],
+      "position": { "x": 1100, "y": 250 }
+    },
+    {
+      "id": "table",
+      "type": "TableDisplayNode",
+      "title": "RSI 과매도 + 볼린저 하단 이탈 종목",
+      "data": "{{ nodes.logic.passed_symbols }}",
+      "columns": [
+        "symbol"
+      ],
+      "limit": 10,
+      "position": { "x": 1320, "y": 250 }
+    }
+  ],
+  "edges": [
+    { "from": "start", "to": "broker" },
+    { "from": "broker", "to": "split" },
+    { "from": "split", "to": "historical" },
+    { "from": "broker", "to": "historical" },
+    { "from": "historical", "to": "rsi_cond" },
+    { "from": "historical", "to": "boll_cond" },
+    { "from": "rsi_cond", "to": "logic" },
+    { "from": "boll_cond", "to": "logic" },
+    { "from": "logic", "to": "table" }
+  ],
+  "credentials": [
+    {
+      "credential_id": "kr_broker_cred",
+      "type": "broker_ls_korea_stock",
+      "data": [
+        { "key": "appkey", "value": "", "type": "password", "label": "App Key" },
+        { "key": "appsecret", "value": "", "type": "password", "label": "App Secret" }
+      ]
+    }
+  ]
+}

--- a/src/programgarden/examples/workflows/95-korea-stock-strategy-condition-logic.md
+++ b/src/programgarden/examples/workflows/95-korea-stock-strategy-condition-logic.md
@@ -1,6 +1,6 @@
 # Korea Stock Compound Condition Strategy (RSI + Bollinger AND)
 
-Evaluate RSI(14) oversold AND Bollinger lower-band breach in parallel across 3 Korean stocks, then combine with LogicNode(all) to filter entry candidates. Query/strategy only — no orders.
+Evaluate RSI(14) oversold AND Bollinger lower-band breach on Samsung Electronics (005930) daily bars, then combine with LogicNode(all) so a symbol survives only when both indicators agree. Query/strategy only — no orders.
 
 ## Workflow Structure
 
@@ -9,7 +9,6 @@ graph LR
     start(["Start"])
     broker(["Broker
 (Korea Stock)"])
-    split["Split (3 symbols)"]
     historical["Historical
 (Korea Stock)"]
     rsi_cond{"Condition
@@ -19,8 +18,6 @@ graph LR
     logic{"Logic (all)"}
     table[/"TableDisplay"/]
     start --> broker
-    broker --> split
-    split --> historical
     broker --> historical
     historical --> rsi_cond
     historical --> boll_cond
@@ -35,8 +32,7 @@ graph LR
 |----|------|------|
 | start | StartNode | Workflow start |
 | broker | KoreaStockBrokerNode | Korea stock broker connection |
-| split | SplitNode | 3 symbols: 005930 / 000660 / 035720 |
-| historical | KoreaStockHistoricalDataNode | 120-day adjusted daily OHLCV per symbol |
+| historical | KoreaStockHistoricalDataNode | 120-day adjusted daily OHLCV for 005930 (single `symbol` object) |
 | rsi_cond | ConditionNode (RSI) | RSI(14) < 30 oversold |
 | boll_cond | ConditionNode (BollingerBands) | 20/2.0 lower-band breach (below_lower) |
 | logic | LogicNode | operator=all → both conditions must pass |
@@ -50,6 +46,7 @@ graph LR
 
 ## Notes
 
-- LogicNode `all` = intersection of the two conditions' `passed_symbols`; use `any` for a union (OR).
-- Each ConditionNode consumes the per-symbol `{{ item.time_series }}` produced by the item-based historical node.
+- Both ConditionNodes read the same series via `{{ nodes.historical.value.time_series }}` and must include `exchange` in `extract` (RSI/BollingerBands `required_fields = [symbol, exchange, date, close]`; domestic stocks carry no exchange, so a literal `"KRX"` is used). Omitting `exchange` makes the condition return `passed_symbols: []` silently.
+- LogicNode `all` = intersection of the two conditions' `passed_symbols` (live-verified: yields the symbol when both fire, empty otherwise); use `any` for a union (OR).
+- **Single-symbol screening**: this pattern combines multiple indicators on ONE symbol. To screen SEVERAL symbols, replicate the `historical` node per symbol — `KoreaStockHistoricalDataNode` takes only a single `symbol` object, so an array or a SplitNode fan-out silently produces 0 bars at live runtime (a single LogicNode cannot AND across per-symbol chains either).
 - Extend by feeding `logic.passed_symbols` into PositionSizingNode → KoreaStockNewOrderNode for an auto-entry variant (see example 94).

--- a/src/programgarden/examples/workflows/95-korea-stock-strategy-condition-logic.md
+++ b/src/programgarden/examples/workflows/95-korea-stock-strategy-condition-logic.md
@@ -1,0 +1,55 @@
+# Korea Stock Compound Condition Strategy (RSI + Bollinger AND)
+
+Evaluate RSI(14) oversold AND Bollinger lower-band breach in parallel across 3 Korean stocks, then combine with LogicNode(all) to filter entry candidates. Query/strategy only — no orders.
+
+## Workflow Structure
+
+```mermaid
+graph LR
+    start(["Start"])
+    broker(["Broker
+(Korea Stock)"])
+    split["Split (3 symbols)"]
+    historical["Historical
+(Korea Stock)"]
+    rsi_cond{"Condition
+(RSI)"}
+    boll_cond{"Condition
+(Bollinger)"}
+    logic{"Logic (all)"}
+    table[/"TableDisplay"/]
+    start --> broker
+    broker --> split
+    split --> historical
+    broker --> historical
+    historical --> rsi_cond
+    historical --> boll_cond
+    rsi_cond --> logic
+    boll_cond --> logic
+    logic --> table
+```
+
+## Node List
+
+| ID | Type | Description |
+|----|------|------|
+| start | StartNode | Workflow start |
+| broker | KoreaStockBrokerNode | Korea stock broker connection |
+| split | SplitNode | 3 symbols: 005930 / 000660 / 035720 |
+| historical | KoreaStockHistoricalDataNode | 120-day adjusted daily OHLCV per symbol |
+| rsi_cond | ConditionNode (RSI) | RSI(14) < 30 oversold |
+| boll_cond | ConditionNode (BollingerBands) | 20/2.0 lower-band breach (below_lower) |
+| logic | LogicNode | operator=all → both conditions must pass |
+| table | TableDisplayNode | Symbols passing both filters |
+
+## Required Credentials
+
+| ID | Type | Description |
+|----|------|------|
+| kr_broker_cred | broker_ls_korea_stock | LS Securities Korea Stock API |
+
+## Notes
+
+- LogicNode `all` = intersection of the two conditions' `passed_symbols`; use `any` for a union (OR).
+- Each ConditionNode consumes the per-symbol `{{ item.time_series }}` produced by the item-based historical node.
+- Extend by feeding `logic.passed_symbols` into PositionSizingNode → KoreaStockNewOrderNode for an auto-entry variant (see example 94).

--- a/src/programgarden/examples/workflows/96-korea-stock-backtest-rsi-bollinger.json
+++ b/src/programgarden/examples/workflows/96-korea-stock-backtest-rsi-bollinger.json
@@ -1,7 +1,7 @@
 {
   "id": "96-korea-stock-backtest-rsi-bollinger",
-  "name": "국내주식 백테스트 (삼성 RSI + KOSDAQ 볼린저)",
-  "description": "삼성전자(005930, KOSPI) RSI 평균회귀 전략과 에코프로비엠(247540, KOSDAQ) 볼린저 하단 반등 전략을 1년 일봉으로 각각 백테스트한 뒤 BenchmarkCompareNode로 샤프비율 비교. 국내 수수료/현금주식 설정(allow_fractional=false).",
+  "name": "국내주식 백테스트 (삼성전자 RSI vs 볼린저 비교)",
+  "description": "삼성전자(005930) 1년 일봉 하나로 RSI(14) 평균회귀 전략과 볼린저(20,2) 하단 반등 전략을 각각 백테스트한 뒤 BenchmarkCompareNode로 샤프비율을 비교한다. 두 전략이 같은 시세를 공유하므로 KoreaStockHistoricalDataNode 는 하나만 둔다.",
   "nodes": [
     {
       "id": "start",
@@ -15,32 +15,24 @@
       "position": { "x": 220, "y": 350 }
     },
     {
-      "id": "split",
-      "type": "SplitNode",
-      "items": [
-        { "symbol": "005930" },
-        { "symbol": "247540" }
-      ],
-      "position": { "x": 420, "y": 350 }
-    },
-    {
       "id": "historical",
       "type": "KoreaStockHistoricalDataNode",
-      "symbol": "{{ nodes.split.item }}",
+      "symbol": { "symbol": "005930", "exchange": "KRX" },
       "start_date": "{{ date.ago(365, format='yyyymmdd') }}",
       "end_date": "{{ date.today(format='yyyymmdd') }}",
       "interval": "1d",
       "adjust": true,
-      "position": { "x": 640, "y": 350 }
+      "position": { "x": 440, "y": 350 }
     },
     {
       "id": "rsi_cond",
       "type": "ConditionNode",
       "plugin": "RSI",
       "items": {
-        "from": "{{ item.time_series }}",
+        "from": "{{ nodes.historical.value.time_series }}",
         "extract": {
-          "symbol": "{{ item.symbol }}",
+          "symbol": "{{ nodes.historical.value.symbol }}",
+          "exchange": "KRX",
           "date": "{{ row.date }}",
           "open": "{{ row.open }}",
           "high": "{{ row.high }}",
@@ -51,19 +43,20 @@
       },
       "fields": {
         "period": 14,
-        "threshold": 30,
+        "threshold": 35,
         "direction": "below"
       },
-      "position": { "x": 880, "y": 180 }
+      "position": { "x": 700, "y": 180 }
     },
     {
       "id": "boll_cond",
       "type": "ConditionNode",
       "plugin": "BollingerBands",
       "items": {
-        "from": "{{ item.time_series }}",
+        "from": "{{ nodes.historical.value.time_series }}",
         "extract": {
-          "symbol": "{{ item.symbol }}",
+          "symbol": "{{ nodes.historical.value.symbol }}",
+          "exchange": "KRX",
           "date": "{{ row.date }}",
           "open": "{{ row.open }}",
           "high": "{{ row.high }}",
@@ -77,12 +70,12 @@
         "std_dev": 2.0,
         "position": "below_lower"
       },
-      "position": { "x": 880, "y": 520 }
+      "position": { "x": 700, "y": 520 }
     },
     {
-      "id": "backtest_samsung_rsi",
+      "id": "backtest_rsi",
       "type": "BacktestEngineNode",
-      "strategy_name": "Samsung RSI Mean Reversion (005930)",
+      "strategy_name": "Samsung RSI Mean Reversion",
       "items": {
         "from": "{{ nodes.rsi_cond.values[0].time_series }}",
         "extract": {
@@ -100,25 +93,17 @@
       "initial_capital": 10000000,
       "commission_rate": 0.00015,
       "slippage": 0.001,
-      "position_sizing": "fixed_percent",
-      "fixed_percent": 20.0,
-      "max_position_percent": 40.0,
-      "stop_loss_percent": 5.0,
-      "take_profit_percent": 12.0,
-      "time_stop_days": 20,
       "allow_short": false,
-      "allow_fractional": false,
-      "risk_free_rate": 0.03,
-      "position": { "x": 1140, "y": 180 }
+      "position": { "x": 960, "y": 180 }
     },
     {
-      "id": "backtest_kosdaq_bollinger",
+      "id": "backtest_bollinger",
       "type": "BacktestEngineNode",
-      "strategy_name": "KOSDAQ Bollinger Reversion (247540)",
+      "strategy_name": "Samsung Bollinger Reversion",
       "items": {
-        "from": "{{ nodes.boll_cond.values[1].time_series }}",
+        "from": "{{ nodes.boll_cond.values[0].time_series }}",
         "extract": {
-          "symbol": "{{ nodes.boll_cond.values[1].symbol }}",
+          "symbol": "{{ nodes.boll_cond.values[0].symbol }}",
           "date": "{{ row.date }}",
           "open": "{{ row.open }}",
           "high": "{{ row.high }}",
@@ -131,59 +116,38 @@
       },
       "initial_capital": 10000000,
       "commission_rate": 0.00015,
-      "slippage": 0.0015,
-      "position_sizing": "fixed_percent",
-      "fixed_percent": 20.0,
-      "max_position_percent": 40.0,
-      "stop_loss_percent": 6.0,
-      "take_profit_percent": 15.0,
-      "time_stop_days": 15,
+      "slippage": 0.001,
       "allow_short": false,
-      "allow_fractional": false,
-      "risk_free_rate": 0.03,
-      "position": { "x": 1140, "y": 520 }
+      "position": { "x": 960, "y": 520 }
     },
     {
       "id": "benchmark",
       "type": "BenchmarkCompareNode",
       "strategies": [
-        "{{ nodes.backtest_samsung_rsi.equity_curve }}",
-        "{{ nodes.backtest_kosdaq_bollinger.equity_curve }}"
+        "{{ nodes.backtest_rsi.equity_curve }}",
+        "{{ nodes.backtest_bollinger.equity_curve }}"
       ],
       "ranking_metric": "sharpe",
-      "position": { "x": 1420, "y": 350 }
+      "position": { "x": 1240, "y": 350 }
     },
     {
       "id": "summary",
       "type": "SummaryDisplayNode",
-      "title": "국내주식 전략 벤치마크 요약",
+      "title": "삼성전자 RSI vs 볼린저 전략 벤치마크 (샤프비율 순위)",
       "data": "{{ nodes.benchmark.ranking }}",
-      "position": { "x": 1660, "y": 220 }
-    },
-    {
-      "id": "equity_chart",
-      "type": "MultiLineChartNode",
-      "title": "전략별 자산 곡선 비교",
-      "data": "{{ nodes.benchmark.combined_curve }}",
-      "x_field": "date",
-      "y_field": "equity",
-      "series_key": "strategy_name",
-      "position": { "x": 1660, "y": 480 }
+      "position": { "x": 1500, "y": 350 }
     }
   ],
   "edges": [
     { "from": "start", "to": "broker" },
-    { "from": "broker", "to": "split" },
-    { "from": "split", "to": "historical" },
     { "from": "broker", "to": "historical" },
     { "from": "historical", "to": "rsi_cond" },
     { "from": "historical", "to": "boll_cond" },
-    { "from": "rsi_cond", "to": "backtest_samsung_rsi" },
-    { "from": "boll_cond", "to": "backtest_kosdaq_bollinger" },
-    { "from": "backtest_samsung_rsi", "to": "benchmark" },
-    { "from": "backtest_kosdaq_bollinger", "to": "benchmark" },
-    { "from": "benchmark", "to": "summary" },
-    { "from": "benchmark", "to": "equity_chart" }
+    { "from": "rsi_cond", "to": "backtest_rsi" },
+    { "from": "boll_cond", "to": "backtest_bollinger" },
+    { "from": "backtest_rsi", "to": "benchmark" },
+    { "from": "backtest_bollinger", "to": "benchmark" },
+    { "from": "benchmark", "to": "summary" }
   ],
   "credentials": [
     {
@@ -198,10 +162,10 @@
   "notes": [
     {
       "id": "note_fees",
-      "content": "## 국내주식 백테스트 설정 메모\n\n- **allow_fractional=false**: 국내주식은 소수점 매매 불가(정수 주식수).\n- **commission_rate 0.00015**: 위탁수수료 근사치. 매도 시 증권거래세(약 0.18%)는 별도 —\n  보수적 백테스트라면 commission_rate 를 왕복 비용으로 상향해 반영한다.\n- **수정주가**: KoreaStockHistoricalDataNode.adjust=true 로 액면분할/배당을 반영해 장기 수익률 왜곡을 방지.\n- 신호 매핑: ConditionNode 가 붙인 per-candle row.signal(buy/sell) + row.side 를 BacktestEngine 이 그대로 소비.",
+      "content": "## 국내주식 백테스트 설정 메모\n\n- **KoreaStockHistoricalDataNode 는 하나만** 두고 두 전략(rsi_cond·boll_cond)이 같은 시세를 공유한다. 서로 다른 종목을 비교하려면 종목마다 이 노드를 복제해야 하는데, **국내 차트 연속조회는 rate-limit 대기를 우회**해 한 세션에서 무거운 연속조회를 연달아 하면 두 번째가 조용히 0봉이 될 수 있다(라이브 실측). 종목별 비교가 필요하면 스케줄을 나누거나 조회 구간을 줄인다.\n- KoreaStockHistoricalDataNode 는 **단일 symbol 만** 받는다 — 배열/SplitNode 로 여러 종목을 순회할 수 없다.\n- **BacktestEngineNode 가 실제로 읽는 파라미터는 initial_capital · commission_rate · slippage · allow_short 4개뿐**이다. position_sizing/stop_loss/take_profit/time_stop/allow_fractional 등은 엔진이 소비하지 않으므로 넣지 않았다(넣어도 무시된다).\n- 체결 수량은 자본 대비 비율로 산출되며 **소수점 주식수**가 나온다(엔진은 정수 라운딩을 하지 않는다).\n- **commission_rate 0.00015**: 위탁수수료 근사치. 매도 시 증권거래세(약 0.18%)는 미반영.\n- **수정주가**: adjust=true 로 액면분할/배당 반영.\n- 신호 매핑: ConditionNode 가 붙인 per-candle row.signal(buy/sell)+row.side 를 BacktestEngine 이 그대로 소비한다. 전략별 자산곡선은 각 BacktestEngineNode 의 equity_curve 출력에 있다.",
       "color": 3,
-      "width": 380,
-      "height": 240,
+      "width": 400,
+      "height": 320,
       "position": { "x": 420, "y": 40 }
     }
   ]

--- a/src/programgarden/examples/workflows/96-korea-stock-backtest-rsi-bollinger.json
+++ b/src/programgarden/examples/workflows/96-korea-stock-backtest-rsi-bollinger.json
@@ -1,0 +1,208 @@
+{
+  "id": "96-korea-stock-backtest-rsi-bollinger",
+  "name": "국내주식 백테스트 (삼성 RSI + KOSDAQ 볼린저)",
+  "description": "삼성전자(005930, KOSPI) RSI 평균회귀 전략과 에코프로비엠(247540, KOSDAQ) 볼린저 하단 반등 전략을 1년 일봉으로 각각 백테스트한 뒤 BenchmarkCompareNode로 샤프비율 비교. 국내 수수료/현금주식 설정(allow_fractional=false).",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "StartNode",
+      "position": { "x": 50, "y": 350 }
+    },
+    {
+      "id": "broker",
+      "type": "KoreaStockBrokerNode",
+      "credential_id": "kr_broker_cred",
+      "position": { "x": 220, "y": 350 }
+    },
+    {
+      "id": "split",
+      "type": "SplitNode",
+      "items": [
+        { "symbol": "005930" },
+        { "symbol": "247540" }
+      ],
+      "position": { "x": 420, "y": 350 }
+    },
+    {
+      "id": "historical",
+      "type": "KoreaStockHistoricalDataNode",
+      "symbol": "{{ nodes.split.item }}",
+      "start_date": "{{ date.ago(365, format='yyyymmdd') }}",
+      "end_date": "{{ date.today(format='yyyymmdd') }}",
+      "interval": "1d",
+      "adjust": true,
+      "position": { "x": 640, "y": 350 }
+    },
+    {
+      "id": "rsi_cond",
+      "type": "ConditionNode",
+      "plugin": "RSI",
+      "items": {
+        "from": "{{ item.time_series }}",
+        "extract": {
+          "symbol": "{{ item.symbol }}",
+          "date": "{{ row.date }}",
+          "open": "{{ row.open }}",
+          "high": "{{ row.high }}",
+          "low": "{{ row.low }}",
+          "close": "{{ row.close }}",
+          "volume": "{{ row.volume }}"
+        }
+      },
+      "fields": {
+        "period": 14,
+        "threshold": 30,
+        "direction": "below"
+      },
+      "position": { "x": 880, "y": 180 }
+    },
+    {
+      "id": "boll_cond",
+      "type": "ConditionNode",
+      "plugin": "BollingerBands",
+      "items": {
+        "from": "{{ item.time_series }}",
+        "extract": {
+          "symbol": "{{ item.symbol }}",
+          "date": "{{ row.date }}",
+          "open": "{{ row.open }}",
+          "high": "{{ row.high }}",
+          "low": "{{ row.low }}",
+          "close": "{{ row.close }}",
+          "volume": "{{ row.volume }}"
+        }
+      },
+      "fields": {
+        "period": 20,
+        "std_dev": 2.0,
+        "position": "below_lower"
+      },
+      "position": { "x": 880, "y": 520 }
+    },
+    {
+      "id": "backtest_samsung_rsi",
+      "type": "BacktestEngineNode",
+      "strategy_name": "Samsung RSI Mean Reversion (005930)",
+      "items": {
+        "from": "{{ nodes.rsi_cond.values[0].time_series }}",
+        "extract": {
+          "symbol": "{{ nodes.rsi_cond.values[0].symbol }}",
+          "date": "{{ row.date }}",
+          "open": "{{ row.open }}",
+          "high": "{{ row.high }}",
+          "low": "{{ row.low }}",
+          "close": "{{ row.close }}",
+          "volume": "{{ row.volume }}",
+          "signal": "{{ row.signal }}",
+          "side": "{{ row.side }}"
+        }
+      },
+      "initial_capital": 10000000,
+      "commission_rate": 0.00015,
+      "slippage": 0.001,
+      "position_sizing": "fixed_percent",
+      "fixed_percent": 20.0,
+      "max_position_percent": 40.0,
+      "stop_loss_percent": 5.0,
+      "take_profit_percent": 12.0,
+      "time_stop_days": 20,
+      "allow_short": false,
+      "allow_fractional": false,
+      "risk_free_rate": 0.03,
+      "position": { "x": 1140, "y": 180 }
+    },
+    {
+      "id": "backtest_kosdaq_bollinger",
+      "type": "BacktestEngineNode",
+      "strategy_name": "KOSDAQ Bollinger Reversion (247540)",
+      "items": {
+        "from": "{{ nodes.boll_cond.values[1].time_series }}",
+        "extract": {
+          "symbol": "{{ nodes.boll_cond.values[1].symbol }}",
+          "date": "{{ row.date }}",
+          "open": "{{ row.open }}",
+          "high": "{{ row.high }}",
+          "low": "{{ row.low }}",
+          "close": "{{ row.close }}",
+          "volume": "{{ row.volume }}",
+          "signal": "{{ row.signal }}",
+          "side": "{{ row.side }}"
+        }
+      },
+      "initial_capital": 10000000,
+      "commission_rate": 0.00015,
+      "slippage": 0.0015,
+      "position_sizing": "fixed_percent",
+      "fixed_percent": 20.0,
+      "max_position_percent": 40.0,
+      "stop_loss_percent": 6.0,
+      "take_profit_percent": 15.0,
+      "time_stop_days": 15,
+      "allow_short": false,
+      "allow_fractional": false,
+      "risk_free_rate": 0.03,
+      "position": { "x": 1140, "y": 520 }
+    },
+    {
+      "id": "benchmark",
+      "type": "BenchmarkCompareNode",
+      "strategies": [
+        "{{ nodes.backtest_samsung_rsi.equity_curve }}",
+        "{{ nodes.backtest_kosdaq_bollinger.equity_curve }}"
+      ],
+      "ranking_metric": "sharpe",
+      "position": { "x": 1420, "y": 350 }
+    },
+    {
+      "id": "summary",
+      "type": "SummaryDisplayNode",
+      "title": "국내주식 전략 벤치마크 요약",
+      "data": "{{ nodes.benchmark.ranking }}",
+      "position": { "x": 1660, "y": 220 }
+    },
+    {
+      "id": "equity_chart",
+      "type": "MultiLineChartNode",
+      "title": "전략별 자산 곡선 비교",
+      "data": "{{ nodes.benchmark.combined_curve }}",
+      "x_field": "date",
+      "y_field": "equity",
+      "series_key": "strategy_name",
+      "position": { "x": 1660, "y": 480 }
+    }
+  ],
+  "edges": [
+    { "from": "start", "to": "broker" },
+    { "from": "broker", "to": "split" },
+    { "from": "split", "to": "historical" },
+    { "from": "broker", "to": "historical" },
+    { "from": "historical", "to": "rsi_cond" },
+    { "from": "historical", "to": "boll_cond" },
+    { "from": "rsi_cond", "to": "backtest_samsung_rsi" },
+    { "from": "boll_cond", "to": "backtest_kosdaq_bollinger" },
+    { "from": "backtest_samsung_rsi", "to": "benchmark" },
+    { "from": "backtest_kosdaq_bollinger", "to": "benchmark" },
+    { "from": "benchmark", "to": "summary" },
+    { "from": "benchmark", "to": "equity_chart" }
+  ],
+  "credentials": [
+    {
+      "credential_id": "kr_broker_cred",
+      "type": "broker_ls_korea_stock",
+      "data": [
+        { "key": "appkey", "value": "", "type": "password", "label": "App Key" },
+        { "key": "appsecret", "value": "", "type": "password", "label": "App Secret" }
+      ]
+    }
+  ],
+  "notes": [
+    {
+      "id": "note_fees",
+      "content": "## 국내주식 백테스트 설정 메모\n\n- **allow_fractional=false**: 국내주식은 소수점 매매 불가(정수 주식수).\n- **commission_rate 0.00015**: 위탁수수료 근사치. 매도 시 증권거래세(약 0.18%)는 별도 —\n  보수적 백테스트라면 commission_rate 를 왕복 비용으로 상향해 반영한다.\n- **수정주가**: KoreaStockHistoricalDataNode.adjust=true 로 액면분할/배당을 반영해 장기 수익률 왜곡을 방지.\n- 신호 매핑: ConditionNode 가 붙인 per-candle row.signal(buy/sell) + row.side 를 BacktestEngine 이 그대로 소비.",
+      "color": 3,
+      "width": 380,
+      "height": 240,
+      "position": { "x": 420, "y": 40 }
+    }
+  ]
+}

--- a/src/programgarden/examples/workflows/96-korea-stock-backtest-rsi-bollinger.md
+++ b/src/programgarden/examples/workflows/96-korea-stock-backtest-rsi-bollinger.md
@@ -1,0 +1,61 @@
+# Korea Stock Backtest (Samsung RSI + KOSDAQ Bollinger)
+
+Backtest a Samsung Electronics (005930, KOSPI) RSI mean-reversion strategy and an Ecopro BM (247540, KOSDAQ) Bollinger lower-band reversion strategy over 1 year of daily bars, then compare Sharpe ratios with BenchmarkCompareNode. Uses Korea-realistic fee / whole-share settings (allow_fractional=false).
+
+## Workflow Structure
+
+```mermaid
+graph LR
+    start(["Start"])
+    broker(["Broker
+(Korea Stock)"])
+    split["Split (2 symbols)"]
+    historical["Historical
+(Korea Stock)"]
+    rsi_cond{"Condition
+(RSI)"}
+    boll_cond{"Condition
+(Bollinger)"}
+    bt_rsi["Backtest
+(Samsung RSI)"]
+    bt_boll["Backtest
+(KOSDAQ Bollinger)"]
+    benchmark["BenchmarkCompare"]
+    summary[/"SummaryDisplay"/]
+    equity_chart[/"MultiLineChart"/]
+    start --> broker --> split --> historical
+    broker --> historical
+    historical --> rsi_cond --> bt_rsi --> benchmark
+    historical --> boll_cond --> bt_boll --> benchmark
+    benchmark --> summary
+    benchmark --> equity_chart
+```
+
+## Node List
+
+| ID | Type | Description |
+|----|------|------|
+| start | StartNode | Workflow start |
+| broker | KoreaStockBrokerNode | Korea stock broker connection |
+| split | SplitNode | 2 symbols: 005930 (KOSPI) / 247540 (KOSDAQ) |
+| historical | KoreaStockHistoricalDataNode | 365-day adjusted daily OHLCV per symbol |
+| rsi_cond | ConditionNode (RSI) | RSI(14) < 30 signals |
+| boll_cond | ConditionNode (BollingerBands) | 20/2.0 lower-band signals |
+| backtest_samsung_rsi | BacktestEngineNode | Samsung RSI mean-reversion (values[0]) |
+| backtest_kosdaq_bollinger | BacktestEngineNode | KOSDAQ Bollinger reversion (values[1]) |
+| benchmark | BenchmarkCompareNode | Rank both strategies by Sharpe |
+| summary | SummaryDisplayNode | Ranking summary card |
+| equity_chart | MultiLineChartNode | Combined equity curves |
+
+## Required Credentials
+
+| ID | Type | Description |
+|----|------|------|
+| kr_broker_cred | broker_ls_korea_stock | LS Securities Korea Stock API |
+
+## Notes
+
+- **allow_fractional=false**: Korean stocks trade in whole shares only.
+- **commission_rate 0.00015** approximates brokerage; the ~0.18% sell-side transaction tax is separate — raise commission_rate to a round-trip figure for a conservative backtest.
+- **adjust=true** applies split/dividend-adjusted prices for accurate long-term returns.
+- Signal mapping: the ConditionNode annotates each candle with `row.signal` (buy/sell) + `row.side`, consumed directly by the BacktestEngine. Each backtest reads its symbol's slice via `nodes.<cond>.values[i].time_series`.

--- a/src/programgarden/examples/workflows/96-korea-stock-backtest-rsi-bollinger.md
+++ b/src/programgarden/examples/workflows/96-korea-stock-backtest-rsi-bollinger.md
@@ -1,6 +1,6 @@
-# Korea Stock Backtest (Samsung RSI + KOSDAQ Bollinger)
+# Korea Stock Backtest (Samsung RSI vs Bollinger)
 
-Backtest a Samsung Electronics (005930, KOSPI) RSI mean-reversion strategy and an Ecopro BM (247540, KOSDAQ) Bollinger lower-band reversion strategy over 1 year of daily bars, then compare Sharpe ratios with BenchmarkCompareNode. Uses Korea-realistic fee / whole-share settings (allow_fractional=false).
+Backtest two strategies on one year of Samsung Electronics (005930) daily bars — an RSI(14) mean-reversion strategy and a Bollinger(20, 2σ) lower-band reversion strategy — then rank them by Sharpe with BenchmarkCompareNode. Both strategies share a single historical fetch.
 
 ## Workflow Structure
 
@@ -9,7 +9,6 @@ graph LR
     start(["Start"])
     broker(["Broker
 (Korea Stock)"])
-    split["Split (2 symbols)"]
     historical["Historical
 (Korea Stock)"]
     rsi_cond{"Condition
@@ -17,18 +16,15 @@ graph LR
     boll_cond{"Condition
 (Bollinger)"}
     bt_rsi["Backtest
-(Samsung RSI)"]
+(RSI)"]
     bt_boll["Backtest
-(KOSDAQ Bollinger)"]
+(Bollinger)"]
     benchmark["BenchmarkCompare"]
     summary[/"SummaryDisplay"/]
-    equity_chart[/"MultiLineChart"/]
-    start --> broker --> split --> historical
-    broker --> historical
+    start --> broker --> historical
     historical --> rsi_cond --> bt_rsi --> benchmark
     historical --> boll_cond --> bt_boll --> benchmark
     benchmark --> summary
-    benchmark --> equity_chart
 ```
 
 ## Node List
@@ -37,15 +33,13 @@ graph LR
 |----|------|------|
 | start | StartNode | Workflow start |
 | broker | KoreaStockBrokerNode | Korea stock broker connection |
-| split | SplitNode | 2 symbols: 005930 (KOSPI) / 247540 (KOSDAQ) |
-| historical | KoreaStockHistoricalDataNode | 365-day adjusted daily OHLCV per symbol |
-| rsi_cond | ConditionNode (RSI) | RSI(14) < 30 signals |
+| historical | KoreaStockHistoricalDataNode | 365-day adjusted daily OHLCV for 005930 (single `symbol` object) |
+| rsi_cond | ConditionNode (RSI) | RSI(14) < 35 signals |
 | boll_cond | ConditionNode (BollingerBands) | 20/2.0 lower-band signals |
-| backtest_samsung_rsi | BacktestEngineNode | Samsung RSI mean-reversion (values[0]) |
-| backtest_kosdaq_bollinger | BacktestEngineNode | KOSDAQ Bollinger reversion (values[1]) |
+| backtest_rsi | BacktestEngineNode | Samsung RSI mean-reversion (`nodes.rsi_cond.values[0]`) |
+| backtest_bollinger | BacktestEngineNode | Samsung Bollinger reversion (`nodes.boll_cond.values[0]`) |
 | benchmark | BenchmarkCompareNode | Rank both strategies by Sharpe |
 | summary | SummaryDisplayNode | Ranking summary card |
-| equity_chart | MultiLineChartNode | Combined equity curves |
 
 ## Required Credentials
 
@@ -55,7 +49,8 @@ graph LR
 
 ## Notes
 
-- **allow_fractional=false**: Korean stocks trade in whole shares only.
-- **commission_rate 0.00015** approximates brokerage; the ~0.18% sell-side transaction tax is separate — raise commission_rate to a round-trip figure for a conservative backtest.
-- **adjust=true** applies split/dividend-adjusted prices for accurate long-term returns.
-- Signal mapping: the ConditionNode annotates each candle with `row.signal` (buy/sell) + `row.side`, consumed directly by the BacktestEngine. Each backtest reads its symbol's slice via `nodes.<cond>.values[i].time_series`.
+- **One historical, two strategies.** Both conditions read the same `{{ nodes.historical.value.time_series }}`, so only one chart fetch runs. Comparing *different* symbols would need one `KoreaStockHistoricalDataNode` per symbol, but Korean chart continuous-queries bypass the rate-limit wait — running two heavy fetches back-to-back in one session can make the second silently return 0 bars (live-observed). `KoreaStockHistoricalDataNode` also takes only a single `symbol` object (no array / SplitNode).
+- **Engine reads only 4 params.** BacktestEngineNode consumes `initial_capital`, `commission_rate`, `slippage`, `allow_short` only. `position_sizing` / `stop_loss` / `take_profit` / `time_stop` / `allow_fractional` etc. are NOT read by the current engine, so they are omitted (they would be silently ignored).
+- **Fractional shares.** Fill quantity is capital-proportional and comes out fractional — the engine does not round to whole shares, so Korea's whole-share rule is not modeled here.
+- **commission_rate 0.00015** approximates brokerage; the ~0.18% sell-side transaction tax is separate — raise commission_rate to a round-trip figure for a conservative backtest. **adjust=true** applies split/dividend-adjusted prices.
+- Signal mapping: the ConditionNode annotates each candle with `row.signal` (buy/sell) + `row.side`, consumed directly by the BacktestEngine (live-verified: 3 trades each, metrics + Sharpe ranking populated). Per-strategy equity curves live in each backtest node's `equity_curve` output.

--- a/src/programgarden/examples/workflows/97-korea-stock-code-node-composite.json
+++ b/src/programgarden/examples/workflows/97-korea-stock-code-node-composite.json
@@ -1,0 +1,71 @@
+{
+  "id": "97-korea-stock-code-node-composite",
+  "name": "국내주식 CodeNode 복합 지표 (RSI+볼린저%b+ATR)",
+  "description": "StartNode -> KoreaStockBrokerNode -> KoreaStockHistoricalDataNode(삼성전자 005930, 1d) -> CodeNode(stdlib만으로 Wilder RSI + Bollinger %b + ATR 손절/목표가를 손수 계산해 복합 매수 신호 산출) -> SummaryDisplayNode. RSI/Bollinger 플러그인 hand-roll 교육용 레퍼런스. 데이터 부족 시 status='insufficient_data', action='flat'. dry_run-safe.",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "StartNode",
+      "position": { "x": 50, "y": 200 }
+    },
+    {
+      "id": "broker",
+      "type": "KoreaStockBrokerNode",
+      "credential_id": "kr_broker_cred",
+      "position": { "x": 250, "y": 200 }
+    },
+    {
+      "id": "historical",
+      "type": "KoreaStockHistoricalDataNode",
+      "symbol": { "symbol": "005930" },
+      "start_date": "{{ date.ago(120, format='yyyymmdd') }}",
+      "end_date": "{{ date.today(format='yyyymmdd') }}",
+      "interval": "1d",
+      "adjust": true,
+      "position": { "x": 500, "y": 200 }
+    },
+    {
+      "id": "composite",
+      "type": "CodeNode",
+      "data": "{{ nodes.historical.value }}",
+      "params": {
+        "rsi_period": 14,
+        "bb_period": 20,
+        "atr_period": 14,
+        "rsi_oversold": 30,
+        "pctb_threshold": 0.1
+      },
+      "outputs": [
+        {
+          "name": "signal",
+          "type": "object"
+        }
+      ],
+      "code": "async def execute(data, params, context):\n    import statistics\n    rsi_p = int(params.get('rsi_period', 14))\n    bb_p = int(params.get('bb_period', 20))\n    atr_p = int(params.get('atr_period', 14))\n    rsi_os = float(params.get('rsi_oversold', 30))\n    pctb_th = float(params.get('pctb_threshold', 0.1))\n    payload = data if isinstance(data, dict) else {}\n    sym = payload.get('symbol')\n    if isinstance(sym, dict):\n        sym = sym.get('symbol')\n    rows = [r for r in (payload.get('time_series') or []) if isinstance(r, dict)]\n    closes = [r.get('close') for r in rows if r.get('close') is not None]\n    need = max(rsi_p, bb_p, atr_p) + 1\n    if len(closes) < need:\n        return {'signal': {'symbol': sym, 'status': 'insufficient_data', 'action': 'flat'}}\n    gains, losses = [], []\n    for i in range(1, len(closes)):\n        chg = closes[i] - closes[i - 1]\n        gains.append(max(chg, 0.0))\n        losses.append(max(-chg, 0.0))\n    avg_gain = statistics.fmean(gains[:rsi_p])\n    avg_loss = statistics.fmean(losses[:rsi_p])\n    for i in range(rsi_p, len(gains)):\n        avg_gain = (avg_gain * (rsi_p - 1) + gains[i]) / rsi_p\n        avg_loss = (avg_loss * (rsi_p - 1) + losses[i]) / rsi_p\n    rsi = 100.0 if avg_loss == 0 else 100.0 - 100.0 / (1.0 + avg_gain / avg_loss)\n    window = closes[-bb_p:]\n    mid = statistics.fmean(window)\n    sd = statistics.pstdev(window)\n    upper = mid + 2.0 * sd\n    lower = mid - 2.0 * sd\n    last = closes[-1]\n    pct_b = None if upper == lower else (last - lower) / (upper - lower)\n    trs = []\n    for i in range(1, len(rows)):\n        h = rows[i].get('high')\n        low = rows[i].get('low')\n        pc = rows[i - 1].get('close')\n        if h is None or low is None or pc is None:\n            continue\n        trs.append(max(h - low, abs(h - pc), abs(low - pc)))\n    atr = statistics.fmean(trs[-atr_p:]) if len(trs) >= atr_p else (statistics.fmean(trs) if trs else 0.0)\n    oversold = rsi < rsi_os and pct_b is not None and pct_b < pctb_th\n    action = 'buy' if oversold else 'flat'\n    stop = round(last - 2.0 * atr) if action == 'buy' else None\n    target = round(last + 3.0 * atr) if action == 'buy' else None\n    return {'signal': {\n        'symbol': sym,\n        'close': last,\n        'rsi': round(rsi, 2),\n        'percent_b': None if pct_b is None else round(pct_b, 3),\n        'atr': round(atr, 1),\n        'action': action,\n        'stop_price': stop,\n        'target_price': target,\n        'status': 'ok',\n    }}",
+      "position": { "x": 800, "y": 200 }
+    },
+    {
+      "id": "display",
+      "type": "SummaryDisplayNode",
+      "title": "삼성전자 복합 지표 신호",
+      "data": "{{ nodes.composite.signal }}",
+      "position": { "x": 1100, "y": 200 }
+    }
+  ],
+  "edges": [
+    { "from": "start", "to": "broker" },
+    { "from": "broker", "to": "historical" },
+    { "from": "historical", "to": "composite" },
+    { "from": "composite", "to": "display" }
+  ],
+  "credentials": [
+    {
+      "credential_id": "kr_broker_cred",
+      "type": "broker_ls_korea_stock",
+      "data": [
+        { "key": "appkey", "value": "", "type": "password", "label": "App Key" },
+        { "key": "appsecret", "value": "", "type": "password", "label": "App Secret" }
+      ]
+    }
+  ]
+}

--- a/src/programgarden/examples/workflows/97-korea-stock-code-node-composite.md
+++ b/src/programgarden/examples/workflows/97-korea-stock-code-node-composite.md
@@ -1,0 +1,46 @@
+# Korea Stock CodeNode Composite Indicator (RSI + Bollinger %b + ATR)
+
+Fetch Samsung Electronics (005930) daily bars, then hand-roll a composite entry signal in a CodeNode using stdlib only: Wilder RSI, Bollinger %b, and ATR-derived stop/target prices. Educational hand-roll reference for the RSI/Bollinger plugins.
+
+## Workflow Structure
+
+```mermaid
+graph LR
+    start(["Start"])
+    broker(["Broker
+(Korea Stock)"])
+    historical["Historical
+(Korea Stock)"]
+    composite["CodeNode
+(composite signal)"]
+    display[/"SummaryDisplay"/]
+    start --> broker
+    broker --> historical
+    historical --> composite
+    composite --> display
+```
+
+## Node List
+
+| ID | Type | Description |
+|----|------|------|
+| start | StartNode | Workflow start |
+| broker | KoreaStockBrokerNode | Korea stock broker connection |
+| historical | KoreaStockHistoricalDataNode | 120-day adjusted daily OHLCV (005930) |
+| composite | CodeNode | Wilder RSI + Bollinger %b + ATR stop/target → composite buy signal |
+| display | SummaryDisplayNode | Signal summary card |
+
+## Required Credentials
+
+| ID | Type | Description |
+|----|------|------|
+| kr_broker_cred | broker_ls_korea_stock | LS Securities Korea Stock API |
+
+## CodeNode Contract
+
+- **Input** `data` = `{{ nodes.historical.value }}` → `{symbol, time_series: [{date, open, high, low, close, volume}, ...]}`.
+- **params**: `rsi_period` (14), `bb_period` (20), `atr_period` (14), `rsi_oversold` (30), `pctb_threshold` (0.1).
+- **Output** `signal` (object): `{symbol, close, rsi, percent_b, atr, action, stop_price, target_price, status}`.
+- **Guards**: fewer than `max(period)+1` candles → `status='insufficient_data'`, `action='flat'`. Degenerate (zero-width) Bollinger band → `percent_b=None`.
+- **Signal logic**: `action='buy'` when `rsi < rsi_oversold` AND `percent_b < pctb_threshold`; stop = close − 2·ATR, target = close + 3·ATR (rounded to whole KRW).
+- stdlib only (`statistics`), dry_run-safe.

--- a/src/programgarden/programgarden/deep_fixtures.py
+++ b/src/programgarden/programgarden/deep_fixtures.py
@@ -318,6 +318,47 @@ def real_order_event_fixture(config: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def futures_contract_fixture(config: Dict[str, Any]) -> Dict[str, Any]:
+    """FuturesContractNode deep fixture (no o3101 master query).
+
+    Real shape: ``{"symbols": [{exchange, symbol}], "contracts": [...], "count": int}``.
+
+    The month code is derived from the fixture anchor, not the wall clock, so a deep
+    run is reproducible. The *symbol string* is therefore not a real listed contract —
+    that is fine and deliberate: deep_validate checks field/type/flow integrity, and
+    downstream fixtures key off the symbol string only as an opaque identifier.
+    """
+    raw = config.get("base_products") or []
+    if isinstance(raw, str):
+        raw = [p.strip() for p in raw.split(",") if p.strip()]
+    products = [str(p).strip().upper() for p in raw if str(p).strip()] or ["HMH"]
+    exchange = str(config.get("futures_exchange") or "HKEX").strip().upper() or "HKEX"
+
+    # 월물 문자 코드 (F=1월 … Z=12월) — 실제 노드와 같은 표기를 쓴다.
+    month_letters = "FGHJKMNQUVXZ"
+    month = _FIXTURE_ANCHOR.month
+    letter = month_letters[month - 1]
+    yy = _FIXTURE_ANCHOR.strftime("%y")
+
+    contracts: List[Dict[str, Any]] = []
+    for product in products:
+        contracts.append(
+            {
+                "symbol": f"{product}{letter}{yy}",
+                "exchange": exchange,
+                "base_product": product,
+                "base_product_name": product,
+                "name": f"{product}({_FIXTURE_ANCHOR.year}.{month:02d})",
+                "contract_month": f"{_FIXTURE_ANCHOR.year:04d}-{month:02d}",
+            }
+        )
+    return {
+        "symbols": [{"exchange": c["exchange"], "symbol": c["symbol"]} for c in contracts],
+        "contracts": contracts,
+        "count": len(contracts),
+    }
+
+
 def market_status_fixture(config: Dict[str, Any]) -> Dict[str, Any]:
     """MarketStatusNode deep fixture (markets open).
 

--- a/src/programgarden/programgarden/deep_fixtures.py
+++ b/src/programgarden/programgarden/deep_fixtures.py
@@ -332,13 +332,29 @@ def futures_contract_fixture(config: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(raw, str):
         raw = [p.strip() for p in raw.split(",") if p.strip()]
     products = [str(p).strip().upper() for p in raw if str(p).strip()] or ["HMH"]
-    exchange = str(config.get("futures_exchange") or "HKEX").strip().upper() or "HKEX"
+
+    # 거래소는 ExchCd 로 정규화한다. config 값을 그대로 되뱉으면, 형제 노드의 enum('6')을
+    # 넣은 워크플로우가 게이트를 통과한 뒤 첫 라이브 실행에서만 죽는다 — 게이트의 존재 이유가 없어진다.
+    _ENUM_TO_EXCHCD = {"1": "", "2": "CME", "3": "SGX", "4": "EUREX", "5": "ICE", "6": "HKEX", "7": "OSE"}
+    exchange = str(config.get("futures_exchange") or "").strip().upper()
+    exchange = _ENUM_TO_EXCHCD.get(exchange, exchange) or "HKEX"
 
     # 월물 문자 코드 (F=1월 … Z=12월) — 실제 노드와 같은 표기를 쓴다.
+    # contract_selection 을 실제 노드와 같은 규칙으로 반영한다(front=당월, next=익월,
+    # quarterly=3·6·9·12월 중 최근접). fixture 가 이걸 무시하면 세 설정이 같은 심볼을 내
+    # 배선 검증이 selection 오류를 못 잡는다.
     month_letters = "FGHJKMNQUVXZ"
+    selection = str(config.get("contract_selection") or "front").strip().lower()
     month = _FIXTURE_ANCHOR.month
+    if selection == "next":
+        month += 1
+    elif selection == "quarterly":
+        while month % 3:
+            month += 1
+    year = _FIXTURE_ANCHOR.year + (month - 1) // 12
+    month = (month - 1) % 12 + 1
     letter = month_letters[month - 1]
-    yy = _FIXTURE_ANCHOR.strftime("%y")
+    yy = f"{year % 100:02d}"
 
     contracts: List[Dict[str, Any]] = []
     for product in products:
@@ -348,8 +364,8 @@ def futures_contract_fixture(config: Dict[str, Any]) -> Dict[str, Any]:
                 "exchange": exchange,
                 "base_product": product,
                 "base_product_name": product,
-                "name": f"{product}({_FIXTURE_ANCHOR.year}.{month:02d})",
-                "contract_month": f"{_FIXTURE_ANCHOR.year:04d}-{month:02d}",
+                "name": f"{product}({year}.{month:02d})",
+                "contract_month": f"{year:04d}-{month:02d}",
             }
         )
     return {

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -1509,20 +1509,27 @@ class MarketUniverseNodeExecutor(NodeExecutorBase):
     MarketUniverseNode executor - 대표지수 종목
 
     ⚠️ 해외주식(overseas_stock) 전용 노드입니다. 해외선물은 지원하지 않습니다.
-    
+
+    거래소 라벨은 반드시 LS 가 아는 미국 원장(NASDAQ/NYSE/AMEX)이어야 한다 —
+    하류 MarketData/주문 노드의 EXCHANGE_CODES 가 이 라벨로 거래소 코드를 정하고,
+    모르는 라벨은 조용히 NASDAQ(82)으로 폴백해 종목을 무음 유실시키기 때문이다.
+
     pytickersymbols 라이브러리를 활용하여 미국 대표지수 구성종목을 조회합니다.
     Broker 연결 없이 독립적으로 실행됩니다.
-    
+
     지원 인덱스 (LS증권 거래 가능 거래소):
     - NASDAQ 100 (~101개)
     - S&P 500 (~503개)
     - S&P 100
     - DOW JONES (다우존스 30)
-    
+
     Note: pytickersymbols는 유럽/아시아 인덱스도 지원하지만,
           LS증권에서 거래 가능한 미국 인덱스만 권장합니다.
     """
-    
+
+    # LS 가 조회/주문할 수 있는 미국 원장. google 접두사가 이 안에 있어야 채택한다.
+    US_EXCHANGES = {"NASDAQ", "NYSE", "AMEX"}
+
     # 인덱스별 심볼 캐시 (앱 실행 중 재사용)
     _cache: Dict[str, List[Dict[str, str]]] = {}
     _cache_time: Dict[str, float] = {}
@@ -1623,26 +1630,31 @@ class MarketUniverseNodeExecutor(NodeExecutorBase):
                 if not symbol:
                     continue
                 
-                # 거래소 정보 추출 (있으면 사용, 없으면 기본값)
+                # 거래소 결정 — `google` 접두사가 실제 상장 거래소다 ("NASDAQ:AMGN", "NYSE:MMM").
+                #
+                # 예전엔 symbols 배열의 **첫 항목**만 보고 yahoo 접미사로 힌트를 뽑은 뒤 break 했다.
+                # pytickersymbols 는 해외 상장분을 첫 자리에 두는 경우가 많아(AMGN → "AMG.F"),
+                # DOW30 30종목 중 29개가 FRA(프랑크푸르트)로 오염됐다. 그리고 하류
+                # EXCHANGE_CODES 는 FRA 를 몰라 조용히 82(NASDAQ)로 폴백 → 진짜 NYSE 종목이
+                # 무음 유실됐다(실측: 예제 08 이 회당 30종목 중 8건만 수신).
                 exchange = default_exchange
-                stock_symbols = stock.get("symbols", [])
-                for sym_info in stock_symbols:
-                    if sym_info.get("yahoo"):
-                        # yahoo 심볼에서 거래소 힌트 추출 가능
-                        yahoo_sym = sym_info.get("yahoo", "")
-                        if "." in yahoo_sym:
-                            # 예: "7203.T" → 도쿄 거래소
-                            suffix = yahoo_sym.split(".")[-1]
-                            exchange_hints = {
-                                "T": "TSE",  # Tokyo
-                                "L": "LSE",  # London
-                                "PA": "EPA",  # Paris
-                                "DE": "FRA",  # Frankfurt
-                                "F": "FRA",
-                            }
-                            exchange = exchange_hints.get(suffix, exchange)
+                resolved_exchange = ""
+                for sym_info in (stock.get("symbols") or []):
+                    google_sym = (sym_info.get("google") or "").strip()
+                    if ":" not in google_sym:
+                        continue
+                    prefix = google_sym.split(":", 1)[0].strip().upper()
+                    if prefix not in self.US_EXCHANGES:
+                        continue
+                    # USD 상장분이 곧 LS 가 조회할 미국 원장이다 — 있으면 최우선.
+                    if (sym_info.get("currency") or "").strip().upper() == "USD":
+                        resolved_exchange = prefix
                         break
-                
+                    resolved_exchange = resolved_exchange or prefix
+
+                if resolved_exchange:
+                    exchange = resolved_exchange
+
                 symbols.append({
                     "exchange": exchange,
                     "symbol": symbol,
@@ -8961,6 +8973,12 @@ class MarketDataNodeExecutor(NodeExecutorBase):
         "AMEX": "81",
     }
 
+    # 거래소 라벨이 미지일 때 두 원장을 시도한 뒤, 응답한 코드를 라벨로 되돌리는 역매핑.
+    CODE_EXCHANGES = {
+        "82": "NASDAQ",
+        "81": "NYSE",
+    }
+
     async def execute(
         self,
         node_id: str,
@@ -8978,21 +8996,40 @@ class MarketDataNodeExecutor(NodeExecutorBase):
         # (dict/list 완전 재귀)를 직접 호출해야 한다. (형제 executor 패턴과 동일)
         config = evaluate_all_bindings(config, context, node_id)
 
-        # 입력 symbols 가져오기 (포트 또는 config에서 명시적 입력 필수)
+        # symbols 획득 — 우선순위: config.symbol(단수) > input.symbols > config.symbols
+        #
+        # 단수 config.symbol 을 먼저 보는 이유: 상류 배열 입력이 있으면 메인 루프가 이 노드를
+        # auto-iterate 로 종목당 1회씩 돌리며 {{ item }} 을 해당 종목으로 해소한다
+        # (_execute_with_auto_iterate). 그런데 여기서 input.symbols(=전체 배열)를 먼저 읽으면
+        # 매 iteration 이 다시 전 종목을 조회해 N종목 × N회 = N² 중복이 된다
+        # (실측: 예제 07 4종목→16건 / 10 5종목→25건 / 08 30종목→LS 폭주 후 job cancelled).
+        # HistoricalDataNodeExecutor 는 이미 단수 우선이라 정상이었다(~9575) — 그 패턴에 맞춘다.
+        config_symbol = config.get("symbol")
+        if isinstance(config_symbol, str):
+            # LLM Tool 경로에서 JSON 문자열로 오는 경우 (형제 executor 와 동일 방어)
+            import json as _json
+            try:
+                _parsed = _json.loads(config_symbol)
+                config_symbol = _parsed if isinstance(_parsed, dict) else None
+            except (ValueError, _json.JSONDecodeError):
+                config_symbol = None
+
         input_symbols = context.get_output(f"_input_{node_id}", "symbols")
         config_symbols = config.get("symbols")
-        symbols = input_symbols or config_symbols
+
+        if isinstance(config_symbol, dict) and config_symbol.get("symbol"):
+            symbols = [config_symbol]
+        else:
+            symbols = input_symbols or config_symbols
 
         # deep_validate: MarketDataNode (REST current-price) would ensure_ls_login
         # unconditionally. Inject a fixture so the flow completes without a
         # network call, derived from the requested symbols.
         if context.is_deep_validate:
             from programgarden import deep_fixtures as _df
-            # Evaluate own config bindings (e.g. symbols/symbol) before the fixture
-            # short-circuit so a wrong binding here is still surfaced.
-            config = evaluate_all_bindings(config, context, node_id)
-            _deep_symbols = input_symbols or config.get("symbols") or config.get("symbol")
-            fixture = _df.market_data_fixture(config, _deep_symbols)
+            # 실경로와 **같은** symbols 를 쓴다. 예전엔 여기만 단수 symbol 폴백을 갖고 있어
+            # deep_validate 는 초록인데 라이브만 다르게 도는 상태였다(게이트가 거짓말함).
+            fixture = _df.market_data_fixture(config, symbols)
             override = context.get_deep_fixture(node_id, node_type)
             return _df.apply_override(fixture, override)
 
@@ -9070,28 +9107,44 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                         continue
                     
                     # 거래소 코드 변환 (81: NYSE/AMEX, 82: NASDAQ)
-                    exchange_code = self.EXCHANGE_CODES.get(exchange.upper(), "82")
-                    
-                    # KEY종목코드 생성 (거래소코드 + 심볼, 예: "82AAPL")
-                    keysymbol = f"{exchange_code}{symbol}"
-                    
-                    # g3101 현재가 조회
-                    body = G3101InBlock(
-                        keysymbol=keysymbol,
-                        exchcd=exchange_code,
-                        symbol=symbol,
-                    )
-                    
-                    response = api.market().g3101(body=body).req()
-                    
+                    # 라벨이 EXCHANGE_CODES 에 없을 때 조용히 82 로 떨어뜨리면 NYSE 종목이
+                    # "No data" 로 무음 유실된다(실측: 예제 08 이 30종목 중 8건만 수신).
+                    # 미지 라벨은 두 원장을 순서대로 시도하고, 성공한 쪽을 실제 거래소로 기록한다.
+                    known_code = self.EXCHANGE_CODES.get(exchange.upper())
+                    candidate_codes = [known_code] if known_code else ["82", "81"]
+
+                    response = None
+                    used_code = None
+                    for exchange_code in candidate_codes:
+                        # KEY종목코드 생성 (거래소코드 + 심볼, 예: "82AAPL")
+                        keysymbol = f"{exchange_code}{symbol}"
+
+                        # g3101 현재가 조회
+                        body = G3101InBlock(
+                            keysymbol=keysymbol,
+                            exchcd=exchange_code,
+                            symbol=symbol,
+                        )
+
+                        response = api.market().g3101(body=body).req()
+                        if response and response.block:
+                            used_code = exchange_code
+                            break
+
                     if response and response.block:
                         out_block = response.block
                         from datetime import datetime
-                        
+
+                        # 라벨이 미지였다면 실제로 응답한 원장으로 정정해 하류(주문 노드 등)가
+                        # 같은 거래소를 쓰게 한다.
+                        resolved_exchange = exchange if known_code else self.CODE_EXCHANGES.get(
+                            used_code, exchange
+                        )
+
                         # values 배열에 단일 항목 추가
                         values.append({
                             "symbol": symbol,
-                            "exchange": exchange,
+                            "exchange": resolved_exchange,
                             "price": float(out_block.price or 0),
                             "change": float(out_block.diff or 0),
                             "change_pct": float(out_block.rate or 0),
@@ -17196,44 +17249,66 @@ class WorkflowJob:
                 # === 자동 iterate 체크 ===
                 # 입력 데이터가 배열이고, 노드가 단일 아이템을 기대하면 자동으로 각 아이템마다 실행
                 input_data = None
+                # auto-iterate 소스 선택 — incoming 엣지를 **전부** 훑어 우선순위로 고른다.
+                # 예전엔 첫 매칭 엣지에서 무조건 break 해서 **엣지 선언 순서가 소스를 결정**했다:
+                #  - 예제 16/28 은 account 엣지가 먼저라 sizing 이 **계좌 보유종목**을 순회했다
+                #    (실측: 워크플로우 어디에도 없는 AUID 를 매수 후보로 처리 — 잔고가 충분했다면
+                #     보유종목에 실제 주문이 나갔다).
+                #  - 예제 28 은 `logic.passed_symbols` 를 올바로 명시했는데도 앞선 account 엣지의
+                #    break 에 가려 아래 explicit 분기까지 도달조차 못 했다.
+                # 우선순위: 명시 from_port > symbols 포트 > 소스 노드 첫 출력.
+                explicit_data = None
+                symbols_data = None
+                fallback_data = None
+
                 for edge in self.workflow.edges:
-                    if edge.to_node_id == node_id:
-                        # 명시적 from_port 우선 (예: ExclusionListNode.filtered).
-                        # 이를 지정하지 않으면 auto-iterate 는 소스 노드의 첫 출력
-                        # 포트를 집어버린다 — ExclusionListNode 는 첫 포트가
-                        # `excluded`(블랙리스트)라서, from_port 없이는 제외 종목을
-                        # 순회하게 되는 silent 버그가 생긴다. IfNode 분기 포트
-                        # (true/false/result)는 별도 라우팅 의미라 여기서 제외.
-                        explicit_port = getattr(edge, "from_port", None)
-                        if explicit_port and explicit_port not in (
-                            "output", "true", "false", "result",
-                        ):
-                            port_data = self.context.get_output(
-                                edge.from_node_id, explicit_port
-                            )
-                            if port_data is not None:
-                                input_data = port_data
-                                break
+                    if edge.to_node_id != node_id:
+                        continue
 
-                        # symbols 포트 우선 확인 (WatchlistNode 출력)
-                        input_data = self.context.get_output(edge.from_node_id, "symbols")
+                    # 1순위: 명시적 from_port (예: ExclusionListNode.filtered,
+                    # LogicNode.passed_symbols). IfNode 분기 포트(true/false/result)는
+                    # 라우팅 의미라 소스에서 제외.
+                    explicit_port = getattr(edge, "from_port", None)
+                    if explicit_port and explicit_port not in (
+                        "output", "true", "false", "result",
+                    ):
+                        port_data = self.context.get_output(
+                            edge.from_node_id, explicit_port
+                        )
+                        if port_data is not None and explicit_data is None:
+                            explicit_data = port_data
 
+                    # 2순위: symbols 포트 (Watchlist/MarketUniverse/SymbolFilter 등 배열 생성 노드)
+                    if symbols_data is None:
+                        port_symbols = self.context.get_output(edge.from_node_id, "symbols")
                         # symbols가 문자열 배열이면 (merge 후) value 포트로 폴백
                         # - WatchlistNode symbols: [{exchange, symbol}, ...] → dict 배열 → 그대로 사용
                         # - HistoricalDataNode merged symbols: ["TSLA"] → string 배열 → value 포트로 전환
-                        if (isinstance(input_data, list) and input_data
-                                and not isinstance(input_data[0], dict)):
+                        if (isinstance(port_symbols, list) and port_symbols
+                                and not isinstance(port_symbols[0], dict)):
                             value_data = self.context.get_output(edge.from_node_id, "value")
                             if value_data is not None:
                                 if isinstance(value_data, list):
-                                    input_data = value_data
+                                    port_symbols = value_data
                                 elif isinstance(value_data, dict):
-                                    input_data = [value_data]
+                                    port_symbols = [value_data]
+                        if port_symbols is not None:
+                            symbols_data = port_symbols
 
-                        if input_data is None:
-                            # 기본 출력 확인
-                            input_data = self.context.get_output(edge.from_node_id, None)
-                        break
+                    # 3순위: 소스 노드의 첫 출력. 단 계좌 노드는 제외한다 —
+                    # 첫 포트가 `positions`(보유잔고)라 매수 후보로 오인된다.
+                    if fallback_data is None:
+                        from_node = self.workflow.nodes.get(edge.from_node_id)
+                        from_type = getattr(from_node, "node_type", None) if from_node else None
+                        if from_type not in self.NO_ITERATE_SOURCE_NODE_TYPES:
+                            fallback_data = self.context.get_output(edge.from_node_id, None)
+
+                if explicit_data is not None:
+                    input_data = explicit_data
+                elif symbols_data is not None:
+                    input_data = symbols_data
+                else:
+                    input_data = fallback_data
 
                 should_iterate, port_name, items = self._should_auto_iterate(node.node_type, input_data)
 
@@ -17417,11 +17492,26 @@ class WorkflowJob:
         "WatchlistNode", "MarketUniverseNode", "ScreenerNode",  # 배열 생성 노드
         "ExclusionListNode",  # 제외 종목 관리 노드 (배열 생성)
         "SymbolFilterNode",  # 집합 연산 노드 (배열 입력/출력)
+        # LogicNode 도 집합 연산 노드다 — 상류 조건 결과 **배열 전체**를 AND/OR 해야 한다.
+        # 종목별로 쪼개 N회 돌면 매 회가 전체 passed_symbols 를 다시 내보내 병합 시 N² 가 된다
+        # (실측: 28 이 5종목인데 logic.passed_symbols 25건 → sizing 이 중복 25건을 순회).
+        "LogicNode",
         "OverseasStockAccountNode", "OverseasFuturesAccountNode",  # 계좌 노드
         "OverseasStockRealAccountNode", "OverseasFuturesRealAccountNode",
+        "KoreaStockAccountNode", "KoreaStockRealAccountNode",
         "SQLiteNode", "HTTPRequestNode",  # 데이터 노드
         "CodeNode",  # custom code: receives the whole array in `data`, loops in-code (one subprocess call)
         "BacktestEngineNode", "BenchmarkCompareNode",  # 분석 노드
+    }
+
+    # auto-iterate 의 **소스**가 되어선 안 되는 노드 (그 노드 자신의 iterate 여부와 무관).
+    # 계좌 노드의 첫 출력 포트는 `positions`(보유잔고)다. 이게 폴백 소스로 잡히면
+    # 하류가 **보유종목을 신규 매수 후보로 순회**한다 — 실주문 위험. 종목 후보는
+    # Watchlist/Universe/SymbolFilter/Condition 같은 배열 생성 노드에서만 와야 한다.
+    NO_ITERATE_SOURCE_NODE_TYPES = {
+        "AccountNode", "RealAccountNode",
+        "OverseasStockAccountNode", "OverseasFuturesAccountNode", "KoreaStockAccountNode",
+        "OverseasStockRealAccountNode", "OverseasFuturesRealAccountNode", "KoreaStockRealAccountNode",
     }
 
     def _should_auto_iterate(self, node_type: str, input_data: Any) -> tuple:
@@ -17535,7 +17625,12 @@ class WorkflowJob:
             return {}
 
         merged = {}
-        array_fields = {"value", "values", "items", "data", "result", "results", "passed_symbols", "failed_symbols"}
+        # 배열로 병합할 포트. `symbols`/`symbol_results` 가 빠져 있어 auto-iterate N회 중
+        # **마지막 1회만 살아남았다**(실측: 28 의 logic 이 5종목 중 1건만 받음).
+        array_fields = {
+            "value", "values", "items", "data", "result", "results",
+            "passed_symbols", "failed_symbols", "symbols", "symbol_results",
+        }
 
         for key in results[0].keys():
             if key in array_fields:

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -2607,13 +2607,36 @@ class SymbolQueryNodeExecutor(NodeExecutorBase):
             )
 
             result = await query.req_async()
+            rows = list(getattr(result, 'block', None) or [])
 
-            wanted_exchange = self.FUTURES_EXCHANGE_CODES.get(futures_exchange, futures_exchange)
-            if wanted_exchange in ("1", "", "ALL"):
-                wanted_exchange = ""  # 전체
+        except Exception as e:
+            context.log("error", f"o3101 API error: {str(e)}", node_id)
+            return {"symbols": [], "count": 0, "error": str(e)}
 
-            if result and hasattr(result, 'block') and result.block:
-                for item in result.block:
+        wanted_exchange = self.FUTURES_EXCHANGE_CODES.get(futures_exchange, futures_exchange)
+        if wanted_exchange in ("1", "", "ALL"):
+            wanted_exchange = ""  # 전체
+
+        listed_exchanges = sorted({
+            (getattr(item, 'ExchCd', '') or '').strip().upper() for item in rows
+        } - {""})
+
+        # 요청한 거래소가 이 계좌의 마스터에 아예 없으면 **조용히 빈 배열을 주지 않는다**.
+        # 빈 유니버스는 하류를 전부 no-op 시키고 워크플로우는 '성공'한 척 아무것도 안 한다 —
+        # 이 저장소가 없애려는 바로 그 무음 실패다. 무엇을 쓸 수 있는지 알려주고 실패한다.
+        # (해외선물 권한은 거래소별이라, 이 계좌에 없는 거래소를 고르면 여기서 걸린다.)
+        if wanted_exchange and rows and wanted_exchange not in listed_exchanges:
+            raise RuntimeError(
+                f"OverseasFuturesSymbolQueryNode[{node_id}]: exchange '{wanted_exchange}' "
+                f"(futures_exchange={futures_exchange!r}) has no contracts in this account's LS "
+                f"master. LS currently lists: {', '.join(listed_exchanges) or '(none)'}. "
+                f"Overseas-futures entitlement is per exchange — check the account, or use "
+                f"futures_exchange='1' for all exchanges."
+            )
+
+        try:
+            if rows:
+                for item in rows:
                     exchcd = (getattr(item, 'ExchCd', '') or '').strip().upper()
                     if wanted_exchange and exchcd != wanted_exchange:
                         continue
@@ -2807,7 +2830,15 @@ class FuturesContractNodeExecutor(NodeExecutorBase):
         base_products = [str(p).strip().upper() for p in base_products if str(p).strip()]
 
         selection = str(config.get("contract_selection") or "front").strip().lower()
+        # 거래소는 ExchCd('HKEX')로 받는다. 다만 형제 노드(OverseasFuturesSymbolQueryNode)는
+        # 같은 이름의 필드를 enum('6'=HKEX)으로 쓴다 — LLM/사용자가 그 값을 그대로 넣어도
+        # 죽지 않도록 여기서 흡수한다.
         exchange_filter = (config.get("futures_exchange") or "").strip().upper()
+        exchange_filter = SymbolQueryNodeExecutor.FUTURES_EXCHANGE_CODES.get(
+            exchange_filter, exchange_filter
+        )
+        if exchange_filter in ("1", "ALL"):
+            exchange_filter = ""  # 전체
 
         if not base_products:
             raise RuntimeError(
@@ -2880,7 +2911,19 @@ class FuturesContractNodeExecutor(NodeExecutorBase):
                 f"many requests are sharing this app key at once."
             )
 
-        listed = self._parse_master(rows, exchange_filter)
+        # 거래소 필터를 걸기 **전** 목록도 들고 있는다 — 실패 메시지의 "쓸 수 있는 코드" 를
+        # 필터 뒤 목록에서 뽑으면, 거래소를 잘못 골랐을 때 "LS 에 아무것도 없다" 로 읽혀
+        # 진짜 원인(거래소 오지정)을 가린다.
+        unfiltered = self._parse_master(rows, "")
+        listed = [c for c in unfiltered if not exchange_filter or c["exchange"] == exchange_filter]
+
+        if exchange_filter and not listed and unfiltered:
+            raise RuntimeError(
+                f"FuturesContractNode[{node_id}]: exchange '{exchange_filter}' has no listed "
+                f"contracts in this account's LS master. LS currently lists: "
+                f"{', '.join(sorted({c['exchange'] for c in unfiltered}))}. "
+                f"Leave futures_exchange empty to search every exchange."
+            )
 
         available = sorted({c["base_product"] for c in listed})
         contracts: List[Dict[str, Any]] = []

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -9107,11 +9107,19 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                         continue
                     
                     # 거래소 코드 변환 (81: NYSE/AMEX, 82: NASDAQ)
-                    # 라벨이 EXCHANGE_CODES 에 없을 때 조용히 82 로 떨어뜨리면 NYSE 종목이
-                    # "No data" 로 무음 유실된다(실측: 예제 08 이 30종목 중 8건만 수신).
-                    # 미지 라벨은 두 원장을 순서대로 시도하고, 성공한 쪽을 실제 거래소로 기록한다.
+                    # 라벨을 조용히 82 로 떨어뜨리면 NYSE 종목이 "No data" 로 무음 유실된다
+                    # (실측: 예제 08 이 30종목 중 8건만 수신).
+                    #
+                    # 라벨이 정확해도 첫 시도가 실패하면 다른 원장을 재시도한다 — LS 의 거래소
+                    # 코드는 실제 상장 거래소와 항상 일치하지 않는다(실측: WMT 는 NYSE 상장인데
+                    # 81 로는 응답이 없고 82 로만 조회된다). 성공한 코드를 실제 거래소로 기록한다.
                     known_code = self.EXCHANGE_CODES.get(exchange.upper())
-                    candidate_codes = [known_code] if known_code else ["82", "81"]
+                    if known_code:
+                        candidate_codes = [known_code] + [
+                            c for c in ("82", "81") if c != known_code
+                        ]
+                    else:
+                        candidate_codes = ["82", "81"]
 
                     response = None
                     used_code = None
@@ -9135,11 +9143,13 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                         out_block = response.block
                         from datetime import datetime
 
-                        # 라벨이 미지였다면 실제로 응답한 원장으로 정정해 하류(주문 노드 등)가
-                        # 같은 거래소를 쓰게 한다.
-                        resolved_exchange = exchange if known_code else self.CODE_EXCHANGES.get(
-                            used_code, exchange
-                        )
+                        # 라벨대로 조회에 성공했으면 그대로 둔다(AMEX 처럼 81 을 공유하는 라벨이
+                        # NYSE 로 덮이지 않게). 다른 원장으로 성공했을 때만 실제 응답한 거래소로
+                        # 정정해 하류(주문 노드 등)가 같은 거래소를 쓰게 한다.
+                        if known_code and used_code == known_code:
+                            resolved_exchange = exchange
+                        else:
+                            resolved_exchange = self.CODE_EXCHANGES.get(used_code, exchange)
 
                         # values 배열에 단일 항목 추가
                         values.append({

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -9017,8 +9017,18 @@ class MarketDataNodeExecutor(NodeExecutorBase):
         input_symbols = context.get_output(f"_input_{node_id}", "symbols")
         config_symbols = config.get("symbols")
 
+        # auto-iterate 중이라면 **이번 아이템 1건만** 조회한다. 여기서 _input_.symbols(=상류가
+        # 넘긴 전체 배열)를 읽으면 iteration 마다 전 종목을 재조회해 N² 가 된다.
+        # `{{ item }}` 리터럴이 있으면 config.symbol 로 들어오지만, 노드 가이드가 권장하는
+        # "Watchlist → MarketData" 배선(리터럴 없이 엣지만)에는 config.symbol 이 없다 —
+        # 그 모양이 곧 챗봇 산출물이라 리터럴 유무와 무관하게 iteration 컨텍스트로 막는다.
+        # (실측: 리터럴 없는 3종목 배선이 values 9건 = 3²)
+        iteration_item = getattr(context, "_iteration_item", None)
+
         if isinstance(config_symbol, dict) and config_symbol.get("symbol"):
             symbols = [config_symbol]
+        elif isinstance(iteration_item, dict) and iteration_item.get("symbol"):
+            symbols = [iteration_item]
         else:
             symbols = input_symbols or config_symbols
 

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -2594,28 +2594,43 @@ class SymbolQueryNodeExecutor(NodeExecutorBase):
         if not success:
             return {"symbols": [], "count": 0, "error": error}
         
-        futures_exchange = config.get("futures_exchange", "1")  # 1: 전체
+        futures_exchange = str(config.get("futures_exchange", "1") or "1")  # 1: 전체
         futures_contract_month = config.get("futures_contract_month", "")  # 월물 필터
-        
+
         all_symbols = []
-        
+
         try:
+            # gubun 은 거래소 필터가 **아니다** — 실측: 0/1/2/6 어느 값이든 같은 전체 목록을 준다.
+            # 거래소 좁히기는 응답의 ExchCd 로 클라이언트에서 한다(아래). gubun 은 "0" 고정.
             query = ls.overseas_futureoption().market().해외선물마스터조회(
-                body=o3101.O3101InBlock(gubun=futures_exchange)
+                body=o3101.O3101InBlock(gubun="0")
             )
-            
+
             result = await query.req_async()
-            
+
+            wanted_exchange = self.FUTURES_EXCHANGE_CODES.get(futures_exchange, futures_exchange)
+            if wanted_exchange in ("1", "", "ALL"):
+                wanted_exchange = ""  # 전체
+
             if result and hasattr(result, 'block') and result.block:
                 for item in result.block:
-                    # 거래소 코드 → 이름 매핑
-                    exchcd = getattr(item, 'ExchCd', '')
-                    exchange_name = getattr(item, 'ExchNm', '') or self._futures_exchcd_to_name(exchcd)
+                    exchcd = (getattr(item, 'ExchCd', '') or '').strip().upper()
+                    if wanted_exchange and exchcd != wanted_exchange:
+                        continue
+
                     contract_month = f"{getattr(item, 'LstngYr', '')}{getattr(item, 'LstngM', '')}"
-                    
+                    # 만기 경과 월물 제외 — LS 는 만기 지난 종목에 시세도 과거봉도 주지 않고
+                    # 에러도 내지 않는다(빈 배열). 그런 종목이 하류로 새면 워크플로우가 조용히 죽는다.
+                    if self._is_expired_contract(getattr(item, 'LstngYr', ''), getattr(item, 'LstngM', '')):
+                        continue
+
                     all_symbols.append({
-                        "exchange": exchange_name,
+                        # exchange 는 **레지스트리 거래소 코드**(HKEX 등)여야 한다. LS 의 ExchNm 은
+                        # 한글 거래소명('홍콩거래소')이라, 그대로 실으면 주문 노드가 그 한글을
+                        # ExchCode 파라미터로 전송해 주문이 깨진다. 한글명은 exchange_name 으로 분리.
+                        "exchange": exchcd,
                         "exchange_code": exchcd,
+                        "exchange_name": getattr(item, 'ExchNm', '') or self._futures_exchcd_to_name(exchcd),
                         "symbol": getattr(item, 'Symbol', ''),
                         "name": getattr(item, 'SymbolNm', ''),
                         "base_product": getattr(item, 'BscGdsCd', ''),
@@ -2623,11 +2638,11 @@ class SymbolQueryNodeExecutor(NodeExecutorBase):
                         "currency": getattr(item, 'CrncyCd', ''),
                         "contract_month": contract_month,
                     })
-            
+
             # 월물 필터링 적용
             if futures_contract_month:
                 all_symbols = self._filter_by_contract_month(all_symbols, futures_contract_month)
-                    
+
         except Exception as e:
             context.log("error", f"o3101 API error: {str(e)}", node_id)
             return {"symbols": [], "count": 0, "error": str(e)}
@@ -2655,6 +2670,36 @@ class SymbolQueryNodeExecutor(NodeExecutorBase):
         }
         return mapping.get(exchcd, exchcd)
     
+    # 노드 스키마의 거래소 enum(1~7) → o3101 응답의 ExchCd.
+    # o3101 의 gubun 입력은 거래소 필터가 아니므로(실측), 좁히기는 이 표로 클라이언트에서 한다.
+    FUTURES_EXCHANGE_CODES = {
+        "1": "",        # 전체
+        "2": "CME",
+        "3": "SGX",
+        "4": "EUREX",
+        "5": "ICE",
+        "6": "HKEX",
+        "7": "OSE",
+    }
+
+    def _is_expired_contract(self, year_raw: str, month_raw: str) -> bool:
+        """만기가 지난 월물인가 (현재 연-월보다 이른가)."""
+        year_raw = (year_raw or "").strip()
+        month_raw = (month_raw or "").strip().upper()
+        if not year_raw or not month_raw:
+            return False  # 판정 불가 — 버리지 않는다
+        month = FUTURES_MONTH_CODES.get(month_raw)
+        if month is None and month_raw.isdigit():
+            month = int(month_raw)
+        try:
+            year = int(year_raw)
+        except ValueError:
+            return False
+        if not month or not 1 <= month <= 12:
+            return False
+        now = datetime.now()
+        return (year, month) < (now.year, now.month)
+
     def _futures_exchcd_to_name(self, exchcd: str) -> str:
         """해외선물 거래소 코드 → 이름"""
         mapping = {
@@ -2715,9 +2760,227 @@ class SymbolQueryNodeExecutor(NodeExecutorBase):
         # 월 코드만 (예: "F", "G")
         if len(month_filter) == 1:
             return [s for s in symbols if s.get("contract_month", "").endswith(month_filter)]
-        
+
         # 연도+월 코드 (예: "2026F")
         return [s for s in symbols if s.get("contract_month", "") == month_filter]
+
+
+# 선물 월물 코드 (거래소 공통) — LS o3101 의 LstngM 이 이 문자를 그대로 준다.
+FUTURES_MONTH_CODES: Dict[str, int] = {
+    "F": 1, "G": 2, "H": 3, "J": 4, "K": 5, "M": 6,
+    "N": 7, "Q": 8, "U": 9, "V": 10, "X": 11, "Z": 12,
+}
+# 분기 월물 (3/6/9/12월) — 지수선물의 유동성이 몰리는 월물.
+QUARTERLY_MONTHS = (3, 6, 9, 12)
+
+
+class FuturesContractNodeExecutor(NodeExecutorBase):
+    """FuturesContractNode executor — 기초자산 → **현재 상장 월물** 해소 (o3101).
+
+    워크플로우가 월물 종목코드(HMHU26)를 하드코딩하면 만기가 지나는 순간 조용히 죽는다.
+    LS 는 만기 경과 종목에 과거봉도 현재가도 주지 않고 **에러도 내지 않기** 때문이다(빈 배열).
+    이 노드는 저작 시점이 아니라 실행 시점에 o3101 마스터를 조회해 살아있는 월물만 고른다.
+
+    출력 `symbols` 는 WatchlistNode 와 동일한 [{exchange, symbol}] 계약이라
+    하류(historical/market/condition/order) 배선이 그대로 유지된다.
+    """
+
+    async def execute(
+        self,
+        node_id: str,
+        node_type: str,
+        config: Dict[str, Any],
+        context: ExecutionContext,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        from programgarden_finance import LS, o3101  # noqa: F401  (LS 는 ensure_ls_login 이 사용)
+
+        base_products = config.get("base_products") or []
+        if isinstance(base_products, str):
+            # LLM Tool 경로에서 JSON 문자열/콤마 문자열로 오는 경우 방어
+            import json as _json
+            try:
+                parsed = _json.loads(base_products)
+                base_products = parsed if isinstance(parsed, list) else [base_products]
+            except (ValueError, _json.JSONDecodeError):
+                base_products = [p.strip() for p in base_products.split(",") if p.strip()]
+        base_products = [str(p).strip().upper() for p in base_products if str(p).strip()]
+
+        selection = str(config.get("contract_selection") or "front").strip().lower()
+        exchange_filter = (config.get("futures_exchange") or "").strip().upper()
+
+        if not base_products:
+            raise RuntimeError(
+                f"FuturesContractNode[{node_id}]: `base_products` is empty. Give at least one "
+                f"underlying code (e.g. ['HMH'] = Mini Hang Seng, ['HMCE'] = Mini H-Shares)."
+            )
+
+        # deep_validate / dry_run: 브로커를 건드리지 않는다. 스키마 형태의 fixture 로
+        # 하류를 흐르게 해서 배선·타입 검증이 끝까지 진행되게 한다.
+        if context.is_deep_validate or context.is_dry_run:
+            from programgarden import deep_fixtures as _df
+            fixture = _df.futures_contract_fixture(config)
+            override = context.get_deep_fixture(node_id, node_type)
+            if context.is_dry_run and not context.is_deep_validate:
+                context.log(
+                    "info",
+                    f"[dry_run] {node_type} simulated (no o3101 contract-master query)",
+                    node_id,
+                )
+            return _df.apply_override(fixture, override)
+
+        cred = context.get_credential("credential_id")
+        appkey = (cred or {}).get("appkey", "")
+        appsecret = (cred or {}).get("appsecret", "")
+        paper_trading = (cred or {}).get("paper_trading", False)
+        if not appkey or not appsecret:
+            raise RuntimeError(
+                f"FuturesContractNode[{node_id}]: no broker credential. This node resolves the live "
+                f"contract month through the LS contract-master query (o3101), which needs a broker "
+                f"session — wire an OverseasFuturesBrokerNode upstream."
+            )
+
+        ls, success, error = ensure_ls_login(
+            appkey, appsecret, paper_trading, context, node_id, "overseas_futures"
+        )
+        if not success:
+            raise RuntimeError(f"FuturesContractNode[{node_id}]: LS login failed: {error}")
+
+        # LS 는 같은 앱키로 요청이 몰리면 o3101 에 **빈 블록**을 돌려준다(에러가 아니라 빈 배열).
+        # 그 한 번에 워크플로우를 죽이면, 실제로는 멀쩡한 전략이 스케줄 한 틱을 통째로 날린다.
+        # 짧게 몇 번 다시 물어보고, 그래도 비어 있을 때만 (진짜 권한/장애로 보고) 크게 실패한다.
+        rows: List[Any] = []
+        last_error: Optional[Exception] = None
+        for attempt in range(3):
+            if attempt:
+                await asyncio.sleep(1.5 * attempt)
+            try:
+                query = ls.overseas_futureoption().market().해외선물마스터조회(
+                    body=o3101.O3101InBlock(gubun="0")
+                )
+                result = await query.req_async()
+            except Exception as e:  # noqa: BLE001 — 원인을 그대로 사용자에게 전달한다
+                last_error = e
+                context.log("warning", f"o3101 조회 실패 (시도 {attempt + 1}/3): {e}", node_id)
+                continue
+            rows = getattr(result, "block", None) or []
+            if rows:
+                break
+            context.log("warning", f"o3101 이 빈 마스터를 반환 (시도 {attempt + 1}/3)", node_id)
+
+        if not rows:
+            if last_error is not None:
+                raise RuntimeError(
+                    f"FuturesContractNode[{node_id}]: LS contract-master query (o3101) failed "
+                    f"after 3 attempts: {last_error}"
+                ) from last_error
+            raise RuntimeError(
+                f"FuturesContractNode[{node_id}]: LS returned an empty contract master (o3101) "
+                f"on 3 attempts. The broker session may lack overseas-futures entitlement, or too "
+                f"many requests are sharing this app key at once."
+            )
+
+        listed = self._parse_master(rows, exchange_filter)
+
+        available = sorted({c["base_product"] for c in listed})
+        contracts: List[Dict[str, Any]] = []
+        for product in base_products:
+            candidates = sorted(
+                (c for c in listed if c["base_product"] == product),
+                key=lambda c: (c["year"], c["month"]),
+            )
+            if not candidates:
+                raise RuntimeError(
+                    f"FuturesContractNode[{node_id}]: no listed contract for underlying "
+                    f"'{product}'"
+                    + (f" on exchange '{exchange_filter}'" if exchange_filter else "")
+                    + f". LS currently lists: {', '.join(available) or '(none)'}."
+                )
+            picked = self._select(candidates, selection)
+            if picked is None:
+                months = ", ".join(c["contract_month"] for c in candidates)
+                raise RuntimeError(
+                    f"FuturesContractNode[{node_id}]: contract_selection='{selection}' has no match "
+                    f"for '{product}'. LS lists these months: {months}."
+                )
+            contracts.append(picked)
+
+        symbols = [{"exchange": c["exchange"], "symbol": c["symbol"]} for c in contracts]
+        detail = [
+            {
+                "symbol": c["symbol"],
+                "exchange": c["exchange"],
+                "base_product": c["base_product"],
+                "base_product_name": c["base_product_name"],
+                "name": c["name"],
+                "contract_month": c["contract_month"],
+            }
+            for c in contracts
+        ]
+        context.log(
+            "info",
+            f"월물 해소 ({selection}): "
+            + ", ".join(f"{c['base_product']}→{c['symbol']}({c['contract_month']})" for c in contracts),
+            node_id,
+        )
+        return {"symbols": symbols, "contracts": detail, "count": len(symbols)}
+
+    def _parse_master(self, rows: Any, exchange_filter: str) -> List[Dict[str, Any]]:
+        """o3101 응답을 파싱하고 **만기 경과 월물을 제거**한다.
+
+        LS 마스터는 만기가 지난 월물을 이미 빼주지만, 그것에만 의존하지 않는다 —
+        마스터에 죽은 월물이 하루라도 남아 있으면 그게 '근월물'로 뽑혀 워크플로우가
+        조용히 죽기 때문이다. 현재 연-월보다 이른 월물은 여기서 잘라낸다.
+        """
+        now = datetime.now()
+        cur = (now.year, now.month)
+
+        parsed: List[Dict[str, Any]] = []
+        for item in rows:
+            symbol = getattr(item, "Symbol", "") or ""
+            base_product = (getattr(item, "BscGdsCd", "") or "").strip().upper()
+            exchange = (getattr(item, "ExchCd", "") or "").strip().upper()
+            year_raw = (getattr(item, "LstngYr", "") or "").strip()
+            month_raw = (getattr(item, "LstngM", "") or "").strip().upper()
+            if not symbol or not base_product or not year_raw or not month_raw:
+                continue
+            if exchange_filter and exchange != exchange_filter:
+                continue
+
+            month = FUTURES_MONTH_CODES.get(month_raw)
+            if month is None and month_raw.isdigit():
+                month = int(month_raw)  # LS 가 숫자 월을 주는 경우 대비
+            try:
+                year = int(year_raw)
+            except ValueError:
+                continue
+            if not month or not 1 <= month <= 12:
+                continue
+            if (year, month) < cur:
+                continue  # 만기 경과 — 이 종목은 시세도 과거봉도 오지 않는다
+
+            parsed.append({
+                "symbol": symbol,
+                "exchange": exchange,
+                "base_product": base_product,
+                "base_product_name": getattr(item, "BscGdsNm", "") or "",
+                "name": getattr(item, "SymbolNm", "") or "",
+                "contract_month": f"{year:04d}-{month:02d}",
+                "year": year,
+                "month": month,
+            })
+        return parsed
+
+    def _select(self, candidates: List[Dict[str, Any]], selection: str) -> Optional[Dict[str, Any]]:
+        """만기 오름차순 candidates 에서 월물 1건을 고른다."""
+        if selection == "next":
+            return candidates[1] if len(candidates) > 1 else None
+        if selection == "quarterly":
+            for c in candidates:
+                if c["month"] in QUARTERLY_MONTHS:
+                    return c
+            return None
+        return candidates[0]  # front (기본)
 
 
 class BrokerNodeExecutor(NodeExecutorBase):
@@ -15920,6 +16183,7 @@ class WorkflowExecutor:
             "SymbolQueryNode": SymbolQueryNodeExecutor(),
             "OverseasStockSymbolQueryNode": SymbolQueryNodeExecutor(),
             "OverseasFuturesSymbolQueryNode": SymbolQueryNodeExecutor(),
+            "FuturesContractNode": FuturesContractNodeExecutor(),
             "SymbolFilterNode": SymbolFilterNodeExecutor(),
             "ExclusionListNode": ExclusionListNodeExecutor(),
             "MarketUniverseNode": MarketUniverseNodeExecutor(),
@@ -17511,6 +17775,10 @@ class WorkflowJob:
         "CandlestickChartNode", "BarChartNode", "SummaryDisplayNode",
         "WatchlistNode", "MarketUniverseNode", "ScreenerNode",  # 배열 생성 노드
         "ExclusionListNode",  # 제외 종목 관리 노드 (배열 생성)
+        # 종목 마스터 조회 노드 — 배열을 **생성**하는 쪽이다. 상류에 배열이 붙었다고
+        # 아이템 수만큼 마스터 조회를 반복하면 같은 전체 목록을 N 번 받아온다.
+        "FuturesContractNode",
+        "OverseasFuturesSymbolQueryNode", "OverseasStockSymbolQueryNode", "KoreaStockSymbolQueryNode",
         "SymbolFilterNode",  # 집합 연산 노드 (배열 입력/출력)
         # LogicNode 도 집합 연산 노드다 — 상류 조건 결과 **배열 전체**를 AND/OR 해야 한다.
         # 종목별로 쪼개 N회 돌면 매 회가 전체 passed_symbols 를 다시 내보내 병합 시 N² 가 된다

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.25.0"
+version = "1.26.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
@@ -29,7 +29,7 @@ lxml = "^6.0.2"
 pytickersymbols = {version = ">=1.17.5", python = ">=3.12,<4.0"}
 aiosqlite = "^0.20.0"
 litellm = ">=1.40.0"
-programgarden-core = "^1.16.0"
+programgarden-core = "^1.18.0"
 programgarden-finance = "^1.6.14"
 programgarden-community = "^1.13.11"
 

--- a/src/programgarden/tests/test_examples_validation.py
+++ b/src/programgarden/tests/test_examples_validation.py
@@ -191,6 +191,10 @@ _NODE_META_KEYS = {"id", "type", "position", "description", "name"}
 #: executor actually reads it.
 _ALLOWED_NODE_EXTRAS = {
     "SplitNode": {"items"},  # executor iterates config['items']; see 69-* legacy
+    # MarketDataNodeExecutor reads config['symbols'] (plural array) at runtime
+    # (executor.py ~8983); the node field schema only declares singular 'symbol'.
+    # Live-confirmed: examples 50/94 return per-symbol `values` from `symbols`.
+    "KoreaStockMarketDataNode": {"symbols"},
 }
 
 

--- a/src/programgarden/tests/test_examples_validation.py
+++ b/src/programgarden/tests/test_examples_validation.py
@@ -75,9 +75,9 @@ class TestWorkflowStaticValidation:
     """Every bundled example workflow must pass WorkflowExecutor.validate()."""
 
     def test_workflow_files_discovered(self):
-        """Sanity: repo ships with 95 example workflows."""
-        assert len(WORKFLOW_FILES) == 95, (
-            f"expected 95 workflow JSON files, found {len(WORKFLOW_FILES)}"
+        """Sanity: repo ships with 99 example workflows."""
+        assert len(WORKFLOW_FILES) == 99, (
+            f"expected 99 workflow JSON files, found {len(WORKFLOW_FILES)}"
         )
 
     @pytest.mark.parametrize("wf_path", WORKFLOW_FILES, ids=_ids(WORKFLOW_FILES))
@@ -161,6 +161,84 @@ class TestWorkflowDryRunCycle:
                     if log.get("level") == "error"
                 )[:5]
             )
+
+
+#: Phase 5.2 domestic-stock (Korea) examples. Unlike the legacy corpus —
+#: which carries some historical unknown fields that BaseNode's
+#: ``extra="allow"`` silently tolerates — these must be schema-exact: every
+#: node key must be a declared model field (or an intentional executor-read
+#: extra, see ``_ALLOWED_NODE_EXTRAS``). Few-shot generation copies these
+#: verbatim, so a phantom field here (e.g. a ``price`` that
+#: PositionSizingNode never reads) propagates into every generated workflow.
+#: Scoped to 94-97 only — earlier Korea examples (50/53/55) predate this gate.
+_KOREA_GATE_STEMS = {
+    "94-korea-stock-order-rsi-buy",
+    "95-korea-stock-strategy-condition-logic",
+    "96-korea-stock-backtest-rsi-bollinger",
+    "97-korea-stock-code-node-composite",
+}
+KOREA_EXAMPLE_FILES: List[Path] = sorted(
+    p for p in EXAMPLES_DIR.glob("*-korea-*.json") if p.stem in _KOREA_GATE_STEMS
+)
+
+#: Node-level keys that are structural/presentational, not schema fields.
+_NODE_META_KEYS = {"id", "type", "position", "description", "name"}
+
+#: Per-node-type keys the executor intentionally reads via ``extra="allow"``
+#: even though they are not declared Pydantic fields. These are functional
+#: (the executor consumes them), unlike phantom fields that are silently
+#: dropped. Keep this list tight — only add a key after confirming the
+#: executor actually reads it.
+_ALLOWED_NODE_EXTRAS = {
+    "SplitNode": {"items"},  # executor iterates config['items']; see 69-* legacy
+}
+
+
+class TestKoreaExampleSchemaFields:
+    """Gate: the domestic-stock examples must use only declared node fields.
+
+    ``WorkflowExecutor.validate()`` and the dry-run cycle both pass despite
+    unknown fields because ``BaseNode(model_config=extra="allow")`` swallows
+    them. This class closes that gap — but only for the new Korea corpus, so
+    legacy examples with historical drift are unaffected.
+    """
+
+    def test_korea_examples_present(self):
+        assert len(KOREA_EXAMPLE_FILES) == 4, (
+            f"expected 4 *-korea-*.json examples, found {len(KOREA_EXAMPLE_FILES)}: "
+            f"{[p.name for p in KOREA_EXAMPLE_FILES]}"
+        )
+
+    @pytest.mark.parametrize(
+        "wf_path", KOREA_EXAMPLE_FILES, ids=_ids(KOREA_EXAMPLE_FILES)
+    )
+    def test_korea_nodes_have_no_unknown_fields(self, wf_path: Path):
+        import programgarden_core
+
+        with open(wf_path, encoding="utf-8") as f:
+            workflow = json.load(f)
+
+        offenders: list[str] = []
+        for node in workflow.get("nodes", []):
+            node_type = node.get("type")
+            cls = getattr(programgarden_core, node_type, None)
+            assert cls is not None, (
+                f"{wf_path.name}: node '{node.get('id')}' type "
+                f"{node_type!r} not exported from programgarden_core"
+            )
+            model_fields = set(getattr(cls, "model_fields", {}))
+            allowed_extras = _ALLOWED_NODE_EXTRAS.get(node_type, set())
+            unknown = set(node) - _NODE_META_KEYS - model_fields - allowed_extras
+            if unknown:
+                offenders.append(
+                    f"{node.get('id')} ({node_type}): {sorted(unknown)}"
+                )
+
+        assert not offenders, (
+            f"{wf_path.name}: nodes reference fields absent from the node "
+            f"schema (extra=\"allow\" hides these at runtime):\n"
+            + "\n".join(f"  - {o}" for o in offenders)
+        )
 
 
 class TestProgrammerExamples:

--- a/src/programgarden/tests/test_futures_contract_node.py
+++ b/src/programgarden/tests/test_futures_contract_node.py
@@ -285,3 +285,81 @@ def test_array_producing_nodes_are_not_auto_iterated():
     assert "OverseasFuturesSymbolQueryNode" in no_iter
     assert "OverseasStockSymbolQueryNode" in no_iter
     assert "KoreaStockSymbolQueryNode" in no_iter
+
+
+# ---------------------------------------------------------------------------
+# 6. 거래소 필터 — 무음 빈 배열 금지 (적대검증이 잡은 회귀)
+# ---------------------------------------------------------------------------
+
+def _symbol_query_context():
+    ctx = _make_context()
+    ctx.is_deep_validate = False
+    ctx.is_dry_run = False
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_symbol_query_unavailable_exchange_raises_not_empty():
+    """해외선물 권한은 **거래소별**이다. 계좌에 없는 거래소를 고르면 마스터에 그 거래소 행이
+    아예 없다. 그때 조용히 빈 배열을 주면 하류가 전부 no-op 하고 워크플로우는 '성공'한 척
+    아무것도 안 한다 — 이 저장소가 없애려는 바로 그 무음 실패다."""
+    from programgarden.executor import SymbolQueryNodeExecutor
+
+    ex = SymbolQueryNodeExecutor()
+    with _patched_master(LISTED_ROWS):  # HKEX + LME 뿐 (실측과 동일)
+        with pytest.raises(RuntimeError) as e:
+            await ex.execute(
+                "q", "OverseasFuturesSymbolQueryNode",
+                {"futures_exchange": "2"},  # CME — 이 계좌에 없다
+                _symbol_query_context(),
+            )
+    msg = str(e.value)
+    assert "CME" in msg
+    assert "HKEX" in msg and "LME" in msg  # 무엇을 쓸 수 있는지 알려준다
+
+
+@pytest.mark.asyncio
+async def test_symbol_query_available_exchange_filters():
+    from programgarden.executor import SymbolQueryNodeExecutor
+
+    ex = SymbolQueryNodeExecutor()
+    with _patched_master(LISTED_ROWS):
+        out = await ex.execute(
+            "q", "OverseasFuturesSymbolQueryNode",
+            {"futures_exchange": "6"},  # HKEX
+            _symbol_query_context(),
+        )
+    assert out["count"] == 7  # LME 1건 제외
+    assert {s["exchange"] for s in out["symbols"]} == {"HKEX"}
+    # exchange 는 레지스트리 코드여야 한다 — LS 의 한글명이 주문 TR 로 새면 주문이 깨진다.
+    assert all(s["exchange_name"] == "홍콩거래소" for s in out["symbols"])
+
+
+@pytest.mark.asyncio
+async def test_contract_node_accepts_sibling_enum_exchange_value():
+    """형제 노드는 같은 이름의 필드를 enum('6'=HKEX)으로 쓴다. 챗봇이 그 값을 그대로
+    넣어도 죽지 않아야 한다."""
+    out = await _run({"base_products": ["HMH"], "futures_exchange": "6"})
+    assert out["symbols"] == [{"exchange": "HKEX", "symbol": "HMHN26"}]
+
+
+@pytest.mark.asyncio
+async def test_contract_node_wrong_exchange_names_the_real_cause():
+    """거래소를 잘못 고른 게 원인일 때, 메시지가 '상장 계약이 하나도 없다'로 읽히면
+    자동수정 루프가 진짜 원인을 못 찾는다."""
+    with pytest.raises(RuntimeError, match="LS currently lists: HKEX, LME"):
+        await _run({"base_products": ["HMH"], "futures_exchange": "CME"})
+
+
+def test_deep_fixture_honors_contract_selection():
+    """fixture 가 selection 을 무시하면 세 설정이 같은 심볼을 내 게이트가 오배선을 못 잡는다."""
+    front = _df.futures_contract_fixture({"base_products": ["HMH"], "contract_selection": "front"})
+    nxt = _df.futures_contract_fixture({"base_products": ["HMH"], "contract_selection": "next"})
+    qtr = _df.futures_contract_fixture({"base_products": ["HMH"], "contract_selection": "quarterly"})
+    syms = {front["symbols"][0]["symbol"], nxt["symbols"][0]["symbol"], qtr["symbols"][0]["symbol"]}
+    assert len(syms) == 3
+
+
+def test_deep_fixture_normalizes_sibling_enum_exchange():
+    fx = _df.futures_contract_fixture({"base_products": ["HMH"], "futures_exchange": "6"})
+    assert fx["symbols"][0]["exchange"] == "HKEX"

--- a/src/programgarden/tests/test_futures_contract_node.py
+++ b/src/programgarden/tests/test_futures_contract_node.py
@@ -1,0 +1,287 @@
+"""
+FuturesContractNode — 만기 종속성 근본 해결 테스트
+
+선물 워크플로우가 월물 종목코드(HMHU26)를 하드코딩하면 만기가 지나는 순간 조용히 죽는다.
+LS 는 만기 경과 종목에 과거봉도 현재가도 주지 않고 **에러도 내지 않기** 때문이다(빈 배열).
+FuturesContractNode 는 실행 시점에 LS 종목마스터(o3101)를 조회해 살아있는 월물만 고른다.
+
+여기서 지키는 계약:
+1. front / next / quarterly 선택이 만기 오름차순 기준으로 정확하다
+2. 만기 경과 월물은 마스터에 남아 있어도 **절대** 선택되지 않는다
+3. 알 수 없는 기초자산은 **조용한 빈 배열이 아니라** 사유가 담긴 에러다
+4. symbols 출력이 WatchlistNode 와 같은 [{exchange, symbol}] 계약이다 (하류 배선 불변)
+5. deep_validate 는 네트워크 없이 통과한다
+6. 배열 생성 노드이므로 auto-iterate 대상이 아니다
+
+실행:
+    cd src/programgarden && poetry run pytest tests/test_futures_contract_node.py -v
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from programgarden.executor import (
+    FuturesContractNodeExecutor,
+    WorkflowJob,
+)
+from programgarden import deep_fixtures as _df
+
+
+# ---------------------------------------------------------------------------
+# Mock helpers — o3101 마스터 응답을 실제 LS 필드명 그대로 흉내낸다.
+# (실측: LstngM 은 월물 **문자 코드**('N'=7월)이지 숫자가 아니다.)
+# ---------------------------------------------------------------------------
+
+def _row(symbol, base, year, month_letter, exch="HKEX", name=None):
+    return SimpleNamespace(
+        Symbol=symbol,
+        SymbolNm=name or f"{base}({year}.{month_letter})",
+        BscGdsCd=base,
+        BscGdsNm="Mini Hang Seng" if base == "HMH" else "Mini H-Shares",
+        ExchCd=exch,
+        ExchNm="홍콩거래소",
+        CrncyCd="HKD",
+        LstngYr=str(year),
+        LstngM=month_letter,
+    )
+
+
+# 2026-07 기준 실제 LS 상장 월물 (실측 반영)
+LISTED_ROWS = [
+    _row("HMHN26", "HMH", 2026, "N"),    # 7월 (근월)
+    _row("HMHQ26", "HMH", 2026, "Q"),    # 8월 (차월)
+    _row("HMHU26", "HMH", 2026, "U"),    # 9월 (분기)
+    _row("HMHZ26", "HMH", 2026, "Z"),    # 12월
+    _row("HMCEN26", "HMCE", 2026, "N"),
+    _row("HMCEQ26", "HMCE", 2026, "Q"),
+    _row("HMCEU26", "HMCE", 2026, "U"),
+    _row("LSRN26", "LSR", 2026, "N", exch="LME"),
+]
+
+
+def _make_context():
+    ctx = MagicMock()
+    ctx.is_deep_validate = False
+    ctx.is_dry_run = False
+    ctx.log = MagicMock()
+    ctx.get_credential = MagicMock(return_value={
+        "appkey": "k", "appsecret": "s", "paper_trading": False,
+    })
+    ctx.get_deep_fixture = MagicMock(return_value=None)
+    return ctx
+
+
+def _patched_master(rows):
+    """ensure_ls_login + o3101 마스터 응답을 통째로 대체한다 (네트워크 0)."""
+    response = SimpleNamespace(block=rows)
+
+    query = MagicMock()
+
+    async def _req_async():
+        return response
+
+    query.req_async = _req_async
+
+    ls = MagicMock()
+    ls.overseas_futureoption.return_value.market.return_value.해외선물마스터조회.return_value = query
+    return patch("programgarden.executor.ensure_ls_login", return_value=(ls, True, None))
+
+
+async def _run(config, rows=LISTED_ROWS, now=(2026, 7)):
+    """지정한 '오늘'로 노드를 실행한다 (만기 판정이 시계에 의존하므로 고정)."""
+    ex = FuturesContractNodeExecutor()
+
+    class _FixedNow:
+        @staticmethod
+        def now():
+            import datetime as _dt
+            return _dt.datetime(now[0], now[1], 15)
+
+    with _patched_master(rows), patch("programgarden.executor.datetime", _FixedNow):
+        return await ex.execute("contract", "FuturesContractNode", config, _make_context())
+
+
+# ---------------------------------------------------------------------------
+# 1. 월물 선택
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_front_picks_nearest_expiry():
+    out = await _run({"base_products": ["HMH", "HMCE"], "contract_selection": "front"})
+    assert out["symbols"] == [
+        {"exchange": "HKEX", "symbol": "HMHN26"},
+        {"exchange": "HKEX", "symbol": "HMCEN26"},
+    ]
+    assert out["count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_next_picks_second_nearest():
+    out = await _run({"base_products": ["HMH"], "contract_selection": "next"})
+    assert out["symbols"] == [{"exchange": "HKEX", "symbol": "HMHQ26"}]
+
+
+@pytest.mark.asyncio
+async def test_quarterly_picks_nearest_quarter_month():
+    """분기월물 = 3/6/9/12월. 7월(N)/8월(Q)을 건너뛰고 9월(U)을 골라야 한다."""
+    out = await _run({"base_products": ["HMH"], "contract_selection": "quarterly"})
+    assert out["symbols"] == [{"exchange": "HKEX", "symbol": "HMHU26"}]
+
+
+@pytest.mark.asyncio
+async def test_base_products_order_is_preserved():
+    out = await _run({"base_products": ["HMCE", "HMH"]})
+    assert [s["symbol"] for s in out["symbols"]] == ["HMCEN26", "HMHN26"]
+
+
+# ---------------------------------------------------------------------------
+# 2. 만기 경과 월물 — 이 프로젝트의 존재 이유
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_expired_contract_is_never_selected():
+    """마스터에 만기 경과 월물이 남아 있어도 근월물로 뽑히면 안 된다.
+
+    LS 는 보통 만기분을 빼주지만, 하루라도 남아 있으면 그게 front 로 뽑혀
+    워크플로우가 조용히 죽는다(시세도 과거봉도 빈 배열). 노드가 직접 잘라낸다.
+    """
+    rows = [
+        _row("HMHM26", "HMH", 2026, "M"),   # 6월 — 이미 만기 경과
+        _row("HMHN26", "HMH", 2026, "N"),   # 7월 — 살아있는 근월
+    ]
+    out = await _run({"base_products": ["HMH"], "contract_selection": "front"}, rows=rows)
+    assert out["symbols"] == [{"exchange": "HKEX", "symbol": "HMHN26"}]
+
+
+@pytest.mark.asyncio
+async def test_all_contracts_expired_raises_with_reason():
+    rows = [_row("HMHM26", "HMH", 2026, "M")]  # 6월만 있고 오늘은 7월
+    with pytest.raises(RuntimeError, match="no listed contract for underlying"):
+        await _run({"base_products": ["HMH"]}, rows=rows)
+
+
+@pytest.mark.asyncio
+async def test_rollover_happens_automatically_next_month():
+    """8월이 되면 같은 워크플로우가 손대지 않고도 8월물로 넘어간다."""
+    out = await _run({"base_products": ["HMH"], "contract_selection": "front"}, now=(2026, 8))
+    assert out["symbols"] == [{"exchange": "HKEX", "symbol": "HMHQ26"}]
+
+
+# ---------------------------------------------------------------------------
+# 3. 실패는 조용하지 않다
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unknown_base_product_raises_listing_available_codes():
+    with pytest.raises(RuntimeError) as e:
+        await _run({"base_products": ["NOPE"]})
+    msg = str(e.value)
+    assert "NOPE" in msg
+    assert "HMH" in msg and "HMCE" in msg  # 무엇을 쓸 수 있는지 알려준다
+
+
+@pytest.mark.asyncio
+async def test_contract_symbol_in_base_products_is_rejected_loudly():
+    """base_products 에 월물 심볼(HMHN26)을 넣는 흔한 실수 — 빈 배열이 아니라 에러여야 한다."""
+    with pytest.raises(RuntimeError, match="HMHN26"):
+        await _run({"base_products": ["HMHN26"]})
+
+
+@pytest.mark.asyncio
+async def test_empty_base_products_raises():
+    ex = FuturesContractNodeExecutor()
+    with pytest.raises(RuntimeError, match="base_products"):
+        await ex.execute("contract", "FuturesContractNode", {"base_products": []}, _make_context())
+
+
+@pytest.mark.asyncio
+async def test_missing_broker_credential_raises_pointing_at_broker_node():
+    ex = FuturesContractNodeExecutor()
+    ctx = _make_context()
+    ctx.get_credential = MagicMock(return_value=None)
+    with pytest.raises(RuntimeError, match="OverseasFuturesBrokerNode"):
+        await ex.execute("contract", "FuturesContractNode", {"base_products": ["HMH"]}, ctx)
+
+
+@pytest.mark.asyncio
+async def test_next_unavailable_raises_instead_of_dropping_symbol():
+    rows = [_row("HMHN26", "HMH", 2026, "N")]  # 월물이 하나뿐
+    with pytest.raises(RuntimeError, match="contract_selection='next'"):
+        await _run({"base_products": ["HMH"], "contract_selection": "next"}, rows=rows)
+
+
+# ---------------------------------------------------------------------------
+# 4. 거래소 필터 / 하류 계약
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_exchange_filter_narrows_master():
+    with pytest.raises(RuntimeError, match="no listed contract"):
+        await _run({"base_products": ["LSR"], "futures_exchange": "HKEX"})  # LSR 은 LME 다
+
+    out = await _run({"base_products": ["LSR"], "futures_exchange": "LME"})
+    assert out["symbols"] == [{"exchange": "LME", "symbol": "LSRN26"}]
+
+
+@pytest.mark.asyncio
+async def test_symbols_port_matches_watchlist_contract():
+    """symbols 원소는 정확히 {exchange, symbol} 2키 — WatchlistNode 와 동일해야
+    하류(historical/market/condition/order) 배선이 그대로 유지된다."""
+    out = await _run({"base_products": ["HMH"]})
+    assert all(set(s.keys()) == {"exchange", "symbol"} for s in out["symbols"])
+    # 거래소는 레지스트리 코드(HKEX)여야 한다 — LS 의 한글명('홍콩거래소')이 새면 주문이 깨진다.
+    assert out["symbols"][0]["exchange"] == "HKEX"
+
+
+@pytest.mark.asyncio
+async def test_contracts_port_carries_detail_for_reports():
+    out = await _run({"base_products": ["HMH"]})
+    c = out["contracts"][0]
+    assert c["symbol"] == "HMHN26"
+    assert c["base_product"] == "HMH"
+    assert c["contract_month"] == "2026-07"
+
+
+# ---------------------------------------------------------------------------
+# 5. 게이트 — deep_validate / auto-iterate
+# ---------------------------------------------------------------------------
+
+def test_deep_fixture_needs_no_network_and_matches_port_shape():
+    fx = _df.futures_contract_fixture({"base_products": ["HMH", "HMCE"]})
+    assert fx["count"] == 2
+    assert all(set(s.keys()) == {"exchange", "symbol"} for s in fx["symbols"])
+    assert [c["base_product"] for c in fx["contracts"]] == ["HMH", "HMCE"]
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_touch_ls():
+    """dry_run = '브로커를 건드리지 않는다'. o3101 을 부르면 mock LS 에 걸려 워크플로우가 죽는다
+    (examples dry-run 게이트가 정확히 이걸 잡는다)."""
+    ex = FuturesContractNodeExecutor()
+    ctx = _make_context()
+    ctx.is_dry_run = True
+    out = await ex.execute("contract", "FuturesContractNode", {"base_products": ["HMH"]}, ctx)
+    assert out["count"] == 1
+    assert set(out["symbols"][0].keys()) == {"exchange", "symbol"}
+
+
+@pytest.mark.asyncio
+async def test_deep_validate_does_not_touch_ls():
+    ex = FuturesContractNodeExecutor()
+    ctx = _make_context()
+    ctx.is_deep_validate = True
+    ctx.get_credential = MagicMock(return_value=None)  # 자격 없어도 통과해야 한다
+    out = await ex.execute("contract", "FuturesContractNode", {"base_products": ["HMH"]}, ctx)
+    assert out["count"] == 1
+    assert set(out["symbols"][0].keys()) == {"exchange", "symbol"}
+
+
+def test_array_producing_nodes_are_not_auto_iterated():
+    """배열을 **생성**하는 노드가 auto-iterate 대상이 되면 상류 아이템 수만큼
+    마스터 조회를 반복해 같은 목록을 N 번 받아온다."""
+    no_iter = WorkflowJob.NO_AUTO_ITERATE_NODE_TYPES
+    assert "FuturesContractNode" in no_iter
+    assert "OverseasFuturesSymbolQueryNode" in no_iter
+    assert "OverseasStockSymbolQueryNode" in no_iter
+    assert "KoreaStockSymbolQueryNode" in no_iter


### PR DESCRIPTION
## 요약

국내주식(KRX) 지원을 위한 SDK 표면(카탈로그·예제·ProductType)과, 그 과정에서 **실증된 배포 결함 1건**을 함께 담았습니다.

핵심 결함: `OverseasFuturesMarketDataNode` 가 배포본(core 1.17.0)에서 **단수 `value` 포트만** 노출합니다. 그런데 실행기(executor)는 `values`(배열)를 채웁니다. 그래서
- `.value` 로 바인딩 → 리졸버가 조용히 `None` → 주문 0건 (조용한 오작동)
- `.values` 로 바인딩 → 정적 검증에서 `INVALID_EXPRESSION_REF` 로 거부

해외주식·국내주식 노드는 이미 `values` 를 선언하고 있어 **선물만** 이 상태였습니다. 소스에는 포트가 있었으나 **배포되지 않은** 것이 원인입니다.

## 변경

| 항목 | 내용 |
|---|---|
| `src/core` | 1.17.0 → **1.18.0** — `OverseasFuturesMarketDataNode.values` OutputPort, 노드가이드/예제의 `.value` → `.values` 정정, `ProductType.KOREA_STOCK` |
| `src/programgarden` | 1.25.0 → **1.26.0** — 국내주식 예제 4종(94~97) + 스키마 게이트, 의존 `programgarden-core` `^1.16.0` → **`^1.18.0`** |

의존을 caret(`^`)으로 두면 core 가 **transitive floating** 이라 소비자가 옛 core 를 물 수 있고, 그게 이번 갭의 구조적 원인이었습니다.

## 검증

- **예제 99건 전수 정적검증**: 이번 빌드 → **REJECT 0건**. 직전 배포본(core 1.17.0) → REJECT 2건(예제 81·85). 대조군(포트명을 없는 이름으로 변조 → REJECT)으로 검사기가 실제로 살아있음을 확인. **lead·employee 독립 2회 재현.**
- **카탈로그 ↔ 런타임 전수 대조**: dev `node_catalog` 75종 × 설치 런타임 75종의 출력 포트 비교 → 불일치는 futures `values` **단 1건**(반대 방향 0건). 이 릴리스로 갭이 완전히 닫힙니다.
- **국내 예제 94~97**: 4/4 ACCEPT. 국내 스코프는 배포본과 이미 정합.
- `test_examples_validation.py`: **313 passed** (1 skipped, 1 xfailed).
- 국내 실 LS 라이브(read-only) 도구계층 e2e 28/28 PASS — 하락종목 부호 회귀 포함. 주문은 실계좌 즉시체결 위험 때문에 라이브 미실행(mock 전용).

## 머지 순서 (중요)

소비자 3서비스(`programgarden_ai` / `sandbox_for_ai` / `cloudrun/dsl-api`)가 `programgarden==1.26.0` + `programgarden-core==1.18.0` 을 **정확 핀**으로 걸어둔 상태입니다. 아직 PyPI 에 없는 버전이므로:

**이 PR 머지 → PyPI publish(core 1.18.0 → programgarden 1.26.0) → 소비자 3개 PR 머지** 순서를 지켜야 설치가 깨지지 않습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Vqn3xZgWmhxbRoNX9rnBq

---

## 추가 (2026-07-13): 실행기 auto-iterate 결함 5건 — 실 LS 실행으로 확진

기존 해외 예제 8건(07·08·10·16·28·81·85·86)을 **실제 LS 로 실행**해 판정하는 과정에서, 게이트(validate/deep_validate/dry-run)가 전부 초록인데 라이브만 잘못 도는 결함들을 찾았습니다. 실행 없이는 잡히지 않는 종류입니다.

### 🔴 실주문 위험 2건

**1. auto-iterate 소스가 엣지 선언 순서로 정해짐** (무조건 `break`)
계좌 엣지가 먼저 선언된 워크플로우에서 `PositionSizingNode` 가 **계좌 보유종목을 신규 매수 후보로 순회**했습니다. 실측: 예제 16/28 이 워크플로우 어디에도 없는 보유종목(AUID)을 처리 — **잔고가 충분했다면 실제 주문이 나갔습니다**. 사용자가 명시한 `from_port`(예: `logic.passed_symbols`)조차 앞선 엣지에 가려 무시됐습니다.
→ 모든 incoming 엣지를 훑어 `[명시 from_port > symbols 포트 > 첫 출력]` 우선순위로 고르고, 계좌 노드는 순회 소스에서 배제.

**2. 거래소 코드가 무음으로 NASDAQ 에 폴백**
`MarketUniverseNode` 가 pytickersymbols 의 첫 항목만 보고 거래소를 정해 **DOW30 30종목 중 29개가 FRA(프랑크푸르트)** 가 됐고, 하류가 이를 조용히 82(NASDAQ)로 떨어뜨려 **NYSE 종목이 "No data" 로 사라졌습니다**(예제 08 이 회당 30종목 중 8건만 수신). 같은 폴백이 주문 노드에도 있습니다.
→ `google` 접두사(`"NYSE:MMM"`)로 실제 상장 거래소를 확정. 다만 LS 의 거래소 코드는 실제 상장지와 항상 일치하지 않아(WMT 는 NYSE 상장인데 82 로만 조회됨) **실패 시 다른 원장을 재시도**하고 성공한 코드를 기록합니다.

### N² 중복 조회 3건

- **`MarketDataNode`** — auto-iterate 가 종목당 1회씩 노드를 돌리는데 실행기가 `_input_.symbols`(전체 배열)를 읽어 iteration 마다 전 종목을 재조회. 07 4종목→16건 / 10 5→25 / 28 5→25 / **08 30종목→LS 폭주 후 job cancelled**.
  → iteration 컨텍스트로 차단(이번 아이템 1건만 조회). `{{ item }}` 리터럴 유무와 무관 — 노드 가이드가 권장하는 "Watchlist → MarketData" 배선(=챗봇 산출물)에는 리터럴이 없어 그 모양이 그대로 N² 였습니다(실측 3종목→9건).
- **`LogicNode` 가 auto-iterate 대상이었음** — 집합 연산 노드인데 종목별로 N회 돌며 매 회 전체 `passed_symbols` 를 내보내 병합 시 N²(28 이 5종목인데 25건).
- **`_merge_iterate_results`** 의 `array_fields` 에 `symbols`/`symbol_results` 누락 → auto-iterate N회 중 마지막 1회만 생존.

### 예제

`81`/`85` 의 HKEX 선물이 **만기 경과 월물**(6월물)이라 `historical` 이 빈 응답이었습니다. 실전 키로 월물 유효성을 실측(6월물 0봉 / 9월물 21봉)해 9월물로 roll-forward 했습니다.

## 검증 (실 LS, 주문 노드 제거 사본)

| 예제 | 수정 전 | 수정 후 |
|---|---|---|
| 07 / 10 / 28 | values 16 / 25 / 25 | **4 / 5 / 5** |
| 08 | 240건 · `cancelled` · exchange=FRA | **30건 · `completed` · NYSE, 유실 0** |
| 16 | `sizing` 이 계좌 보유종목 순회 | **워치리스트** 순회 |
| 86 | market 0건 (`symbols 필수` 에러) | **1건** |
| 81 / 85 | `historical` 빈 응답 | **실제 봉 데이터** |

- 16/28 의 `orders=0` 은 결함이 아니라 **테스트 계좌 잔고 부족**(`orderable_amount` 11.27 USD < AAPL 316 USD → `qty=0`)이며 배선은 정상임을 확인했습니다.
- 회귀: SDK 스위트 **1393 passed** — 수정 전후 실패 목록이 동일해 **신규 회귀 0**입니다(잔여 실패는 외부 HTTP 엔드포인트 의존 테스트).

## 남은 결함 (별건)

- `FundamentalNode` 가 수정 전 `MarketDataNode` 와 동일한 read 순서(예제 미사용이라 미실증).
- `PositionSizingNode` 가 `qty=0` 일 때 사유 없이 주문을 만들지 않음.
- 예제 34 의 `historical` 이 `"symbol": "NVDA"` 문자열이라 dict 검사에 걸려 빈 결과.
- 🔴 RSI 플러그인이 데이터 부족 시 `random.uniform(30, 70)` 으로 **난수 RSI** 를 만들어 매매 조건에 먹임.
- 선물 예제 12건이 만기 월물을 하드코딩 — 만기가 지나면 또 죽습니다(근월물 자동 선택 기능 부재).
