### PR TITLE
release(1.25.1): 노드 출력 스키마 정합 + 하드 실패 raise + SplitNode 정적 가드

### DIFF
--- a/src/core/programgarden_core/nodes/ai.py
+++ b/src/core/programgarden_core/nodes/ai.py
@@ -361,6 +361,11 @@ class AIAgentNode(BaseNode):
     ]
     _anti_patterns: ClassVar[List[Dict[str, str]]] = [
         {
+            "pattern": "Adding an AIAgentNode without connecting an LLMModelNode via an 'ai_model' edge",
+            "reason": "AIAgentNode CANNOT run without an LLM — the ai_model edge injects the LLM connection. With no LLMModelNode wired via an ai_model edge, the node fails at runtime (raises). The workflow validator now blocks this with an ERROR at save time.",
+            "alternative": "Always add an LLMModelNode and wire it to the AIAgentNode with an ai_model edge: {\"from\": \"<llm_node_id>\", \"to\": \"<agent_id>\", \"type\": \"ai_model\"}. A plain 'main' edge does NOT inject the LLM.",
+        },
+        {
             "pattern": "Connecting a real-time node (RealMarketDataNode) directly to AIAgentNode without ThrottleNode",
             "reason": "Real-time nodes fire on every tick. Without throttling, AIAgentNode would call the LLM API thousands of times per minute, causing massive cost and rate limit errors. The workflow validator blocks this with an ERROR.",
             "alternative": "Insert ThrottleNode between the real-time source and AIAgentNode. Set ThrottleNode interval to match your intended analysis frequency (e.g. 60s).",

--- a/src/core/programgarden_core/nodes/display.py
+++ b/src/core/programgarden_core/nodes/display.py
@@ -10,7 +10,7 @@ ProgramGarden Core - Display Nodes
 - SummaryDisplayNode: JSON/요약 데이터 표시
 """
 
-from typing import Optional, List, Literal, Dict, Any, ClassVar, TYPE_CHECKING
+from typing import Optional, List, Literal, Dict, Any, Union, ClassVar, TYPE_CHECKING
 from pydantic import Field
 
 if TYPE_CHECKING:
@@ -304,9 +304,16 @@ class TableDisplayNode(BaseDisplayNode):
     _updated_at: ClassVar[str] = "2026-05-19"
     _change_note: ClassVar[Optional[str]] = None
 
-    columns: Optional[List[str]] = Field(
+    # columns 는 두 형태를 모두 받는다(스키마=코드=카탈로그 정합; 렌더러 _normalize_columns):
+    #   1) 필드명 문자열 리스트 — ["symbol", "close"]
+    #   2) {key, label} 객체 리스트 — [{"key": "close", "label": "종가"}] (현지화 헤더용)
+    # 옛 선언은 List[str] 뿐이라 객체형을 코드만 몰래 허용하는 드리프트였다.
+    columns: Optional[List[Union[str, Dict[str, Any]]]] = Field(
         default=None,
-        description="표시할 컬럼 목록 (미지정시 전체)",
+        description=(
+            "표시할 컬럼 (미지정시 전체). 필드명 문자열 리스트 [\"symbol\",\"close\"] 또는 "
+            "현지화 헤더용 객체 리스트 [{\"key\":\"close\",\"label\":\"종가\"}] 둘 다 허용."
+        ),
     )
 
     limit: Optional[int] = Field(
@@ -336,7 +343,10 @@ class TableDisplayNode(BaseDisplayNode):
             "columns": FieldSchema(
                 name="columns",
                 type=FieldType.ARRAY,
-                description="표시할 컬럼 목록",
+                description=(
+                    "표시할 컬럼. 필드명 문자열 리스트 [\"symbol\",\"close\"] 또는 "
+                    "{key,label} 객체 리스트 [{\"key\":\"close\",\"label\":\"종가\"}](현지화 헤더) 허용"
+                ),
                 category=FieldCategory.SETTINGS,
                 expression_mode=ExpressionMode.FIXED_ONLY,
                 ui_options={"multiple": True},

--- a/src/core/programgarden_core/nodes/infra.py
+++ b/src/core/programgarden_core/nodes/infra.py
@@ -458,6 +458,11 @@ class SplitNode(BaseNode):
             "alternative": "Bind `{{ item }}` directly on the downstream node and delete SplitNode.",
         },
         {
+            "pattern": "Adding SplitNode without wiring its `array` input to an upstream list producer",
+            "reason": "SplitNode with no array source (no WatchlistNode/MarketUniverseNode/AccountNode/ConditionNode feeding a list, and no `array` binding) emits zero items — downstream `{{ nodes.split.item }}` resolves empty and the workflow produces silent empty results.",
+            "alternative": "Wire an upstream node that outputs an array into SplitNode, or — for a single known symbol — delete SplitNode and bind that symbol directly on the downstream node.",
+        },
+        {
             "pattern": "parallel=True for order-placement loops",
             "reason": "Placing orders concurrently without delay_ms will trip LS-Sec TR rate limits and cause spurious cancellations.",
             "alternative": "Use sequential mode with delay_ms >= 500ms for order-sensitive loops.",
@@ -530,7 +535,7 @@ class SplitNode(BaseNode):
         },
     ]
     _node_guide: ClassVar[Dict[str, Any]] = {
-        "input_handling": "`array` input — typically bound implicitly by the upstream array output. No explicit config needed; SplitNode infers the iteration from the DAG.",
+        "input_handling": "`array` input is REQUIRED and MUST have a source: either an incoming edge from an upstream node that outputs an ARRAY (WatchlistNode/MarketUniverseNode → symbols, AccountNode → positions/held_symbols, ConditionNode → values, etc.), or an explicit `array` config binding. SplitNode has NOTHING to split if no upstream produces a list — it emits zero items and every downstream `{{ nodes.split.item }}` silently resolves empty. If you already know a single concrete symbol (e.g. 'AAPL'), do NOT add SplitNode — bind that one symbol directly on the downstream node.",
         "output_consumption": "Downstream binds `{{ nodes.split.item }}` for the current element, `{{ nodes.split.index }}` for the 0-based position, and `{{ nodes.split.total }}` for the count.",
         "common_combinations": [
             "WatchlistNode → SplitNode → OverseasStockFundamentalNode",

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -14,11 +14,21 @@
   렌더러가 `f"{c:<12}"`(c=dict) 로 `dict.__format__` 크래시. `_normalize_columns` 로 문자열/
   객체 양형 수용(라벨로 헤더). 스키마도 `List[str] → List[str | {key,label}]` union 으로 정합
   (코드만 관대하던 드리프트 해소).
-- **노드 7종 에러/early-return 스키마 정합 (sweep)** — 발산 경로가 정상반환 키를 누락해
-  하류 포트 바인딩이 silent None 이 되던 결함: AIAgentNode(`response`), ConditionNode
-  (`symbols/is_condition_met/symbol_results`), BacktestEngineNode(`signals/values`),
-  ModifyOrderNode(`modified_order_id`), BrokerNode(`connected`), CancelOrderNode
-  (`cancel_result/cancelled_order`), PortfolioNode(`drawdown_percent`). 값 의미·제어흐름 불변.
+- **노드 실패 시맨틱 3-버킷 정리 (sweep)** — 노드가 하드 실패를 `{"...port": None, "error": …}`
+  에러-dict 로 돌려주면 하류가 침묵의 None 을 먹고 워크플로우가 `completed` 로 굴러
+  silent garbage 를 냈다(deep_validate 의 sole-error 승격 안전망도 키가 여럿이면 발동 안 함).
+  이제 경로마다 세 버킷으로 정리한다:
+  - **진짜 실패 → raise**(node/job failed + 사유; deep_validate blocking): AIAgentNode
+    (LLM 미연결·연결 실패·LLM 호출 실패·tool abort), ModifyOrderNode(수정 예외 3),
+    ConditionNode(resource/plugin-timeout/plugin-exc·items 미배선·required_fields 누락),
+    BrokerNode(overseas_stock+paper_trading 미지원), BacktestEngineNode(리소스 고갈).
+  - **정상 0건 → 선언 스키마 그대로 빈 값, error 키 없음**: ConditionNode(빈 positions=무보유·
+    빈 items 결과), PortfolioNode(전략 입력 0). (positions/items 바인딩 자체 부재는 static
+    validate 가 잡는다.)
+  - **부분 성공/모드 → 기존 유지**: CancelOrderNode dry_run(시뮬레이션), Condition 성공 경로.
+  AIAgentNode 는 dry_run 도 시뮬레이션 모드로 취급해 fixture 로 단락(주문 노드가 dry_run 에서
+  시뮬레이션하는 것과 동일) — 실 LLM 실패 raise 는 실 런타임에서만 시끄럽다. RealMarketData
+  (`ohlcv_data` 는 그 노드 정상 스키마)는 불변.
 - **SplitNode 배열 소스 정적 검증 (B′)** — array config 바인딩도 없고 리스트 생산 상류도
   없는 SplitNode 는 0개 아이템을 방출해 하류가 조용히 빈다. resolver 가 빌드타임에
   `MISSING_REQUIRED_FIELD` 로 flag(오탐 보수적: 모든 상류가 확정 스칼라일 때만). 스키마

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,4 +1,30 @@
 ## [Unreleased]
+
+## [1.25.1] - 2026-07-13
+> 라이브 E2E(pg-test-9)가 잡은 노드 출력-스키마 정합 결함 묶음. 관통 불변식:
+> **노드는 어떤 실행 경로에서도 자기 선언 출력 스키마를 반환한다.** 옛 호환 형태는
+> 삭제하고, 에러/빈-결과 경로도 스키마를 지킨다(에러는 error 필드로 명시, 위장 금지).
+
+### Fixed
+- **HistoricalDataNode no-symbol 스키마 정합 (A′)** — 심볼 부재 early-return 이 정상반환
+  (`value/values/symbols/period/interval`)과 전혀 다른 `{ohlcv_data, symbols}` 를 뱉어
+  하류 `{{ nodes.x.value.time_series }}` 바인딩이 조용히 None → `data or []` 가 삼켜
+  count:0 쓰레기 결과를 냈다. 이제 이 노드는 어떤 경로로도 다른 스키마를 반환하지 않는다.
+- **TableDisplayNode 객체형 columns 크래시 (C′)** — `columns=[{key,label}]`(현지화 헤더)에서
+  렌더러가 `f"{c:<12}"`(c=dict) 로 `dict.__format__` 크래시. `_normalize_columns` 로 문자열/
+  객체 양형 수용(라벨로 헤더). 스키마도 `List[str] → List[str | {key,label}]` union 으로 정합
+  (코드만 관대하던 드리프트 해소).
+- **노드 7종 에러/early-return 스키마 정합 (sweep)** — 발산 경로가 정상반환 키를 누락해
+  하류 포트 바인딩이 silent None 이 되던 결함: AIAgentNode(`response`), ConditionNode
+  (`symbols/is_condition_met/symbol_results`), BacktestEngineNode(`signals/values`),
+  ModifyOrderNode(`modified_order_id`), BrokerNode(`connected`), CancelOrderNode
+  (`cancel_result/cancelled_order`), PortfolioNode(`drawdown_percent`). 값 의미·제어흐름 불변.
+- **SplitNode 배열 소스 정적 검증 (B′)** — array config 바인딩도 없고 리스트 생산 상류도
+  없는 SplitNode 는 0개 아이템을 방출해 하류가 조용히 빈다. resolver 가 빌드타임에
+  `MISSING_REQUIRED_FIELD` 로 flag(오탐 보수적: 모든 상류가 확정 스칼라일 때만). 스키마
+  설명에 array 필수·단일심볼이면 불필요를 명시. 예제 `69-telegram-price-alert` 의
+  무효 `items`(executor 미사용)→`array` 수정.
+
 ### Added
 - **CodeNode example workflows 89–93** (json + md; example files 90 → 95) — stdlib-only
   quant hand-roll references: RSI + z-score composite, return-correlation matrix, Kelly

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -34,6 +34,13 @@
   `MISSING_REQUIRED_FIELD` 로 flag(오탐 보수적: 모든 상류가 확정 스칼라일 때만). 스키마
   설명에 array 필수·단일심볼이면 불필요를 명시. 예제 `69-telegram-price-alert` 의
   무효 `items`(executor 미사용)→`array` 수정.
+- **AIAgentNode `ai_model` 엣지 필수 정적 검증** — LLMModelNode 가 `ai_model` 엣지로
+  연결되지 않은 AIAgentNode 는 LLM 없이 애초에 동작 불가(런타임 raise)인데, 예전엔
+  static validate·deep_validate 를 둘 다 통과해 저장됐다(deep_validate 는 인프라 오류 시
+  검증을 건너뛰고 '성공'으로 저장할 수 있어 못 믿는다). resolver `_validate_ai_agent_nodes`
+  가 빌드타임에 `MISSING_REQUIRED_FIELD` 로 막는다(LLM 없이는 못 도는 필수 연결이라 오탐
+  위험 0). 노드 스키마 안티패턴에도 필수 연결임을 명시. (edge 형태 오류는 기존
+  `INVALID_AI_MODEL_EDGE` 가 별도 담당 — 여기선 '연결 자체 부재' 만 본다.)
 
 ### Added
 - **CodeNode example workflows 89–93** (json + md; example files 90 → 95) — stdlib-only

--- a/src/programgarden/examples/workflows/38-fundamental-data.json
+++ b/src/programgarden/examples/workflows/38-fundamental-data.json
@@ -56,6 +56,14 @@
       }
     },
     {
+      "id": "aggregate",
+      "type": "AggregateNode",
+      "position": {
+        "x": 800,
+        "y": 250
+      }
+    },
+    {
       "id": "display",
       "type": "TableDisplayNode",
       "title": "펀더멘털 데이터",
@@ -68,9 +76,9 @@
         "high_52w",
         "low_52w"
       ],
-      "data": "{{ nodes.fundamental.values }}",
+      "data": "{{ nodes.aggregate.array }}",
       "position": {
-        "x": 800,
+        "x": 1000,
         "y": 250
       }
     }
@@ -94,6 +102,10 @@
     },
     {
       "from": "fundamental",
+      "to": "aggregate"
+    },
+    {
+      "from": "aggregate",
       "to": "display"
     }
   ],

--- a/src/programgarden/examples/workflows/69-telegram-price-alert.json
+++ b/src/programgarden/examples/workflows/69-telegram-price-alert.json
@@ -18,7 +18,7 @@
     {
       "id": "split_symbol",
       "type": "SplitNode",
-      "items": [
+      "array": [
         {"symbol": "NVDA", "exchange": "NASDAQ"}
       ],
       "position": {"x": 450, "y": 200}

--- a/src/programgarden/examples/workflows/69-telegram-price-alert.json
+++ b/src/programgarden/examples/workflows/69-telegram-price-alert.json
@@ -16,17 +16,11 @@
       "position": {"x": 250, "y": 200}
     },
     {
-      "id": "split_symbol",
-      "type": "SplitNode",
-      "array": [
-        {"symbol": "NVDA", "exchange": "NASDAQ"}
-      ],
-      "position": {"x": 450, "y": 200}
-    },
-    {
       "id": "market",
       "type": "OverseasStockMarketDataNode",
-      "symbols": "{{ nodes.split_symbol.items }}",
+      "symbols": [
+        {"symbol": "NVDA", "exchange": "NASDAQ"}
+      ],
       "position": {"x": 650, "y": 200}
     },
     {
@@ -47,8 +41,7 @@
   ],
   "edges": [
     {"from": "start", "to": "broker"},
-    {"from": "broker", "to": "split_symbol"},
-    {"from": "split_symbol", "to": "market"},
+    {"from": "broker", "to": "market"},
     {"from": "market", "to": "if_price_above"},
     {"from": "if_price_above", "to": "telegram_alert", "from_port": "true"}
   ],
@@ -73,7 +66,7 @@
   "notes": [
     {
       "id": "note_guide",
-      "content": "## 왕초보 튜토리얼\n\n**질문**: '엔비디아가 100불 넘으면 알려줘'\n\n**흐름**:\n1. SplitNode → 감시 종목 1개 정의 (NVDA)\n2. MarketDataNode → g3101 API로 현재가 조회\n3. IfNode → 현재가 >= $100 체크\n4. TelegramNode → 조건 충족 시만 알림\n\n**커스터마이징**:\n- 다른 종목: items 의 symbol/exchange 변경\n- 다른 목표가: IfNode.right 숫자 변경\n- 하락 알림: operator를 '<=' 로, right를 하한가로\n\n**주의**: NVDA 가 현재 $100 미만이면 IfNode 는 false 분기 → 텔레그램 발송 안됨 (정상 동작)",
+      "content": "## 왕초보 튜토리얼\n\n**질문**: '엔비디아가 100불 넘으면 알려줘'\n\n**흐름**:\n1. MarketDataNode → 감시 종목(NVDA)의 현재가를 g3101 API로 조회\n2. IfNode → 현재가 >= $100 체크\n3. TelegramNode → 조건 충족 시만 알림\n\n**커스터마이징**:\n- 다른 종목: market 노드 symbols 의 symbol/exchange 변경\n- 다른 목표가: IfNode.right 숫자 변경\n- 하락 알림: operator를 '<=' 로, right를 하한가로\n\n**여러 종목 감시**: symbols 에 항목을 추가한 뒤, 종목별 개별 처리가 필요하면 SplitNode(+ 짝 AggregateNode)로 분리하세요. 단일 종목이면 SplitNode 없이 바로 바인딩하는 것이 정석입니다.\n\n**주의**: NVDA 가 현재 $100 미만이면 IfNode 는 false 분기 → 텔레그램 발송 안됨 (정상 동작)",
       "color": 3,
       "width": 340,
       "height": 280,

--- a/src/programgarden/programgarden/__init__.py
+++ b/src/programgarden/programgarden/__init__.py
@@ -91,7 +91,7 @@ except ImportError:
     # Community package not installed
     pass
 
-__version__ = "1.18.0"
+__version__ = "1.25.1"
 __all__ = [
     # Core
     "ProgramGarden",

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -2812,6 +2812,7 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 node_id,
             )
             return {
+                "connected": False,
                 "connection": None,
                 "error": "overseas_stock does not support paper_trading. Set paper_trading=False to use real mode.",
             }
@@ -8143,9 +8144,12 @@ class ConditionNodeExecutor(NodeExecutorBase):
             context.log("warning", f"Resource limit reached: {resource_check['reason']}", node_id)
             # 리소스 부족 시 빈 결과 반환 (안전 모드)
             return {
+                "symbols": [],
                 "result": False,
+                "is_condition_met": False,
                 "passed_symbols": [],
                 "failed_symbols": [],
+                "symbol_results": [],
                 "values": {},
                 "error": "resource_limit",
             }
@@ -8198,9 +8202,12 @@ class ConditionNodeExecutor(NodeExecutorBase):
                         node_id
                     )
                     return {
+                        "symbols": [],
                         "result": False,
+                        "is_condition_met": False,
                         "passed_symbols": [],
                         "failed_symbols": [],
+                        "symbol_results": [],
                         "values": [],
                         "error": "missing_positions",
                         "error_message": "positions가 설정되지 않았습니다. 예: {{ nodes.realAccount.positions }}",
@@ -8252,6 +8259,7 @@ class ConditionNodeExecutor(NodeExecutorBase):
                         return {
                             "symbols": [p.get("symbol") for p in positions if isinstance(p, dict)],
                             "result": True if (getattr(context, "is_deep_validate", False) and _passed) else result.get("result", False),
+                            "is_condition_met": True if (getattr(context, "is_deep_validate", False) and _passed) else result.get("result", False),
                             "passed_symbols": _passed,
                             "failed_symbols": [] if (getattr(context, "is_deep_validate", False) and _passed) else result.get("failed_symbols", []),
                             "symbol_results": result.get("symbol_results", []),
@@ -8262,9 +8270,12 @@ class ConditionNodeExecutor(NodeExecutorBase):
                         import traceback
                         context.log("debug", f"Plugin traceback: {traceback.format_exc()}", node_id)
                         return {
+                            "symbols": [],
                             "result": False,
+                            "is_condition_met": False,
                             "passed_symbols": [],
                             "failed_symbols": [],
+                            "symbol_results": [],
                             "values": [],
                             "error": str(e),
                         }
@@ -8274,6 +8285,7 @@ class ConditionNodeExecutor(NodeExecutorBase):
                     return {
                         "symbols": list(positions.keys()),
                         "result": True,
+                        "is_condition_met": True,
                         "passed_symbols": passed_symbols,
                         "failed_symbols": [],
                         "symbol_results": [],
@@ -8291,9 +8303,12 @@ class ConditionNodeExecutor(NodeExecutorBase):
                     node_id
                 )
                 return {
+                    "symbols": [],
                     "result": False,
+                    "is_condition_met": False,
                     "passed_symbols": [],
                     "failed_symbols": [],
+                    "symbol_results": [],
                     "values": [],
                     "error": "missing_items",
                     "error_message": "items가 설정되지 않았습니다. items { from, extract } 형태로 추가하세요.",
@@ -8311,9 +8326,12 @@ class ConditionNodeExecutor(NodeExecutorBase):
                         node_id
                     )
                     return {
+                        "symbols": [],
                         "result": False,
+                        "is_condition_met": False,
                         "passed_symbols": [],
                         "failed_symbols": [],
+                        "symbol_results": [],
                         "values": [],
                         "error": "missing_required_fields",
                         "error_message": f"extract에 필수 필드 누락: {missing}",
@@ -8328,9 +8346,12 @@ class ConditionNodeExecutor(NodeExecutorBase):
                     node_id
                 )
                 return {
+                    "symbols": [],
                     "result": False,
+                    "is_condition_met": False,
                     "passed_symbols": [],
                     "failed_symbols": [],
+                    "symbol_results": [],
                     "values": [],
                     "error": "empty_items_result",
                     "error_message": "items 처리 결과가 비어있습니다. from 배열을 확인하세요.",
@@ -8386,9 +8407,12 @@ class ConditionNodeExecutor(NodeExecutorBase):
         except PluginTimeoutError as e:
             context.log("error", f"Plugin timeout: {e}", node_id)
             return {
+                "symbols": [],
                 "result": False,
+                "is_condition_met": False,
                 "passed_symbols": [],
                 "failed_symbols": symbols if 'symbols' in locals() else [],
+                "symbol_results": [],
                 "values": {},
                 "error": "plugin_timeout",
             }
@@ -10350,6 +10374,8 @@ class BacktestEngineNodeExecutor(NodeExecutorBase):
             return {
                 "equity_curve": [],
                 "trades": [],
+                "signals": [],
+                "values": [],
                 "metrics": {},
                 "summary": {"error": resource_check["reason"]},
             }
@@ -10370,6 +10396,8 @@ class BacktestEngineNodeExecutor(NodeExecutorBase):
                     return {
                         "equity_curve": [],
                         "trades": [],
+                        "signals": [],
+                        "values": [],
                         "metrics": {},
                         "summary": {"error": "items 처리 결과가 비어있습니다."},
                     }
@@ -11356,6 +11384,7 @@ class PortfolioNodeExecutor(NodeExecutorBase):
             "rebalance_signal": False,
             "rebalance_orders": [],
             "allocated_capital": {},
+            "drawdown_percent": 0,
         }
 
 
@@ -13834,6 +13863,7 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
                     "original_order_id": original_order_id,
                     "product": "overseas_stock",
                 },
+                "modified_order_id": None,
                 "modified_order": None,
             }
 
@@ -13956,6 +13986,7 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
                     "original_order_id": original_order_id,
                     "product": "overseas_futures",
                 },
+                "modified_order_id": None,
                 "modified_order": None,
             }
 
@@ -14058,6 +14089,7 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
                     "original_order_id": original_order_id,
                     "product": "korea_stock",
                 },
+                "modified_order_id": None,
                 "modified_order": None,
             }
 
@@ -14117,7 +14149,9 @@ class CancelOrderNodeExecutor(NodeExecutorBase):
             )
             return {
                 "order_id": order_id,
+                "cancel_result": None,
                 "cancelled_order_id": order_id,
+                "cancelled_order": None,
                 "status": "simulated",
                 "dry_run": True,
                 "requested": config,
@@ -15037,12 +15071,12 @@ class AIAgentNodeExecutor(NodeExecutorBase):
         workflow = kwargs.get("workflow")
         if not workflow:
             context.log("error", "AIAgentNode requires workflow context", node_id)
-            return {"error": "Workflow context not provided"}
+            return {"response": None, "error": "Workflow context not provided"}
 
         ai_model_node_id = workflow.get_ai_model_node_id(node_id)
         if not ai_model_node_id:
             context.log("error", "No LLMModelNode connected via ai_model edge", node_id)
-            return {"error": "No LLM model connected. Connect a LLMModelNode via ai_model edge."}
+            return {"response": None, "error": "No LLM model connected. Connect a LLMModelNode via ai_model edge."}
 
         # LLMModelNode의 출력에서 connection 가져오기
         llm_connection = context.get_output(ai_model_node_id, "connection")
@@ -15062,7 +15096,7 @@ class AIAgentNodeExecutor(NodeExecutorBase):
 
         if not llm_connection:
             context.log("error", "Failed to get LLM connection", node_id)
-            return {"error": "Failed to get LLM connection from LLMModelNode."}
+            return {"response": None, "error": "Failed to get LLM connection from LLMModelNode."}
 
         # secrets에서 API 키 복원 (H-8: 평문 노출 방지)
         llm_node_ref = llm_connection.get("_llm_node_id", ai_model_node_id)
@@ -15169,7 +15203,7 @@ class AIAgentNodeExecutor(NodeExecutorBase):
                     )
             except Exception as e:
                 context.log("error", f"LLM call failed: {e}", node_id)
-                return {"error": f"LLM call failed: {e}"}
+                return {"response": None, "error": f"LLM call failed: {e}"}
 
             # 토큰 사용량 이벤트
             from programgarden_core.bases.listener import TokenUsageEvent
@@ -15290,7 +15324,7 @@ class AIAgentNodeExecutor(NodeExecutorBase):
                     ))
 
                     if tool_error_strategy == "abort":
-                        return {"error": f"Tool '{tool_name}' failed: {e}"}
+                        return {"response": None, "error": f"Tool '{tool_name}' failed: {e}"}
                     elif tool_error_strategy == "skip":
                         messages.append({
                             "role": "tool",

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -9640,8 +9640,20 @@ class HistoricalDataNodeExecutor(NodeExecutorBase):
                         symbol_exchange_map[sym] = mc
         
         if not symbols:
+            # NOTE: 정상 return(아래 9690)과 **동일 스키마**로 반환해야 한다. 옛
+            # `{"ohlcv_data": {}, "symbols": []}` 는 정상 형태(value/values/period/
+            # interval)와 완전히 달라, 하류의 정상 바인딩(`{{ nodes.x.value.time_series }}`
+            # / ConditionNode 의 `item.time_series`)이 조용히 None 이 되고 방어적
+            # `data or []` 가 그걸 삼켜 에러 없이 빈 결과(count:0)를 낸다.
+            # (deep_fixtures.historical_data_fixture 도 이 스키마를 못박는다.)
             context.log("warning", "No symbols provided", node_id)
-            return {"ohlcv_data": {}, "symbols": []}
+            return {
+                "value": None,
+                "values": [],
+                "symbols": [],
+                "period": "",
+                "interval": config.get("interval", "1d"),
+            }
         
         # 기간 설정 ({{ today_yyyymmdd() }}, {{ days_ago_yyyymmdd(100) }} 바인딩 사용)
         start_date = config.get("start_date", "")

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -2811,12 +2811,15 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 "paper_trading=False로 설정하거나, 해외선물(overseas_futures)을 사용하세요.",
                 node_id,
             )
-            return {
-                "connected": False,
-                "connection": None,
-                "error": "overseas_stock does not support paper_trading. Set paper_trading=False to use real mode.",
-            }
-        
+            # 하드 실패(지원하지 않는 설정 조합) → raise. 에러-dict 로 굴러가면 하류가
+            # connected/connection 을 침묵의 False/None 으로 먹고 워크플로우가 완주한다.
+            from programgarden_core.exceptions import ValidationError
+            raise ValidationError(
+                "overseas_stock does not support paper_trading (LS-Sec limitation). Set "
+                "paper_trading=False, or use overseas_futures for paper trading.",
+                node_id=node_id,
+            )
+
         # ========================================
         # Credential 자동 주입 (GenericNodeExecutor와 동일 패턴)
         # credential_id가 있으면 appkey, appsecret이 config에 주입됨
@@ -8127,6 +8130,7 @@ class ConditionNodeExecutor(NodeExecutorBase):
     ) -> Dict[str, Any]:
         from programgarden.plugin import PluginSandbox, PluginTimeoutError
         from programgarden_core.models import get_plugin_hints
+        from programgarden_core.exceptions import ValidationError, ExecutionError
 
         # 플러그인 ID 추출
         plugin_id = config.get("plugin", "Unknown")
@@ -8141,18 +8145,14 @@ class ConditionNodeExecutor(NodeExecutorBase):
         )
         
         if not resource_check["can_proceed"]:
-            context.log("warning", f"Resource limit reached: {resource_check['reason']}", node_id)
-            # 리소스 부족 시 빈 결과 반환 (안전 모드)
-            return {
-                "symbols": [],
-                "result": False,
-                "is_condition_met": False,
-                "passed_symbols": [],
-                "failed_symbols": [],
-                "symbol_results": [],
-                "values": {},
-                "error": "resource_limit",
-            }
+            # 하드 실패(리소스 고갈로 실행 불가) → raise. 빈 결과를 성공으로 위장하면
+            # 하류 IfNode 가 is_condition_met=False 를 조용히 먹어 잘못된 분기를 탄다.
+            context.log("error", f"Resource limit reached: {resource_check['reason']}", node_id)
+            raise ExecutionError(
+                f"ConditionNode cannot run — resource limit reached: "
+                f"{resource_check['reason']}",
+                node_id=node_id,
+            )
         
         # 권장 배치 크기 저장 (백테스트 모드에서 사용)
         recommended_batch_size = resource_check.get("recommended_batch_size", 10)
@@ -8196,9 +8196,12 @@ class ConditionNodeExecutor(NodeExecutorBase):
                 context.log("debug", f"positions 평가 후: {type(positions).__name__}, {len(positions) if isinstance(positions, (list, dict)) else 0} items", node_id)
 
                 if not positions or not isinstance(positions, list):
-                    context.log("error", 
-                        f"ConditionNode '{node_id}': positions가 설정되지 않았습니다. "
-                        f"config에 positions: {{{{ nodes.realAccount.positions }}}} 형태로 추가하세요.",
+                    # 정상 0건: 보유 포지션이 없으면(빈 리스트) 검사할 대상이 없어 신호 0건.
+                    # `positions` 바인딩이 아예 없는 config 오류는 static validate 가
+                    # (resolver._validate: position-plugin ↔ positions) 이미 잡으므로,
+                    # 런타임 빈/미해결은 하드 실패로 죽이지 않고 정상 빈 값으로 흘린다.
+                    context.log("info",
+                        f"ConditionNode '{node_id}': positions 비어있음 → 통과 종목 없음(정상 0건).",
                         node_id
                     )
                     return {
@@ -8209,8 +8212,6 @@ class ConditionNodeExecutor(NodeExecutorBase):
                         "failed_symbols": [],
                         "symbol_results": [],
                         "values": [],
-                        "error": "missing_positions",
-                        "error_message": "positions가 설정되지 않았습니다. 예: {{ nodes.realAccount.positions }}",
                     }
                 
                 # fields 표현식 평가
@@ -8266,19 +8267,14 @@ class ConditionNodeExecutor(NodeExecutorBase):
                             "values": result.get("values", []),
                         }
                     except Exception as e:
+                        # 하드 실패(플러그인 실행 예외) → raise.
                         context.log("error", f"Plugin error: {e}", node_id)
                         import traceback
                         context.log("debug", f"Plugin traceback: {traceback.format_exc()}", node_id)
-                        return {
-                            "symbols": [],
-                            "result": False,
-                            "is_condition_met": False,
-                            "passed_symbols": [],
-                            "failed_symbols": [],
-                            "symbol_results": [],
-                            "values": [],
-                            "error": str(e),
-                        }
+                        raise ExecutionError(
+                            f"ConditionNode plugin execution failed: {e}",
+                            node_id=node_id,
+                        ) from e
                 else:
                     # 플러그인 없으면 모두 통과
                     passed_symbols = [{"symbol": s, "exchange": "UNKNOWN"} for s in positions.keys()]
@@ -8302,17 +8298,13 @@ class ConditionNodeExecutor(NodeExecutorBase):
                     f"items {{ from, extract }} 형태로 추가하세요.",
                     node_id
                 )
-                return {
-                    "symbols": [],
-                    "result": False,
-                    "is_condition_met": False,
-                    "passed_symbols": [],
-                    "failed_symbols": [],
-                    "symbol_results": [],
-                    "values": [],
-                    "error": "missing_items",
-                    "error_message": "items가 설정되지 않았습니다. items { from, extract } 형태로 추가하세요.",
-                }
+                # 하드 실패(필수입력 부재) → raise.
+                raise ValidationError(
+                    "ConditionNode uses an indicator plugin but has no `items` binding. Add "
+                    "items { from, extract } — e.g. items: { from: '{{ nodes.hist.values }}', "
+                    "extract: { symbol: '{{ item.symbol }}', close: '{{ row.close }}' } }.",
+                    node_id=node_id,
+                )
 
             # === 플러그인 required_fields 검증 ===
             if plugin_schema and hasattr(plugin_schema, 'required_fields'):
@@ -8325,24 +8317,23 @@ class ConditionNodeExecutor(NodeExecutorBase):
                         f"플러그인 {plugin_id}는 {required_fields} 필드가 필요합니다.",
                         node_id
                     )
-                    return {
-                        "symbols": [],
-                        "result": False,
-                        "is_condition_met": False,
-                        "passed_symbols": [],
-                        "failed_symbols": [],
-                        "symbol_results": [],
-                        "values": [],
-                        "error": "missing_required_fields",
-                        "error_message": f"extract에 필수 필드 누락: {missing}",
-                    }
+                    # 하드 실패(필수입력 부재 — 플러그인 required_fields 누락) → raise.
+                    raise ValidationError(
+                        f"ConditionNode plugin '{plugin_id}' requires extract fields "
+                        f"{required_fields}, but these are missing: {missing}. Add them to "
+                        f"items.extract.",
+                        node_id=node_id,
+                    )
 
             # items 처리 (from 배열을 순회하며 extract 적용)
             data = self._process_items_with_extract(items_config, context, node_id)
 
             if not data:
-                context.log("error",
-                    f"ConditionNode '{node_id}': items 처리 결과가 비어있습니다.",
+                # 정상 0건(런타임에 from 배열이 비어 평가할 항목 없음 — 예: 장 마감/무거래).
+                # 하드 실패가 아니므로 선언 스키마 그대로 빈 값(no signal). error 키 없음.
+                # 구조적 미배선은 B′ SplitNode/도달성 가드·deep_validate 가 별도로 잡는다.
+                context.log("info",
+                    f"ConditionNode '{node_id}': items 처리 결과가 비어있어 통과 종목 없음(정상 0건).",
                     node_id
                 )
                 return {
@@ -8353,8 +8344,6 @@ class ConditionNodeExecutor(NodeExecutorBase):
                     "failed_symbols": [],
                     "symbol_results": [],
                     "values": [],
-                    "error": "empty_items_result",
-                    "error_message": "items 처리 결과가 비어있습니다. from 배열을 확인하세요.",
                 }
 
             # symbols 자동 추출 (data에서)
@@ -8405,17 +8394,13 @@ class ConditionNodeExecutor(NodeExecutorBase):
                 field_mapping=field_mapping,
             )
         except PluginTimeoutError as e:
+            # 하드 실패(플러그인 타임아웃) → raise.
+            from programgarden_core.exceptions import ExecutionError
             context.log("error", f"Plugin timeout: {e}", node_id)
-            return {
-                "symbols": [],
-                "result": False,
-                "is_condition_met": False,
-                "passed_symbols": [],
-                "failed_symbols": symbols if 'symbols' in locals() else [],
-                "symbol_results": [],
-                "values": {},
-                "error": "plugin_timeout",
-            }
+            raise ExecutionError(
+                f"ConditionNode plugin timed out: {e}",
+                node_id=node_id,
+            ) from e
         finally:
             # 리소스 반환
             await context.release_resources_after_task(
@@ -10370,16 +10355,15 @@ class BacktestEngineNodeExecutor(NodeExecutorBase):
         )
         
         if not resource_check["can_proceed"]:
+            # 하드 실패(리소스 고갈로 실행 불가) → raise(빈 결과를 성공으로 위장하지 않음).
+            from programgarden_core.exceptions import ExecutionError
             context.log("error", f"Cannot run backtest: {resource_check['reason']}", node_id)
-            return {
-                "equity_curve": [],
-                "trades": [],
-                "signals": [],
-                "values": [],
-                "metrics": {},
-                "summary": {"error": resource_check["reason"]},
-            }
-        
+            raise ExecutionError(
+                f"BacktestEngineNode cannot run — resource limit reached: "
+                f"{resource_check['reason']}",
+                node_id=node_id,
+            )
+
         try:
             # === items { from, extract } 방식으로 입력 데이터 가져오기 ===
             items_config = config.get("items")
@@ -13855,17 +13839,14 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
             }
             
         except Exception as e:
-            context.log("warning", f"Modify order exception: {e}", node_id)
-            return {
-                "modify_result": {
-                    "success": False,
-                    "error": str(e),
-                    "original_order_id": original_order_id,
-                    "product": "overseas_stock",
-                },
-                "modified_order_id": None,
-                "modified_order": None,
-            }
+            # 하드 실패 → raise(에러-dict 로 삼키면 하류가 침묵의 None → silent garbage).
+            from programgarden_core.exceptions import ExecutionError
+            context.log("error", f"Modify order exception (overseas_stock): {e}", node_id)
+            raise ExecutionError(
+                f"ModifyOrderNode failed to modify overseas_stock order "
+                f"'{original_order_id}': {e}",
+                node_id=node_id,
+            ) from e
 
     async def _modify_overseas_futures(
         self,
@@ -13978,17 +13959,13 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
             }
             
         except Exception as e:
-            context.log("warning", f"Modify futures order exception: {e}", node_id)
-            return {
-                "modify_result": {
-                    "success": False,
-                    "error": str(e),
-                    "original_order_id": original_order_id,
-                    "product": "overseas_futures",
-                },
-                "modified_order_id": None,
-                "modified_order": None,
-            }
+            from programgarden_core.exceptions import ExecutionError
+            context.log("error", f"Modify futures order exception: {e}", node_id)
+            raise ExecutionError(
+                f"ModifyOrderNode failed to modify overseas_futures order "
+                f"'{original_order_id}': {e}",
+                node_id=node_id,
+            ) from e
 
     async def _modify_korea_stock(
         self,
@@ -14081,17 +14058,13 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
             }
 
         except Exception as e:
-            context.log("warning", f"Korea stock modify order exception: {e}", node_id)
-            return {
-                "modify_result": {
-                    "success": False,
-                    "error": str(e),
-                    "original_order_id": original_order_id,
-                    "product": "korea_stock",
-                },
-                "modified_order_id": None,
-                "modified_order": None,
-            }
+            from programgarden_core.exceptions import ExecutionError
+            context.log("error", f"Korea stock modify order exception: {e}", node_id)
+            raise ExecutionError(
+                f"ModifyOrderNode failed to modify korea_stock order "
+                f"'{original_order_id}': {e}",
+                node_id=node_id,
+            ) from e
 
     def _error_result(self, error_msg: str) -> Dict[str, Any]:
         """에러 결과 반환"""
@@ -15041,13 +15014,16 @@ class AIAgentNodeExecutor(NodeExecutorBase):
     ) -> Dict[str, Any]:
         import json as json_module
         from programgarden.providers import LLMProvider
+        from programgarden_core.exceptions import ValidationError, ExecutionError
 
-        # === 0. deep_validate: 실 LLM/ReAct 루프를 절대 돌리지 않는다 ===
+        # === 0. deep_validate / dry_run: 실 LLM/ReAct 루프를 절대 돌리지 않는다 ===
         # 가짜(스키마-shaped) response 를 주입해 다운스트림 {{ nodes.X.response[.field] }}
-        # 바인딩이 풀리고 flow 무결성이 검증되도록 한다(네트워크·모델비용 0). 실 LLM
-        # 호출 실패를 {"error":...} 로 삼키던 silent-fail 경로 자체를 제거한다.
+        # 바인딩이 풀리고 flow 무결성이 검증되도록 한다(네트워크·모델비용 0).
+        # dry_run 도 시뮬레이션 모드다(주문 노드가 dry_run 에서 시뮬레이션하는 것과 동일).
+        # 실 LLM 호출 실패는 아래 실경로에서 **raise** 로 시끄럽게 처리하고(silent None 금지),
+        # 시뮬레이션 모드에선 실 호출 자체를 안 하므로 여기서 fixture 로 단락한다.
         # preset 을 먼저 적용해 output_format/output_schema 가 런타임과 동일하게 반영되도록 함.
-        if getattr(context, "is_deep_validate", False):
+        if getattr(context, "is_deep_validate", False) or getattr(context, "is_dry_run", False):
             from programgarden import deep_fixtures as _df
             _deep_config = config
             _preset_id = config.get("preset")
@@ -15071,12 +15047,21 @@ class AIAgentNodeExecutor(NodeExecutorBase):
         workflow = kwargs.get("workflow")
         if not workflow:
             context.log("error", "AIAgentNode requires workflow context", node_id)
-            return {"response": None, "error": "Workflow context not provided"}
+            # 하드 실패(설정 오류) → raise. 에러-dict 로 굴러가면 하류가 침묵의 None 을
+            # 먹고 워크플로우가 완주해 silent garbage 가 된다(§sweep 리워크).
+            raise ValidationError(
+                "AIAgentNode requires workflow context but none was provided.",
+                node_id=node_id,
+            )
 
         ai_model_node_id = workflow.get_ai_model_node_id(node_id)
         if not ai_model_node_id:
             context.log("error", "No LLMModelNode connected via ai_model edge", node_id)
-            return {"response": None, "error": "No LLM model connected. Connect a LLMModelNode via ai_model edge."}
+            raise ValidationError(
+                "No LLM model connected. Connect a LLMModelNode to this AIAgentNode via an "
+                "ai_model edge.",
+                node_id=node_id,
+            )
 
         # LLMModelNode의 출력에서 connection 가져오기
         llm_connection = context.get_output(ai_model_node_id, "connection")
@@ -15096,7 +15081,11 @@ class AIAgentNodeExecutor(NodeExecutorBase):
 
         if not llm_connection:
             context.log("error", "Failed to get LLM connection", node_id)
-            return {"response": None, "error": "Failed to get LLM connection from LLMModelNode."}
+            raise ValidationError(
+                "Failed to get LLM connection from the connected LLMModelNode "
+                "(check the model node's config/credentials).",
+                node_id=node_id,
+            )
 
         # secrets에서 API 키 복원 (H-8: 평문 노출 방지)
         llm_node_ref = llm_connection.get("_llm_node_id", ai_model_node_id)
@@ -15203,7 +15192,7 @@ class AIAgentNodeExecutor(NodeExecutorBase):
                     )
             except Exception as e:
                 context.log("error", f"LLM call failed: {e}", node_id)
-                return {"response": None, "error": f"LLM call failed: {e}"}
+                raise ExecutionError(f"AIAgentNode LLM call failed: {e}", node_id=node_id) from e
 
             # 토큰 사용량 이벤트
             from programgarden_core.bases.listener import TokenUsageEvent
@@ -15324,7 +15313,11 @@ class AIAgentNodeExecutor(NodeExecutorBase):
                     ))
 
                     if tool_error_strategy == "abort":
-                        return {"response": None, "error": f"Tool '{tool_name}' failed: {e}"}
+                        raise ExecutionError(
+                            f"AIAgentNode tool '{tool_name}' failed and tool_error_strategy="
+                            f"'abort': {e}",
+                            node_id=node_id,
+                        ) from e
                     elif tool_error_strategy == "skip":
                         messages.append({
                             "role": "tool",

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -7471,6 +7471,26 @@ class DisplayNodeExecutor(NodeExecutorBase):
             return str(value)[:15] + "..." if len(str(value)) > 15 else str(value)
         return str(value)[:20]
 
+    def _normalize_columns(self, columns: Any) -> Optional[List[tuple]]:
+        """`columns` 설정을 [(key, label), ...] 로 정규화.
+
+        스키마 정본은 `List[str]`(예: ["symbol","close"])이지만, LLM 이 리치 객체형
+        [{"key":"date","label":"날짜"}] 을 뱉는 경우가 있다. 이때 옛 렌더러는
+        `f"{c:<12}"`(c=dict)에서 `unsupported format string passed to dict.__format__`
+        로 크래시했다. 양형을 모두 받아 (조회 key, 표시 label)로 환원한다."""
+        if not columns:
+            return None
+        norm: List[tuple] = []
+        for c in columns:
+            if isinstance(c, dict):
+                key = c.get("key") or c.get("name") or c.get("field") or c.get("label")
+                label = c.get("label") or c.get("title") or key
+                if key:
+                    norm.append((str(key), str(label)))
+            elif c is not None:
+                norm.append((str(c), str(c)))
+        return norm or None
+
     def _get_data(self, config: Dict[str, Any], context: ExecutionContext, node_id: str) -> Any:
         """data 필드 또는 엣지에서 데이터 가져오기"""
         # 1. config의 data 필드가 바인딩 표현식인 경우 이미 평가됨
@@ -7581,12 +7601,16 @@ class DisplayNodeExecutor(NodeExecutorBase):
                     rows = sorted(rows, key=lambda x: x.get(sort_by, 0), reverse=(sort_order == "desc"))
                 rows = rows[:limit]
                 
-                cols = columns or list(rows[0].keys())[:8]
-                header = " | ".join(f"{c:<12}" for c in cols)
+                cols = self._normalize_columns(columns) or [
+                    (k, k) for k in list(rows[0].keys())[:8]
+                ]
+                header = " | ".join(f"{label:<12}" for _, label in cols)
                 print(header)
                 print("-" * 80)
                 for row in rows:
-                    values = " | ".join(f"{self._format_value(row.get(c)):<12}" for c in cols)
+                    values = " | ".join(
+                        f"{self._format_value(row.get(key)):<12}" for key, _ in cols
+                    )
                     print(values)
                     
             elif isinstance(data, dict):
@@ -7599,12 +7623,16 @@ class DisplayNodeExecutor(NodeExecutorBase):
                     items = items[:limit]
                     
                     if items:
-                        cols = columns or list(items[0][1].keys())[:6]
-                        header = f"{'Key':<12} | " + " | ".join(f"{c:<12}" for c in cols)
+                        cols = self._normalize_columns(columns) or [
+                            (k, k) for k in list(items[0][1].keys())[:6]
+                        ]
+                        header = f"{'Key':<12} | " + " | ".join(f"{label:<12}" for _, label in cols)
                         print(header)
                         print("-" * 80)
                         for key, val in items:
-                            values = f"{key:<12} | " + " | ".join(f"{self._format_value(val.get(c)):<12}" for c in cols)
+                            values = f"{key:<12} | " + " | ".join(
+                                f"{self._format_value(val.get(col_key)):<12}" for col_key, _ in cols
+                            )
                             print(values)
                 else:
                     # flat dict

--- a/src/programgarden/programgarden/resolver.py
+++ b/src/programgarden/programgarden/resolver.py
@@ -1091,22 +1091,35 @@ class WorkflowResolver:
                             )
                         )
 
-    # SplitNode 가 분리할 배열을 실제로 못 받는데도 런타임엔 조용히 0개 아이템을
-    # 방출한다(executor: config `array` 없고 상류 출력에도 리스트 없음 → input_array=[]).
-    # 그러면 하류 `{{ nodes.<split>.item }}` 이 조용히 비어 워크플로우가 count:0 쓰레기
-    # 결과를 낸다(단일 심볼에 SplitNode 를 잘못 붙이는 것이 전형적 저작 결함). 정적으로
+    # SplitNode 는 실 엔진에서 두 조건이 **모두** 충족돼야만 동작한다(6변형 dry_run
+    # 프로브로 확정, executor._execute_split_branch / _execute_main_flow):
+    #   (1) 짝 AggregateNode 가 그래프상 도달 가능해야 한다. 없으면 _execute_split_branch
+    #       가 aggregate_id=None 에서 즉시 return → branch 자체가 실행 안 됨(노드 pending
+    #       유지, 하류 item 전부 공백). engine._find_split_aggregate_pairs 참조.
+    #   (2) split 로 들어오는 상류 노드가 리스트를 출력해야 한다. 엔진은 분리 대상 배열을
+    #       **오직 상류 노드 출력**(포트 symbols/values/array/data/items)에서만 읽는다.
+    #       config `array` 필드는 **어느 경로에서도 읽히지 않는다**(SplitNodeExecutor.execute
+    #       의 config.get("array") 는 죽은 코드 — 실행 엔진이 그 executor 를 거치지 않고
+    #       상류 출력에서 배열을 직접 가져와 item 을 set). 따라서 `array`/`items` 를 config
+    #       리터럴로 넣는 저작 패턴은 검증만 통과하고 런타임엔 0개를 낸다.
+    # 둘 중 하나라도 빠지면 하류 `{{ nodes.<split>.item }}` 이 조용히 비어 count:0 쓰레기
+    # 결과가 된다(단일 심볼에 SplitNode 를 잘못 붙이는 것이 전형적 저작 결함). 정적으로
     # 잡아 AI self-correct 루프가 dry_run 전에 보게 한다.
-    # 오탐(최대 리스크) 최소화: 상류 중 하나라도 리스트를 낼 "가능성"이 있으면 통과한다.
-    #   가능성 = (a) `array` config 가 배선됨, (b) 상류가 CodeNode(동적 출력),
-    #            (c) 상류 스키마 미상(커뮤니티/제네릭), (d) 상류 출력 포트 타입 중 하나라도
-    #                확정 스칼라/시그널이 아님. 모든 상류가 확정 스칼라일 때만 flag.
+    # 오탐(최대 리스크) 최소화: (2)는 상류 중 하나라도 리스트를 낼 "가능성"이 있으면 통과.
+    #   가능성 = (a) 상류가 CodeNode(동적 출력), (b) 상류 스키마 미상(커뮤니티/제네릭),
+    #            (c) 상류 출력 포트 타입 중 하나라도 확정 스칼라/시그널이 아님.
+    #            모든 상류가 확정 스칼라일 때만 flag.
     _SPLIT_SCALAR_OUTPUT_TYPES = frozenset({
         "signal", "boolean", "integer", "number", "float", "string",
         "broker_connection",
     })
 
     def _validate_split_nodes(self, workflow, registry, result: ValidationResult) -> None:
-        """SplitNode 의 분리 대상 배열이 배선됐는지 정적 검증(오탐 보수적)."""
+        """SplitNode 가 실 엔진에서 동작 가능하게 배선됐는지 정적 검증(오탐 보수적).
+
+        엔진 동작(프로브 확정): SplitNode 는 (1) 짝 AggregateNode 가 도달 가능하고
+        (2) 상류가 리스트를 출력해야만 branch 를 실행한다. config `array` 는 안 읽힌다.
+        """
         split_nodes = [
             n for n in workflow.nodes
             if isinstance(n, dict) and n.get("type") == "SplitNode"
@@ -1116,7 +1129,12 @@ class WorkflowResolver:
         node_type_by_id = {
             n.get("id"): n.get("type") for n in workflow.nodes if isinstance(n, dict)
         }
-        # split_id -> [upstream source ids]
+        aggregate_ids: Set[str] = {
+            n.get("id") for n in workflow.nodes
+            if isinstance(n, dict) and n.get("type") == "AggregateNode"
+        }
+        # adjacency(from_id -> [to_id]) + incoming(to_id -> [from_id])
+        adjacency: Dict[str, List[str]] = {}
         incoming: Dict[str, List[str]] = {}
         for edge in workflow.edges:
             to_raw = getattr(edge, "to_node", "") or ""
@@ -1125,6 +1143,25 @@ class WorkflowResolver:
             from_id = from_raw.split(".")[0] if from_raw else ""
             if to_id:
                 incoming.setdefault(to_id, []).append(from_id)
+            if from_id and to_id:
+                adjacency.setdefault(from_id, []).append(to_id)
+
+        def _reaches_aggregate(start: Optional[str]) -> bool:
+            # 엔진 _find_split_aggregate_pairs 와 동일하게 그래프 도달성으로 짝을 판정.
+            if not start:
+                return False
+            seen: Set[str] = set()
+            queue: List[str] = [start]
+            while queue:
+                cur = queue.pop(0)
+                if cur in seen:
+                    continue
+                seen.add(cur)
+                for nxt in adjacency.get(cur, []):
+                    if nxt in aggregate_ids:
+                        return True
+                    queue.append(nxt)
+            return False
 
         def _may_produce_list(src_type: Optional[str]) -> bool:
             # 동적/미상 출력은 리스트 가능 → 보수적으로 통과.
@@ -1144,9 +1181,29 @@ class WorkflowResolver:
 
         for node in split_nodes:
             sid = node.get("id")
-            # (a) `array` config 가 배선돼 있으면 소스 존재로 본다(빈 리터럴 포함 — 의도된 것).
-            if node.get("array") is not None:
+            # (1) 짝 AggregateNode 도달성 — 없으면 엔진이 branch 를 실행조차 안 한다.
+            if not _reaches_aggregate(sid):
+                result.add(
+                    build_error(
+                        ErrorCode.MISSING_REQUIRED_FIELD,
+                        (
+                            f"SplitNode '{sid}' has no reachable AggregateNode. The engine "
+                            f"only runs a SplitNode's per-item branch when a paired "
+                            f"AggregateNode is reachable from it — without one the branch "
+                            f"never executes (the node stays pending) and every downstream "
+                            f"`{{{{ nodes.{sid}.item }}}}` resolves empty (silent count:0)."
+                        ),
+                        location=ErrorLocation(node_id=sid, node_type="SplitNode", field_path=None),
+                        suggestion=(
+                            "Add an AggregateNode downstream of this split's branch (so it is "
+                            "reachable from the SplitNode), which recollects the per-item "
+                            "results. If you only ever have a single value, DELETE the "
+                            "SplitNode and bind that value directly on the downstream node."
+                        ),
+                    )
+                )
                 continue
+            # (2) 상류 리스트 소스 — config `array` 는 엔진이 안 읽으므로 소스로 인정 안 함.
             srcs = incoming.get(sid, [])
             if srcs and any(_may_produce_list(node_type_by_id.get(s)) for s in srcs):
                 continue
@@ -1154,19 +1211,21 @@ class WorkflowResolver:
                 build_error(
                     ErrorCode.MISSING_REQUIRED_FIELD,
                     (
-                        f"SplitNode '{sid}' has no array source to split — no `array` "
-                        f"config binding and no upstream node that outputs a list. It will "
-                        f"emit zero items and every downstream `{{{{ nodes.{sid}.item }}}}` "
-                        f"resolves empty (silent count:0 result)."
+                        f"SplitNode '{sid}' has no upstream node that outputs a list. The "
+                        f"engine reads the array to split ONLY from an upstream node's list "
+                        f"output (ports symbols/values/array/data/items) — the `array` "
+                        f"config field is NOT read at runtime. It will emit zero items and "
+                        f"every downstream `{{{{ nodes.{sid}.item }}}}` resolves empty "
+                        f"(silent count:0 result)."
                     ),
                     location=ErrorLocation(node_id=sid, node_type="SplitNode", field_path="array"),
                     suggestion=(
-                        "Wire the array: either add an edge from an upstream node that "
-                        "outputs a list (WatchlistNode/MarketUniverseNode → symbols, "
-                        "AccountNode → positions, ConditionNode → values), or set the `array` "
-                        "field to a whole-value expression / literal list. For a single known "
-                        "symbol, DELETE SplitNode and bind that symbol directly on the "
-                        "downstream node."
+                        "Connect an edge from an upstream node that OUTPUTS a list "
+                        "(WatchlistNode/MarketUniverseNode → symbols, AccountNode → "
+                        "positions, ConditionNode → values, or a CodeNode returning a list). "
+                        "Do NOT put the list in an `array`/`items` config field — the engine "
+                        "ignores it. For a single known symbol, DELETE SplitNode and bind "
+                        "that symbol directly on the downstream node."
                     ),
                 )
             )

--- a/src/programgarden/programgarden/resolver.py
+++ b/src/programgarden/programgarden/resolver.py
@@ -323,6 +323,9 @@ class WorkflowResolver:
         # 10.6 SplitNode 소스 검증 (분리할 배열이 실제로 배선됐는지)
         self._validate_split_nodes(workflow, registry, result)
 
+        # 10.7 AIAgentNode ai_model 엣지 필수 검증 (LLM 없이는 애초에 동작 불가)
+        self._validate_ai_agent_nodes(workflow, result)
+
         # 11. Static recommendations (topology analysis)
         for rec in run_static_recommendation_rules(
             workflow,
@@ -1164,6 +1167,55 @@ class WorkflowResolver:
                         "field to a whole-value expression / literal list. For a single known "
                         "symbol, DELETE SplitNode and bind that symbol directly on the "
                         "downstream node."
+                    ),
+                )
+            )
+
+    def _validate_ai_agent_nodes(self, workflow, result: ValidationResult) -> None:
+        """AIAgentNode 는 ai_model 엣지로 LLMModelNode 가 연결돼야 한다.
+
+        LLM 이 없으면 이 노드는 **애초에 동작 불가**(런타임에 raise)이므로 오탐 위험이
+        0이다. static validate 에서 잡아 챗봇이 저장 전에 고치게 한다 — deep_validate 는
+        인프라 오류 시 검증을 건너뛰고 '성공'으로 저장할 수 있어 못 믿는다(soft-skip).
+        ai_model 엣지의 source/target **형태** 오류는 _validate_edge_references 가
+        (INVALID_AI_MODEL_EDGE) 별도로 잡으므로, 여기선 '연결 자체가 없는' 구멍만 본다.
+        """
+        from programgarden_core.models.edge import EdgeType
+
+        agent_ids = [
+            n.get("id")
+            for n in workflow.nodes
+            if isinstance(n, dict) and n.get("type") == "AIAgentNode"
+        ]
+        if not agent_ids:
+            return
+        # ai_model 엣지가 타깃으로 삼는 AIAgentNode id 집합
+        ai_model_targets: Set[str] = set()
+        for edge in workflow.edges:
+            edge_type = getattr(edge, "edge_type", None)
+            et = (
+                edge_type.value if hasattr(edge_type, "value")
+                else (str(edge_type) if edge_type else "main")
+            )
+            if et != EdgeType.AI_MODEL.value:
+                continue
+            to_raw = getattr(edge, "to_node", "") or ""
+            to_id = to_raw.split(".")[0] if to_raw else ""
+            if to_id:
+                ai_model_targets.add(to_id)
+
+        for aid in agent_ids:
+            if aid in ai_model_targets:
+                continue
+            result.add(
+                build_error(
+                    ErrorCode.MISSING_REQUIRED_FIELD,
+                    f"AIAgentNode '{aid}' has no LLM model connected — it cannot run without "
+                    f"one. Connect an LLMModelNode to '{aid}' via an \"ai_model\" edge.",
+                    location=ErrorLocation(node_id=aid, node_type="AIAgentNode", field_path="ai_model"),
+                    suggestion=(
+                        "Add an LLMModelNode and wire it with an ai_model edge, e.g. "
+                        f'{{"from": "<llm_node_id>", "to": "{aid}", "edge_type": "ai_model"}}.'
                     ),
                 )
             )

--- a/src/programgarden/programgarden/resolver.py
+++ b/src/programgarden/programgarden/resolver.py
@@ -320,6 +320,9 @@ class WorkflowResolver:
         # 10.5 CodeNode 정적 검증 (compile/screen 사전검증 + credential 봉쇄)
         self._validate_code_nodes(workflow, result)
 
+        # 10.6 SplitNode 소스 검증 (분리할 배열이 실제로 배선됐는지)
+        self._validate_split_nodes(workflow, registry, result)
+
         # 11. Static recommendations (topology analysis)
         for rec in run_static_recommendation_rules(
             workflow,
@@ -1084,6 +1087,86 @@ class WorkflowResolver:
                                 details={"credential_tokens": sorted(hit)},
                             )
                         )
+
+    # SplitNode 가 분리할 배열을 실제로 못 받는데도 런타임엔 조용히 0개 아이템을
+    # 방출한다(executor: config `array` 없고 상류 출력에도 리스트 없음 → input_array=[]).
+    # 그러면 하류 `{{ nodes.<split>.item }}` 이 조용히 비어 워크플로우가 count:0 쓰레기
+    # 결과를 낸다(단일 심볼에 SplitNode 를 잘못 붙이는 것이 전형적 저작 결함). 정적으로
+    # 잡아 AI self-correct 루프가 dry_run 전에 보게 한다.
+    # 오탐(최대 리스크) 최소화: 상류 중 하나라도 리스트를 낼 "가능성"이 있으면 통과한다.
+    #   가능성 = (a) `array` config 가 배선됨, (b) 상류가 CodeNode(동적 출력),
+    #            (c) 상류 스키마 미상(커뮤니티/제네릭), (d) 상류 출력 포트 타입 중 하나라도
+    #                확정 스칼라/시그널이 아님. 모든 상류가 확정 스칼라일 때만 flag.
+    _SPLIT_SCALAR_OUTPUT_TYPES = frozenset({
+        "signal", "boolean", "integer", "number", "float", "string",
+        "broker_connection",
+    })
+
+    def _validate_split_nodes(self, workflow, registry, result: ValidationResult) -> None:
+        """SplitNode 의 분리 대상 배열이 배선됐는지 정적 검증(오탐 보수적)."""
+        split_nodes = [
+            n for n in workflow.nodes
+            if isinstance(n, dict) and n.get("type") == "SplitNode"
+        ]
+        if not split_nodes:
+            return
+        node_type_by_id = {
+            n.get("id"): n.get("type") for n in workflow.nodes if isinstance(n, dict)
+        }
+        # split_id -> [upstream source ids]
+        incoming: Dict[str, List[str]] = {}
+        for edge in workflow.edges:
+            to_raw = getattr(edge, "to_node", "") or ""
+            from_raw = getattr(edge, "from_node", "") or ""
+            to_id = to_raw.split(".")[0] if to_raw else ""
+            from_id = from_raw.split(".")[0] if from_raw else ""
+            if to_id:
+                incoming.setdefault(to_id, []).append(from_id)
+
+        def _may_produce_list(src_type: Optional[str]) -> bool:
+            # 동적/미상 출력은 리스트 가능 → 보수적으로 통과.
+            if not src_type or src_type == "CodeNode":
+                return True
+            schema = registry.get_schema(src_type)
+            if schema is None:
+                return True
+            ports = list(schema.outputs or [])
+            if not ports:
+                return True  # 출력 미선언 → 알 수 없음 → 통과
+            for out in ports:
+                ptype = out.get("type") if isinstance(out, dict) else getattr(out, "type", None)
+                if ptype not in self._SPLIT_SCALAR_OUTPUT_TYPES:
+                    return True  # 배열/오브젝트 등 비스칼라 포트 존재 → 가능성 있음
+            return False  # 모든 포트가 확정 스칼라 → 리스트 생산 불가
+
+        for node in split_nodes:
+            sid = node.get("id")
+            # (a) `array` config 가 배선돼 있으면 소스 존재로 본다(빈 리터럴 포함 — 의도된 것).
+            if node.get("array") is not None:
+                continue
+            srcs = incoming.get(sid, [])
+            if srcs and any(_may_produce_list(node_type_by_id.get(s)) for s in srcs):
+                continue
+            result.add(
+                build_error(
+                    ErrorCode.MISSING_REQUIRED_FIELD,
+                    (
+                        f"SplitNode '{sid}' has no array source to split — no `array` "
+                        f"config binding and no upstream node that outputs a list. It will "
+                        f"emit zero items and every downstream `{{{{ nodes.{sid}.item }}}}` "
+                        f"resolves empty (silent count:0 result)."
+                    ),
+                    location=ErrorLocation(node_id=sid, node_type="SplitNode", field_path="array"),
+                    suggestion=(
+                        "Wire the array: either add an edge from an upstream node that "
+                        "outputs a list (WatchlistNode/MarketUniverseNode → symbols, "
+                        "AccountNode → positions, ConditionNode → values), or set the `array` "
+                        "field to a whole-value expression / literal list. For a single known "
+                        "symbol, DELETE SplitNode and bind that symbol directly on the "
+                        "downstream node."
+                    ),
+                )
+            )
 
     def _validate_credential_references(
         self,

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.25.0"
+version = "1.25.1"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"

--- a/src/programgarden/tests/test_ai_agent.py
+++ b/src/programgarden/tests/test_ai_agent.py
@@ -68,10 +68,12 @@ def _make_context(
     ctx.log = MagicMock()
     ctx.job_id = "test-job-1"
     ctx.is_running = True
-    # These tests exercise the real LLM/ReAct path; pin the deep-validate flag to
-    # False so AIAgentNodeExecutor does not take its deep fixture short-circuit
-    # (a bare MagicMock attribute is truthy and would otherwise trigger it).
+    # These tests exercise the real LLM/ReAct path; pin the deep-validate AND
+    # dry-run flags to False so AIAgentNodeExecutor does not take its simulation
+    # fixture short-circuit (a bare MagicMock attribute is truthy and would
+    # otherwise trigger it).
     ctx.is_deep_validate = False
+    ctx.is_dry_run = False
     ctx.get_workflow_credential = MagicMock(return_value=credential_data)
 
     # set_output / get_output / get_all_outputs
@@ -399,12 +401,14 @@ class TestAIAgentNodeExecutor:
 
         config = {"user_prompt": "Hello"}
 
-        result = await executor.execute(
-            node_id="agent", node_type="AIAgentNode",
-            config=config, context=ctx, workflow=wf,
-        )
-
-        assert "error" in result
+        # 하드 실패(LLM 미연결) → raise (에러-dict 를 하류가 침묵의 None 으로 먹지 않도록).
+        from programgarden_core.exceptions import ValidationError
+        with pytest.raises(ValidationError) as ei:
+            await executor.execute(
+                node_id="agent", node_type="AIAgentNode",
+                config=config, context=ctx, workflow=wf,
+            )
+        assert "LLM model" in str(ei.value)
 
     @pytest.mark.asyncio
     async def test_tool_call_loop(self):
@@ -844,19 +848,21 @@ class TestToolErrorStrategy:
             call_count += 1
             return tool_call_response if call_count == 1 else final_response
 
+        # 하드 실패(tool abort) → raise.
+        from programgarden_core.exceptions import ExecutionError
         with patch("programgarden.providers.LLMProvider.chat", side_effect=mock_chat):
             with patch(
                 "programgarden.executor.AIAgentToolExecutor.call_tool",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("API connection failed"),
             ):
-                result = await executor.execute(
-                    node_id="agent", node_type="AIAgentNode",
-                    config=config, context=ctx, workflow=wf,
-                )
+                with pytest.raises(ExecutionError) as ei:
+                    await executor.execute(
+                        node_id="agent", node_type="AIAgentNode",
+                        config=config, context=ctx, workflow=wf,
+                    )
 
-        assert "error" in result
-        assert "API connection failed" in result["error"]
+        assert "API connection failed" in str(ei.value)
 
     @pytest.mark.asyncio
     async def test_skip_continues_with_error_message(self):
@@ -1038,13 +1044,14 @@ class TestLLMErrorHandling:
             new_callable=AsyncMock,
             side_effect=LLMAuthError("Invalid API key", provider="openai", model="gpt-4o"),
         ):
-            result = await executor.execute(
-                node_id="agent", node_type="AIAgentNode",
-                config=config, context=ctx, workflow=wf,
-            )
+            from programgarden_core.exceptions import ExecutionError
+            with pytest.raises(ExecutionError) as ei:
+                await executor.execute(
+                    node_id="agent", node_type="AIAgentNode",
+                    config=config, context=ctx, workflow=wf,
+                )
 
-        assert "error" in result
-        assert "Invalid API key" in result["error"]
+        assert "Invalid API key" in str(ei.value)
 
     @pytest.mark.asyncio
     async def test_rate_limit_error(self):
@@ -1061,13 +1068,14 @@ class TestLLMErrorHandling:
                 "Rate limit exceeded", provider="openai", model="gpt-4o", retry_after=30.0,
             ),
         ):
-            result = await executor.execute(
-                node_id="agent", node_type="AIAgentNode",
-                config=config, context=ctx, workflow=wf,
-            )
+            from programgarden_core.exceptions import ExecutionError
+            with pytest.raises(ExecutionError) as ei:
+                await executor.execute(
+                    node_id="agent", node_type="AIAgentNode",
+                    config=config, context=ctx, workflow=wf,
+                )
 
-        assert "error" in result
-        assert "Rate limit" in result["error"]
+        assert "Rate limit" in str(ei.value)
 
     @pytest.mark.asyncio
     async def test_timeout_error(self):
@@ -1082,13 +1090,14 @@ class TestLLMErrorHandling:
             new_callable=AsyncMock,
             side_effect=LLMTimeoutError("Request timed out", provider="openai", model="gpt-4o"),
         ):
-            result = await executor.execute(
-                node_id="agent", node_type="AIAgentNode",
-                config=config, context=ctx, workflow=wf,
-            )
+            from programgarden_core.exceptions import ExecutionError
+            with pytest.raises(ExecutionError) as ei:
+                await executor.execute(
+                    node_id="agent", node_type="AIAgentNode",
+                    config=config, context=ctx, workflow=wf,
+                )
 
-        assert "error" in result
-        assert "timed out" in result["error"]
+        assert "timed out" in str(ei.value)
 
     @pytest.mark.asyncio
     async def test_token_limit_error(self):
@@ -1103,13 +1112,14 @@ class TestLLMErrorHandling:
             new_callable=AsyncMock,
             side_effect=LLMTokenLimitError("Context window exceeded", provider="openai", model="gpt-4o"),
         ):
-            result = await executor.execute(
-                node_id="agent", node_type="AIAgentNode",
-                config=config, context=ctx, workflow=wf,
-            )
+            from programgarden_core.exceptions import ExecutionError
+            with pytest.raises(ExecutionError) as ei:
+                await executor.execute(
+                    node_id="agent", node_type="AIAgentNode",
+                    config=config, context=ctx, workflow=wf,
+                )
 
-        assert "error" in result
-        assert "Context window" in result["error"]
+        assert "Context window" in str(ei.value)
 
 
 class TestStreamingResponse:

--- a/src/programgarden/tests/test_hard_failure_raises.py
+++ b/src/programgarden/tests/test_hard_failure_raises.py
@@ -1,0 +1,110 @@
+"""하드 실패 경로는 조용히 완주하지 않고 시끄럽게(raise → node/job failed) 실패한다.
+
+배경(sweep 리워크): 노드의 하드 실패(자격증명·설정 오류·API·리소스·필수입력 부재 등)를
+`{"...port": None, "error": ...}` 에러-dict 로 돌려주면, 하류가 침묵의 None 을 먹고
+워크플로우가 `completed` 로 굴러 silent garbage 를 낸다(deep_validate 의 sole-error
+승격 안전망도 키가 여럿이면 발동 안 함). 그래서 하드 실패는 **raise** 로 전환했다.
+
+이 스위트는 **실제 에러 경로**(executor 를 patch 하지 않고 실 ExecutionContext 로 구동)로
+'하드 실패 = 시끄럽다' 와 '정상 0건 = 스키마 지킨 조용한 빈 값' 을 동시에 못박는다.
+"""
+import asyncio
+import os
+
+import pytest
+
+from programgarden import ProgramGarden
+from programgarden.executor import (
+    ExecutionContext,
+    BrokerNodeExecutor,
+    AIAgentNodeExecutor,
+    ConditionNodeExecutor,
+)
+from programgarden_core.exceptions import ValidationError, ExecutionError
+
+
+def _ctx(tmp_path):
+    return ExecutionContext(job_id="j", workflow_id="w", storage_dir=str(tmp_path))
+
+
+# ── 1. executor 레벨: 하드 실패는 raise (에러-dict 반환 아님) ──────────────────
+
+@pytest.mark.asyncio
+async def test_broker_paper_trading_raises(tmp_path):
+    """overseas_stock + paper_trading 은 지원 안 됨 → 조용한 에러-dict 아니라 raise."""
+    with pytest.raises(ValidationError) as ei:
+        await BrokerNodeExecutor().execute(
+            "broker", "OverseasStockBrokerNode",
+            {"paper_trading": True, "product": "overseas_stock", "credential_id": "c"},
+            _ctx(tmp_path),
+        )
+    assert "paper_trading" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_aiagent_no_llm_model_raises(tmp_path):
+    """AIAgentNode 에 LLM 모델 미연결(설정 오류) → raise."""
+    with pytest.raises(ValidationError) as ei:
+        # workflow kwarg 없음 = ai_model 엣지/워크플로우 컨텍스트 부재
+        await AIAgentNodeExecutor().execute(
+            "agent", "AIAgentNode", {"user_prompt": "hi"}, _ctx(tmp_path),
+        )
+    # no-workflow 또는 no-LLM-model — 어느 쪽이든 설정 오류로 raise 되어야 한다
+    assert "workflow" in str(ei.value).lower() or "llm" in str(ei.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_condition_missing_items_raises(tmp_path):
+    """지표 플러그인 ConditionNode 에 items 미배선(필수입력 부재) → raise."""
+    with pytest.raises(ValidationError) as ei:
+        await ConditionNodeExecutor().execute(
+            "cond", "ConditionNode", {"plugin": "RSI", "fields": {"period": 14}},
+            _ctx(tmp_path),
+        )
+    assert "items" in str(ei.value)
+
+
+# ── 2. 정상 0건은 raise 하지 않고 선언 스키마 그대로 빈 값 ───────────────────
+
+@pytest.mark.asyncio
+async def test_condition_empty_positions_is_normal_zero(tmp_path):
+    """포지션 플러그인인데 positions 가 빈 리스트(무보유) = 정상 0건 → raise 안 함.
+
+    (positions 바인딩 자체가 없는 config 오류는 static validate 가 잡는다.)
+    """
+    out = await ConditionNodeExecutor().execute(
+        "cond", "ConditionNode",
+        {"plugin": "StopLoss", "positions": [], "fields": {"stop_loss_pct": 5}},
+        _ctx(tmp_path),
+    )
+    assert isinstance(out, dict)
+    assert out.get("is_condition_met") is False
+    assert out.get("passed_symbols") == []
+    # 정상 0건이므로 error 키가 없어야 한다(하드 실패로 위장 금지)
+    assert "error" not in out
+
+
+# ── 3. 엔진 레벨: 하드 실패 노드는 job 을 failed 로 만든다(조용히 completed 아님) ─
+
+def test_hard_failure_fails_the_job(tmp_path):
+    """실 엔진 실행: Broker paper-trading 하드 실패 → job status=failed + 사유 노출."""
+    dsl = {
+        "id": "hardfail", "name": "hardfail", "version": "1.0.0",
+        "nodes": [
+            {"id": "start", "type": "StartNode"},
+            {"id": "broker", "type": "OverseasStockBrokerNode",
+             "paper_trading": True, "credential_id": "c"},
+        ],
+        "edges": [{"from": "start", "to": "broker"}],
+        "credentials": [{
+            "credential_id": "c", "type": "broker_ls_overseas_stock",
+            "data": [
+                {"key": "appkey", "value": "x", "type": "password", "label": "k"},
+                {"key": "appsecret", "value": "y", "type": "password", "label": "s"},
+            ],
+        }],
+    }
+    res = ProgramGarden().run(dsl, storage_dir=str(tmp_path), wait=True, timeout=60)
+    assert res.get("status") == "failed"
+    assert res.get("stats", {}).get("errors_count", 0) >= 1
+    assert "paper_trading" in str(res.get("stats", {}).get("last_error", ""))

--- a/src/programgarden/tests/test_market_status_ai_agent_tool.py
+++ b/src/programgarden/tests/test_market_status_ai_agent_tool.py
@@ -37,9 +37,11 @@ def _make_context(outputs: Dict[str, Dict[str, Any]] | None = None) -> MagicMock
     ctx.log = MagicMock()
     ctx.job_id = "test-job-ms"
     ctx.is_running = True
-    # Real LLM/tool-loop path: keep the deep-validate short-circuit off (a bare
-    # MagicMock attribute is truthy and would otherwise skip the live loop).
+    # Real LLM/tool-loop path: keep the deep-validate AND dry-run short-circuits
+    # off (a bare MagicMock attribute is truthy and would otherwise skip the live
+    # loop via the AIAgent simulation fixture).
     ctx.is_deep_validate = False
+    ctx.is_dry_run = False
     ctx.get_workflow_credential = MagicMock(return_value=None)
 
     _store: Dict[str, Dict[str, Any]] = outputs or {}

--- a/src/programgarden/tests/test_validation_errors_structured.py
+++ b/src/programgarden/tests/test_validation_errors_structured.py
@@ -628,3 +628,51 @@ def test_type_check_skips_method_chain(executor: WorkflowExecutor) -> None:
     # it must not be flagged as a mismatch.
     result = executor.validate(_sizing_wf("{{ nodes.account.positions.first() }}"))
     assert ErrorCode.INVALID_FIELD_TYPE.value not in _codes(result)
+
+
+# ── AIAgentNode 는 ai_model 엣지로 LLMModelNode 가 연결돼야 한다 (1.25.1) ─────────
+
+def test_ai_agent_without_ai_model_edge_is_flagged(executor: WorkflowExecutor) -> None:
+    """LLM 미연결 AIAgentNode → static validate 가 MISSING_REQUIRED_FIELD 로 막는다.
+
+    (선존재 구멍: 예전엔 validate/deep_validate 둘 다 통과해 저장됐고 실행 시에만 죽었다.)
+    """
+    workflow = _wrap(
+        [
+            {"id": "s1", "type": "StartNode"},
+            {"id": "agent", "type": "AIAgentNode", "user_prompt": "hi"},
+        ],
+        edges=[{"from": "s1", "to": "agent"}],
+    )
+    result = executor.validate(workflow)
+    assert result.summary.is_valid is False
+    assert ErrorCode.MISSING_REQUIRED_FIELD.value in _codes(result)
+    err = next(
+        e for e in result.errors
+        if getattr(getattr(e, "location", None), "node_type", None) == "AIAgentNode"
+    )
+    assert "ai_model" in err.message or "LLM model" in err.message
+
+
+def test_ai_agent_with_ai_model_edge_passes(executor: WorkflowExecutor) -> None:
+    """LLMModelNode 를 ai_model 엣지로 연결하면 규칙에 걸리지 않는다(오탐 0)."""
+    workflow = _wrap(
+        [
+            {"id": "s1", "type": "StartNode"},
+            {"id": "llm", "type": "LLMModelNode", "model": "gpt-4o", "credential_id": "c1"},
+            {"id": "agent", "type": "AIAgentNode", "user_prompt": "hi"},
+        ],
+        edges=[
+            {"from": "s1", "to": "agent"},
+            {"from": "llm", "to": "agent", "type": "ai_model"},
+        ],
+    )
+    workflow["credentials"] = [{"credential_id": "c1", "type": "llm_openai", "data": []}]
+    result = executor.validate(workflow)
+    # AIAgentNode 에 대한 ai_model MISSING_REQUIRED_FIELD 가 없어야 한다
+    ai_missing = [
+        e for e in result.errors
+        if getattr(getattr(e, "location", None), "node_type", None) == "AIAgentNode"
+        and getattr(getattr(e, "location", None), "field_path", None) == "ai_model"
+    ]
+    assert ai_missing == []


### PR DESCRIPTION
## 무엇을 고쳤나 (쉬운 말)

워크플로우가 **에러 없이 조용히 빈 결과**를 내는 버그들을 잡았습니다. 사용자는 "계산됐다"며 `count: 0` 같은 쓰레기 값을 받고, 왜 그런지 알 방법이 없었습니다.

## 근본 원인 하나

**노드가 실행 경로에 따라 서로 다른 출력 스키마를 뱉고 있었습니다.**

`HistoricalDataNode` 는 정상일 땐 `{"value": {…, time_series: [...]}, "values": [...]}` 를 반환하는데, 심볼이 없으면 **완전히 다른 옛 형태** `{"ohlcv_data": {}, "symbols": []}` 를 반환했습니다. 그래서 하류의 **멀쩡한 바인딩**(`{{ nodes.x.value.time_series }}`)이 조용히 `None` 이 되고, CodeNode 의 방어적 `data or []` 가 그걸 삼켜 에러 없이 빈 결과가 나왔습니다. (라이브러리 자체 주석이 이미 `ohlcv_data` 맵을 두고 *"silently starved the ConditionNode and produced deep false positives"* 라고 경고하고 있었는데, fallback 경로에 그대로 남아 있었습니다.)

**불변식으로 정리했습니다: 노드는 어떤 실행 경로에서도 자기 선언 출력 스키마를 반환한다.**

## 세 갈래 규칙

| 경우 | 반환 |
|---|---|
| **진짜 실패** (자격증명·API 실패·LLM 미연결·툴 abort·필수입력 부재) | **raise** — 사유 + 어디를 고쳐야 하는지 |
| **정상인데 0건** (스크리너 0건, 무보유 등) | 선언 스키마 그대로 **빈 값**, `error` 키 없음 |
| **부분 성공** (쓸 수 있는 결과 + 경고) | 기존 `{…값…, "error": …}` 유지 |

### 왜 raise 인가 — 에러-dict 는 조용히 삼켜진다

엔진의 승격 안전망(`executor.py`)은 **`{"error": …}` 단독**일 때만 blocking 에러로 올립니다. `error` 옆에 다른 키가 하나라도 있으면 "soft warning" 으로 그냥 흘려보냅니다 (`test_error_with_other_ports_is_not_promoted` 가 못박은 의미론). 게다가 **그 안전망은 deep_validate 전용이고 실 런타임엔 아예 없습니다.**

→ 하드 실패에 스키마 키를 채워 넣는 접근은 **실패를 승격 버킷 밖으로 밀어내 오히려 더 깊이 묻습니다.** 그래서 **raise** 로 갔습니다. `error-dict-as-return` 레거시 패턴을 삭제합니다.

**실증** (LLM 미연결 AIAgent, 실 런타임):
```
job status = failed
agent state = failed | outputs = {}
ERROR: No LLMModelNode connected via ai_model edge
```
이전엔 `completed` + `response=None` 으로 조용히 흘러갔습니다.

## 변경 내역

- **`HistoricalDataNode`** — no-symbol fallback 이 정상 스키마로 빈 값 반환 (`ohlcv_data` 삭제)
- **노드 7종 정합** — AIAgent / ConditionNode / BacktestEngine / ModifyOrder / Broker / CancelOrder / Portfolio: 하드 실패는 raise, 정상 0건은 스키마 지킨 빈 값
- **`TableDisplayNode`** — 객체형 `columns`(`[{key,label}]`)에서 `unsupported format string passed to dict.__format__` 로 크래시하던 것 수정. 스키마를 `List[str | {key,label}]` union 으로 **정본화**(코드=스키마=카탈로그 정합)
- **`SplitNode` 정적 가드** — `array` 가 미바인딩이고 리스트 생산 상류도 없으면 빌드 시점에 flag. 스키마 설명에 "단일 심볼이면 SplitNode 불필요" 명시
- **`69-telegram-price-alert.json`** — `items` config 를 쓰고 있었으나 executor 는 `array` 만 읽어 무시 → 실제로 깨져 있던 예제 수정
- **신규 회귀 테스트** `test_hard_failure_raises.py` — 실제 에러 경로(executor patch 아님)로 "하드 실패가 조용히 완주하지 않음" 을 못박음

## 검증

- **회귀 0** — base(`2da62d0`) 대비 실패 목록 **완전 동일** (community 4 / PositionSizing 2 / programmer examples 2 / hkex 2+60 errors / HTTP 플레이크 1 — 전부 선존재). **1365 passed**
- **하드 실패 시끄러움** — 각 raise 경로 실 엔진 검증 (위 실증)
- **SplitNode 가드 오탐 0** — 전 예제 static validate 통과
- **B′ 재현물** — 조용한 `count: 0` 대신 `is_valid=False` + 명확한 SplitNode 에러

## 알려진 잔여 (이번 PR 범위 밖, 선존재)

LLM 이 연결되지 않은 AIAgentNode 가 `validate()` / `deep_validate()` 를 **통과합니다**(빌드 시점 미검출 — base 에서도 동일). 이제 실 런타임에서는 시끄럽게 실패하지만, **빌드 시점에 잡는 구조적 규칙(`ai_model` 엣지 필수)** 은 후속 과제입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ozaHLK9CkXGJAf4ZqiVTX