### PR TITLE
release: programgarden 1.28.0 / core 1.20.0 — 선언한 출력 포트를 런타임이 실제로 내보낸다

### DIFF
--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [1.20.0] - 2026-07-14
+### Fixed
+- **Output-port declarations now match what the runtime actually emits.** The resolver validates
+  field existence *from these declarations*, so a drifted declaration breaks validation in both
+  directions: it rejects fields that do exist, and accepts fields that don't (which then silently
+  resolve to None at runtime). Corrected across account, screener, symbol-query, market-universe
+  and realtime nodes — most notably `positions`, which declared `pnl` / `pnl_percent` while the
+  runtime has emitted `pnl_amount` / `pnl_rate` all along.
+- Realtime market-data `data` port: dropped the `current_price` / `bid_price` / `ask_price` /
+  `change_percent` fields it never emitted. `data` is an **alias of `ohlcv_data`** — a
+  `{symbol: [bar]}` dict; the code that would have produced full tick data was dead.
+
+### Changed
+- Split the shared field constants (`SYMBOL_LIST_FIELDS`, `POSITION_FIELDS`,
+  `MARKET_DATA_FULL_FIELDS`) into **per-node constants**. Sharing a constant across nodes whose
+  runtimes differ is what caused the drift: widening it for one node makes every other node lie.
+  Ships together with the `programgarden` 1.28.0 runtime (which now actually emits `held_symbols`
+  and keeps a port's key set identical across its REST and WebSocket branches).
+
 ## [1.19.0] - 2026-07-13
 ### Changed
 - Node output-schema conformance (`ai.py` / `display.py` / `infra.py`): a node returns its declared

--- a/src/core/programgarden_core/nodes/account_futures.py
+++ b/src/core/programgarden_core/nodes/account_futures.py
@@ -19,7 +19,7 @@ from programgarden_core.nodes.base import (
     ProductScope,
     BrokerProvider,
     OVERSEAS_FUTURES_BALANCE_FIELDS,
-    POSITION_FIELDS,
+    OVERSEAS_FUTURES_POSITION_FIELDS,
     SYMBOL_LIST_FIELDS,
 )
 
@@ -171,7 +171,7 @@ class OverseasFuturesAccountNode(BaseNode):
     _outputs: List[OutputPort] = [
         OutputPort(name="held_symbols", type="symbol_list", description="i18n:ports.held_symbols", fields=SYMBOL_LIST_FIELDS),
         OutputPort(name="balance", type="balance_data", description="i18n:ports.balance", fields=OVERSEAS_FUTURES_BALANCE_FIELDS),
-        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=POSITION_FIELDS),
+        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=OVERSEAS_FUTURES_POSITION_FIELDS),
     ]
 
     _version: ClassVar[str] = "1.0.0"

--- a/src/core/programgarden_core/nodes/account_korea_stock.py
+++ b/src/core/programgarden_core/nodes/account_korea_stock.py
@@ -18,7 +18,7 @@ from programgarden_core.nodes.base import (
     ProductScope,
     BrokerProvider,
     KOREA_STOCK_BALANCE_FIELDS,
-    POSITION_FIELDS,
+    KOREA_STOCK_POSITION_FIELDS,
     SYMBOL_LIST_FIELDS,
 )
 
@@ -170,7 +170,7 @@ class KoreaStockAccountNode(BaseNode):
     _outputs: List[OutputPort] = [
         OutputPort(name="held_symbols", type="symbol_list", description="i18n:ports.held_symbols", fields=SYMBOL_LIST_FIELDS),
         OutputPort(name="balance", type="balance_data", description="i18n:ports.balance", fields=KOREA_STOCK_BALANCE_FIELDS),
-        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=POSITION_FIELDS),
+        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=KOREA_STOCK_POSITION_FIELDS),
     ]
 
     _version: ClassVar[str] = "1.0.0"

--- a/src/core/programgarden_core/nodes/account_stock.py
+++ b/src/core/programgarden_core/nodes/account_stock.py
@@ -19,7 +19,7 @@ from programgarden_core.nodes.base import (
     ProductScope,
     BrokerProvider,
     OVERSEAS_STOCK_BALANCE_FIELDS,
-    POSITION_FIELDS,
+    OVERSEAS_STOCK_POSITION_FIELDS,
     SYMBOL_LIST_FIELDS,
 )
 
@@ -200,7 +200,7 @@ class OverseasStockAccountNode(BaseNode):
             name="positions",
             type="position_data",
             description="i18n:ports.positions",
-            fields=POSITION_FIELDS,
+            fields=OVERSEAS_STOCK_POSITION_FIELDS,
             example=[
                 {"symbol": "AAPL", "exchange": "NASDAQ", "quantity": 10, "avg_price": 175.20, "pnl_rate": 6.99},
                 {"symbol": "TSLA", "exchange": "NASDAQ", "quantity": 5, "avg_price": 240.00, "pnl_rate": -2.50},

--- a/src/core/programgarden_core/nodes/base.py
+++ b/src/core/programgarden_core/nodes/base.py
@@ -112,9 +112,79 @@ class OutputPort(BaseModel):
 
 
 # === OutputPort.fields 공통 상수 ===
+#
+# 🔴 **상수 공유는 노드가 같은 키를 내보낼 때만 한다.**
+# resolver 는 이 선언으로 `nodes.<id>.<port>.<field>` 의 필드 존재를 **정적 검증**한다.
+# 그래서 선언이 런타임과 어긋나면 검증이 양방향으로 다 틀린다:
+#   실제 있는 필드를 바인딩 → INVALID_EXPRESSION_REF 로 **부당 거부** (동작하는 워크플로우를 막음)
+#   실제 없는 필드를 바인딩 → **통과** 시킨 뒤 런타임에 조용히 None (표에 '-' 만 찍힘)
+# 노드 하나를 맞추려고 공유 상수에 필드를 더하면 **다른 노드가 반대 방향으로 거짓말**한다.
+# → 런타임 키가 다르면 **노드별 상수로 쪼갠다.** 증명은 `tests/test_output_schema_contract.py`
+#   (executor 의 런타임 dict 리터럴을 AST 로 뽑아 선언과 대조).
+
+# WatchlistNode / SymbolFilterNode / ExclusionListNode / 계좌 노드의 held_symbols —
+# 정말로 exchange+symbol 둘만 내보내는 포트 전용.
 SYMBOL_LIST_FIELDS: List[Dict[str, str]] = [
     {"name": "exchange", "type": "string", "description": "거래소 코드 (NASDAQ, NYSE, CME 등)"},
     {"name": "symbol", "type": "string", "description": "종목코드"},
+]
+
+# ── ScreenerNode.symbols (조건 검색 결과) ──
+# LS(g3101 enrich) 분기와 yfinance 분기가 **같은 키 집합**을 내보낸다.
+SCREENER_SYMBOL_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 코드"},
+    {"name": "symbol", "type": "string", "description": "종목코드"},
+    {"name": "name", "type": "string", "description": "종목명 (상류 종목 리스트가 줬거나 yfinance 조회로 채움)"},
+    {"name": "market", "type": "string", "description": "시장 구분 (상류가 준 값 통과 — 예: KOSPI/KOSDAQ)"},
+    {"name": "price", "type": "number", "description": "현재가 (필터 시점)"},
+    {"name": "market_cap", "type": "number", "description": "시가총액"},
+    {"name": "volume", "type": "number", "description": "거래량"},
+    {"name": "sector", "type": "string", "description": "섹터 (yfinance 분기에서만 채워짐 — LS 분기는 빈 문자열)"},
+]
+
+# ── MarketUniverseNode.symbols (지수 구성종목) ──
+MARKET_UNIVERSE_SYMBOL_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 코드"},
+    {"name": "symbol", "type": "string", "description": "종목코드"},
+    {"name": "name", "type": "string", "description": "종목명"},
+]
+
+# ── OverseasStockSymbolQueryNode.symbols (g3190 마스터) ──
+OVERSEAS_STOCK_SYMBOL_QUERY_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 이름 (NASDAQ, NYSE 등)"},
+    {"name": "exchange_code", "type": "string", "description": "LS 거래소 코드"},
+    {"name": "symbol", "type": "string", "description": "종목코드"},
+    {"name": "name", "type": "string", "description": "종목명 (한글 우선, 없으면 영문)"},
+    {"name": "isin", "type": "string", "description": "ISIN 코드"},
+    {"name": "price", "type": "number", "description": "전일 종가"},
+    {"name": "market_cap", "type": "number", "description": "시가총액"},
+    {"name": "shares_outstanding", "type": "number", "description": "상장 주식 수"},
+    {"name": "currency", "type": "string", "description": "통화 코드"},
+    {"name": "suspend", "type": "string", "description": "거래정지 여부 (Y/N)"},
+    {"name": "sellonly", "type": "string", "description": "매도전용 여부 (Y/N)"},
+]
+
+# ── KoreaStockSymbolQueryNode.symbols (t9945 마스터) ──
+KOREA_STOCK_SYMBOL_QUERY_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 코드 (항상 KRX)"},
+    {"name": "market", "type": "string", "description": "시장 구분 (KOSPI / KOSDAQ)"},
+    {"name": "symbol", "type": "string", "description": "종목코드 (6자리)"},
+    {"name": "name", "type": "string", "description": "종목명"},
+    {"name": "is_etf", "type": "boolean", "description": "ETF 여부"},
+    {"name": "product", "type": "string", "description": "상품 구분 (항상 korea_stock)"},
+]
+
+# ── OverseasFuturesSymbolQueryNode.symbols (o3101 마스터) ──
+OVERSEAS_FUTURES_SYMBOL_QUERY_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 코드 (CME, HKEX 등 — 주문에 쓰는 값)"},
+    {"name": "exchange_code", "type": "string", "description": "LS 거래소 코드 (exchange 와 동일)"},
+    {"name": "exchange_name", "type": "string", "description": "거래소 한글명 (표시용 — 주문에 쓰면 안 된다)"},
+    {"name": "symbol", "type": "string", "description": "종목코드 (월물 포함)"},
+    {"name": "name", "type": "string", "description": "종목명"},
+    {"name": "base_product", "type": "string", "description": "기초상품 코드 (예: ES)"},
+    {"name": "base_product_name", "type": "string", "description": "기초상품명"},
+    {"name": "currency", "type": "string", "description": "통화 코드"},
+    {"name": "contract_month", "type": "string", "description": "월물 (YYYYMM)"},
 ]
 
 # ── Partial-failure metadata (internal) ──
@@ -222,14 +292,114 @@ KOREA_STOCK_FUNDAMENTAL_FIELDS: List[Dict[str, str]] = [
     {"name": "industry", "type": "string", "description": "업종명"},
 ]
 
-POSITION_FIELDS: List[Dict[str, str]] = [
+# ── 보유 포지션 (positions 포트) ──
+# 🔴 옛 공유 상수 `POSITION_FIELDS` 는 `pnl` / `pnl_percent` 를 선언했으나 **런타임에 그런 키는 없다**
+# (실제는 `pnl_amount` / `pnl_rate`). 챗봇이 카탈로그를 보고 `pnl` 을 바인딩하면 정적 검증은
+# 통과하고 런타임엔 조용히 None 이 됐다. 상품별로 키가 다르므로 노드별로 쪼갠다.
+
+# 해외주식 REST 계좌 (COSOQ00201 block4)
+OVERSEAS_STOCK_POSITION_FIELDS: List[Dict[str, str]] = [
     {"name": "exchange", "type": "string", "description": "거래소 코드"},
     {"name": "symbol", "type": "string", "description": "종목코드"},
-    {"name": "quantity", "type": "number", "description": "보유 수량"},
+    {"name": "name", "type": "string", "description": "종목명"},
+    {"name": "qty", "type": "number", "description": "보유 수량"},
+    {"name": "quantity", "type": "number", "description": "보유 수량 (주문 노드 호환 별칭)"},
+    {"name": "direction", "type": "string", "description": "포지션 방향 (주식은 항상 long)"},
+    {"name": "close_side", "type": "string", "description": "청산 주문 방향 (주식은 항상 sell)"},
     {"name": "avg_price", "type": "number", "description": "평균 매입가"},
     {"name": "current_price", "type": "number", "description": "현재가"},
-    {"name": "pnl", "type": "number", "description": "평가 손익"},
-    {"name": "pnl_percent", "type": "number", "description": "수익률 (%)"},
+    {"name": "pnl_amount", "type": "number", "description": "평가 손익 (금액)"},
+    {"name": "pnl_rate", "type": "number", "description": "수익률 (%)"},
+    {"name": "eval_amount", "type": "number", "description": "평가 금액"},
+    {"name": "purchase_amount", "type": "number", "description": "매입 금액"},
+    {"name": "currency", "type": "string", "description": "통화 코드"},
+    {"name": "market", "type": "string", "description": "시장 구분명"},
+]
+
+# 국내주식 REST 계좌 (t0424)
+KOREA_STOCK_POSITION_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 코드 (항상 KRX)"},
+    {"name": "symbol", "type": "string", "description": "종목코드"},
+    {"name": "name", "type": "string", "description": "종목명"},
+    {"name": "quantity", "type": "number", "description": "보유 수량"},
+    {"name": "price", "type": "number", "description": "현재가 (주문 노드 호환 별칭)"},
+    {"name": "avg_price", "type": "number", "description": "평균 매입가"},
+    {"name": "current_price", "type": "number", "description": "현재가"},
+    {"name": "pnl_amount", "type": "number", "description": "평가 손익 (금액)"},
+    {"name": "pnl_rate", "type": "number", "description": "수익률 (%)"},
+    {"name": "sellable_qty", "type": "number", "description": "매도 가능 수량"},
+    {"name": "eval_amount", "type": "number", "description": "평가 금액"},
+    {"name": "product", "type": "string", "description": "상품 구분 (항상 korea_stock)"},
+]
+
+# 해외선물 REST 계좌 (CIDBQ01500 block2)
+# 주의: 이 TR 응답에는 수익률(pnl_rate)이 없다 — 손익 금액(pnl_amount)만 온다.
+OVERSEAS_FUTURES_POSITION_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 코드"},
+    {"name": "symbol", "type": "string", "description": "종목코드 (월물 포함)"},
+    {"name": "name", "type": "string", "description": "종목명"},
+    {"name": "direction", "type": "string", "description": "포지션 방향 (long / short)"},
+    {"name": "close_side", "type": "string", "description": "청산 주문 방향 (sell / buy)"},
+    {"name": "quantity", "type": "number", "description": "보유 계약 수"},
+    {"name": "price", "type": "number", "description": "현재가 (주문 노드 호환 별칭)"},
+    {"name": "entry_price", "type": "number", "description": "진입 가격"},
+    {"name": "current_price", "type": "number", "description": "현재가"},
+    {"name": "pnl_amount", "type": "number", "description": "평가 손익 (금액)"},
+    {"name": "currency", "type": "string", "description": "통화 코드"},
+]
+
+# ── 실시간 계좌 포지션 (RealAccountNode.positions) ──
+# 실시간 노드는 두 갈래로 positions 를 내보낸다: ① REST 스냅샷 직렬화 ② WebSocket tracker.
+# 둘의 키가 다르면 **같은 포트인데 순간마다 다른 필드**가 나온다 → 두 갈래를 같은 키로 통일했다.
+OVERSEAS_STOCK_REAL_POSITION_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 코드"},
+    {"name": "market_code", "type": "string", "description": "LS 시장 코드"},
+    {"name": "symbol", "type": "string", "description": "종목코드"},
+    {"name": "name", "type": "string", "description": "종목명"},
+    {"name": "qty", "type": "number", "description": "보유 수량"},
+    {"name": "quantity", "type": "number", "description": "보유 수량 (주문 노드 호환 별칭)"},
+    {"name": "price", "type": "number", "description": "현재가 (주문 노드 호환 별칭)"},
+    {"name": "avg_price", "type": "number", "description": "평균 매입가"},
+    {"name": "current_price", "type": "number", "description": "현재가"},
+    {"name": "pnl_amount", "type": "number", "description": "평가 손익 (금액)"},
+    {"name": "pnl_rate", "type": "number", "description": "수익률 (%)"},
+    {"name": "eval_amount", "type": "number", "description": "평가 금액"},
+    {"name": "currency", "type": "string", "description": "통화 코드"},
+    {"name": "product", "type": "string", "description": "상품 구분 (항상 overseas_stock)"},
+]
+
+KOREA_STOCK_REAL_POSITION_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 코드 (항상 KRX)"},
+    {"name": "market_code", "type": "string", "description": "시장 구분 코드"},
+    {"name": "symbol", "type": "string", "description": "종목코드"},
+    {"name": "name", "type": "string", "description": "종목명"},
+    {"name": "qty", "type": "number", "description": "보유 수량"},
+    {"name": "quantity", "type": "number", "description": "보유 수량 (주문 노드 호환 별칭)"},
+    {"name": "price", "type": "number", "description": "현재가 (주문 노드 호환 별칭)"},
+    {"name": "avg_price", "type": "number", "description": "평균 매입가"},
+    {"name": "current_price", "type": "number", "description": "현재가"},
+    {"name": "pnl_amount", "type": "number", "description": "평가 손익 (금액)"},
+    {"name": "pnl_rate", "type": "number", "description": "수익률 (%)"},
+    {"name": "eval_amount", "type": "number", "description": "평가 금액"},
+    {"name": "currency", "type": "string", "description": "통화 코드 (항상 KRW)"},
+    {"name": "product", "type": "string", "description": "상품 구분 (항상 korea_stock)"},
+]
+
+OVERSEAS_FUTURES_REAL_POSITION_FIELDS: List[Dict[str, str]] = [
+    {"name": "exchange", "type": "string", "description": "거래소 코드"},
+    {"name": "symbol", "type": "string", "description": "종목코드 (월물 포함)"},
+    {"name": "name", "type": "string", "description": "종목명"},
+    {"name": "direction", "type": "string", "description": "포지션 방향 (long / short)"},
+    {"name": "close_side", "type": "string", "description": "청산 주문 방향 (sell / buy)"},
+    {"name": "qty", "type": "number", "description": "보유 계약 수"},
+    {"name": "quantity", "type": "number", "description": "보유 계약 수 (주문 노드 호환 별칭)"},
+    {"name": "price", "type": "number", "description": "현재가 (주문 노드 호환 별칭)"},
+    {"name": "entry_price", "type": "number", "description": "진입 가격"},
+    {"name": "current_price", "type": "number", "description": "현재가"},
+    {"name": "pnl_amount", "type": "number", "description": "평가 손익 (금액)"},
+    {"name": "pnl_rate", "type": "number", "description": "수익률 (%)"},
+    {"name": "currency", "type": "string", "description": "통화 코드"},
+    {"name": "product", "type": "string", "description": "상품 구분 (항상 overseas_futures)"},
 ]
 
 ORDER_RESULT_FIELDS: List[Dict[str, str]] = [
@@ -358,26 +528,19 @@ ORDER_EVENT_FIELDS: List[Dict[str, str]] = [
     {"name": "timestamp", "type": "string", "description": "이벤트 시각"},
 ]
 
+# ── 실시간 시세 노드의 봉(bar) ──
+# 🔴 실시간 노드의 `ohlcv_data` / `data` 는 **같은 객체**다 (`data` 는 별칭).
+# 값의 모양은 `{"AAPL": [bar, ...]}` — 종목코드로 키를 잡은 dict 이고, bar 가 아래 필드다.
+# 옛 선언은 `exchange` / `timestamp` 를 약속했지만 런타임 bar 에 그런 키는 없고(실제는 `date`),
+# `data` 포트는 아예 `current_price` / `bid_price` / `ask_price` / `change_percent` 를 약속했는데
+# **그 값을 만드는 코드(`_build_full_data`)는 아무도 호출하지 않는 죽은 코드였다.**
 OHLCV_DATA_FIELDS: List[Dict[str, str]] = [
-    {"name": "exchange", "type": "string", "description": "거래소 코드"},
-    {"name": "symbol", "type": "string", "description": "종목코드"},
+    {"name": "date", "type": "string", "description": "봉 일자 (YYYYMMDD)"},
     {"name": "open", "type": "number", "description": "시가"},
     {"name": "high", "type": "number", "description": "고가"},
     {"name": "low", "type": "number", "description": "저가"},
-    {"name": "close", "type": "number", "description": "종가"},
+    {"name": "close", "type": "number", "description": "종가 (= 최근 체결가)"},
     {"name": "volume", "type": "number", "description": "거래량"},
-    {"name": "timestamp", "type": "string", "description": "캔들 시각"},
-]
-
-MARKET_DATA_FULL_FIELDS: List[Dict[str, str]] = [
-    {"name": "exchange", "type": "string", "description": "거래소 코드"},
-    {"name": "symbol", "type": "string", "description": "종목코드"},
-    {"name": "current_price", "type": "number", "description": "현재가"},
-    {"name": "bid_price", "type": "number", "description": "매수호가 (해외주식 실시간에서는 미제공)"},
-    {"name": "ask_price", "type": "number", "description": "매도호가 (해외주식 실시간에서는 미제공)"},
-    {"name": "volume", "type": "number", "description": "거래량"},
-    {"name": "change_percent", "type": "number", "description": "등락률 (%)"},
-    {"name": "timestamp", "type": "string", "description": "시세 시각"},
 ]
 
 CONDITION_RESULT_FIELDS: List[Dict[str, str]] = [

--- a/src/core/programgarden_core/nodes/base.py
+++ b/src/core/programgarden_core/nodes/base.py
@@ -187,16 +187,22 @@ KOREA_STOCK_REAL_BALANCE_FIELDS: List[Dict[str, str]] = [
 ]
 
 # ── 국내주식 시세 전용 (t1102 기반) ──
+# 런타임 정본: executor.py `MarketDataNodeExecutor._fetch_korea_stock`
+# (해외와 같은 이름 규칙을 쓴다 — 예전 선언의 current_price/open_price/market_cap 은 런타임에 없었다.)
 KOREA_STOCK_PRICE_DATA_FIELDS: List[Dict[str, str]] = [
     {"name": "symbol", "type": "string", "description": "종목코드 (6자리)"},
+    {"name": "exchange", "type": "string", "description": "거래소 코드 (KRX)"},
     {"name": "name", "type": "string", "description": "종목명"},
-    {"name": "current_price", "type": "number", "description": "현재가"},
+    {"name": "price", "type": "number", "description": "현재가 (원)"},
+    {"name": "change", "type": "number", "description": "전일대비 (하락이면 음수)"},
+    {"name": "change_pct", "type": "number", "description": "등락률 (%)"},
     {"name": "volume", "type": "number", "description": "거래량"},
-    {"name": "change_percent", "type": "number", "description": "등락률 (%)"},
-    {"name": "open_price", "type": "number", "description": "시가"},
-    {"name": "high_price", "type": "number", "description": "고가"},
-    {"name": "low_price", "type": "number", "description": "저가"},
-    {"name": "market_cap", "type": "number", "description": "시가총액 (억원)"},
+    {"name": "open", "type": "number", "description": "시가"},
+    {"name": "high", "type": "number", "description": "고가"},
+    {"name": "low", "type": "number", "description": "저가"},
+    {"name": "close", "type": "number", "description": "종가 (현재가와 동일)"},
+    {"name": "per", "type": "number", "description": "PER"},
+    {"name": "pbr", "type": "number", "description": "PBR"},
 ]
 
 # ── 국내주식 펀더멘털 전용 ──
@@ -236,14 +242,42 @@ ORDER_RESULT_FIELDS: List[Dict[str, str]] = [
     {"name": "status", "type": "string", "description": "주문 상태"},
 ]
 
+# ⚠️ 이 선언은 **런타임이 실제로 내보내는 키와 정확히 같아야 한다.**
+# resolver 가 이 이름들로 필드 존재를 정적 검증하므로, 어긋나면 두 방향으로 다 틀린다:
+#   실제 있는 필드를 바인딩 → INVALID_EXPRESSION_REF 로 **거부**
+#   실제 없는 필드를 바인딩 → **통과**시킨 뒤 런타임에 조용히 None
+# (2026-07-13 실측: 선언이 current_price/change_percent 였으나 런타임은 price/change_pct 였다.)
+# 런타임 정본: executor.py `MarketDataNodeExecutor._fetch_overseas_stock`
 PRICE_DATA_FIELDS: List[Dict[str, str]] = [
-    {"name": "exchange", "type": "string", "description": "거래소 코드"},
     {"name": "symbol", "type": "string", "description": "종목코드"},
-    {"name": "current_price", "type": "number", "description": "현재가"},
+    {"name": "exchange", "type": "string", "description": "거래소 코드"},
+    {"name": "price", "type": "number", "description": "현재가"},
+    {"name": "change", "type": "number", "description": "전일대비 (하락이면 음수)"},
+    {"name": "change_pct", "type": "number", "description": "등락률 (%)"},
     {"name": "volume", "type": "number", "description": "거래량"},
-    {"name": "change_percent", "type": "number", "description": "등락률 (%)"},
+    {"name": "open", "type": "number", "description": "시가"},
+    {"name": "high", "type": "number", "description": "고가"},
+    {"name": "low", "type": "number", "description": "저가"},
+    {"name": "close", "type": "number", "description": "종가 (현재가와 동일)"},
     {"name": "per", "type": "number", "description": "PER (주가수익비율)"},
     {"name": "eps", "type": "number", "description": "EPS (주당순이익)"},
+]
+
+# ── 해외선물 시세 전용 (o3105 기반) ──
+# 해외주식과 모양이 다르다(symbol_name 있음 / per·eps 없음). 상수를 공유하면 드리프트가 난다.
+# 런타임 정본: executor.py `MarketDataNodeExecutor._fetch_overseas_futures`
+OVERSEAS_FUTURES_PRICE_DATA_FIELDS: List[Dict[str, str]] = [
+    {"name": "symbol", "type": "string", "description": "종목코드 (월물 심볼)"},
+    {"name": "exchange", "type": "string", "description": "거래소 코드"},
+    {"name": "symbol_name", "type": "string", "description": "종목명"},
+    {"name": "price", "type": "number", "description": "현재가"},
+    {"name": "change", "type": "number", "description": "전일대비 (하락이면 음수)"},
+    {"name": "change_pct", "type": "number", "description": "등락률 (%)"},
+    {"name": "volume", "type": "number", "description": "거래량"},
+    {"name": "open", "type": "number", "description": "시가"},
+    {"name": "high", "type": "number", "description": "고가"},
+    {"name": "low", "type": "number", "description": "저가"},
+    {"name": "close", "type": "number", "description": "종가 (현재가와 동일)"},
 ]
 
 FUNDAMENTAL_DATA_FIELDS: List[Dict[str, str]] = [

--- a/src/core/programgarden_core/nodes/data_futures.py
+++ b/src/core/programgarden_core/nodes/data_futures.py
@@ -22,7 +22,7 @@ from programgarden_core.nodes.base import (
     OutputPort,
     ProductScope,
     BrokerProvider,
-    PRICE_DATA_FIELDS,
+    OVERSEAS_FUTURES_PRICE_DATA_FIELDS,
 )
 
 
@@ -74,7 +74,7 @@ class OverseasFuturesMarketDataNode(BaseNode):
         ],
     }
     _features: ClassVar[List[str]] = [
-        "Returns a single futures contract's snapshot: current_price, volume, open_interest, change_percent, bid, ask",
+        "Returns a single futures contract's snapshot: symbol, exchange, symbol_name, price, change, change_pct, volume, open, high, low, close",
         "Item-based execution: pair with SplitNode to query multiple contracts in sequence",
         "is_tool_enabled=True — AI Agent can call this node to look up live futures prices autonomously",
         "Supported exchanges: CME, EUREX, SGX, HKEX — symbol format includes contract month code (e.g., ESH26)",
@@ -121,7 +121,7 @@ class OverseasFuturesMarketDataNode(BaseNode):
                     }
                 ],
             },
-            "expected_output": "values port: array of {symbol, exchange, current_price, volume, open_interest, change_percent, bid, ask}.",
+            "expected_output": "values port: array of {symbol, exchange, symbol_name, price, change, change_pct, volume, open, high, low, close}.",
         },
         {
             "title": "Multi-contract scan — compare HKEX futures prices",
@@ -161,9 +161,9 @@ class OverseasFuturesMarketDataNode(BaseNode):
             "Broker connection auto-injected from OverseasFuturesBrokerNode."
         ),
         "output_consumption": (
-            "Consume the `values` port ONLY — an array of {symbol, exchange, current_price, volume, open_interest, change_percent, bid, ask}. "
+            "Consume the `values` port ONLY — an array of {symbol, exchange, symbol_name, price, change, change_pct, volume, open, high, low, close}. "
             "⚠️ The `value` (singular) port is NOT populated at runtime — the executor emits `values` only; "
-            "binding `{{ nodes.market.value }}` (or `.value.current_price`) silently resolves to None. "
+            "binding `{{ nodes.market.value }}` (or `.value.price`) silently resolves to None. "
             "TableDisplayNode.data ← `{{ nodes.market.values }}`; PositionSizingNode.market_data ← `{{ nodes.market.values }}`."
         ),
         "common_combinations": [
@@ -183,11 +183,13 @@ class OverseasFuturesMarketDataNode(BaseNode):
         InputPort(name="trigger", type="signal", description="i18n:ports.trigger", required=False),
     ]
     _outputs: List[OutputPort] = [
-        OutputPort(name="value", type="market_data", description="i18n:ports.market_data_value", fields=PRICE_DATA_FIELDS),
+        OutputPort(name="value", type="market_data", description="i18n:ports.market_data_value",
+                   fields=OVERSEAS_FUTURES_PRICE_DATA_FIELDS),
         OutputPort(
             name="values",
             type="array",
-            description="Array of per-contract market quotes — [{symbol, exchange, current_price, ...}, ...]",
+            description="Array of per-contract market quotes — [{symbol, exchange, price, change, change_pct, ...}, ...]",
+            fields=OVERSEAS_FUTURES_PRICE_DATA_FIELDS,
         ),
     ]
 

--- a/src/core/programgarden_core/nodes/data_korea_stock.py
+++ b/src/core/programgarden_core/nodes/data_korea_stock.py
@@ -74,7 +74,7 @@ class KoreaStockMarketDataNode(BaseNode):
         ],
     }
     _features: ClassVar[List[str]] = [
-        "Returns a single domestic stock's snapshot: current_price, volume, change_percent, bid, ask, per, eps, 52w_high, 52w_low",
+        "Returns a single domestic stock's snapshot: symbol, exchange, name, price, change, change_pct, volume, open, high, low, close, per, pbr",
         "Symbol format is a 6-digit KRX code (e.g., '005930') — no exchange field required (domestic market only)",
         "Item-based execution: pair with SplitNode to query multiple domestic stocks in sequence",
         "is_tool_enabled=True — AI Agent can call this node to look up KRX stock prices autonomously",
@@ -121,7 +121,7 @@ class KoreaStockMarketDataNode(BaseNode):
                     }
                 ],
             },
-            "expected_output": "values port: array of {symbol, current_price, volume, change_percent, bid, ask, per, eps} per domestic stock.",
+            "expected_output": "values port: array of {symbol, exchange, name, price, change, change_pct, volume, open, high, low, close, per, pbr} per domestic stock.",
         },
         {
             "title": "Price lookup for domestic PositionSizingNode",
@@ -165,11 +165,11 @@ class KoreaStockMarketDataNode(BaseNode):
         ),
         "output_consumption": (
             "Consume the `values` port ONLY — an array of per-symbol snapshots "
-            "[{symbol, current_price, volume, change_percent, bid, ask, per, eps, 52w_high, 52w_low}, ...]. "
+            "[{symbol, exchange, name, price, change, change_pct, volume, open, high, low, close, per, pbr}, ...]. "
             "⚠️ The `value` (singular) port is NOT populated at runtime — the executor emits `values` only; "
-            "binding `{{ nodes.market.value }}` (or `.value.current_price`) silently resolves to None. "
+            "binding `{{ nodes.market.value }}` (or `.value.price`) silently resolves to None. "
             "TableDisplayNode.data ← `{{ nodes.market.values }}`; PositionSizingNode.market_data ← `{{ nodes.market.values }}` "
-            "(the array carries each symbol's current_price, which PositionSizingNode resolves internally)."
+            "(the array carries each symbol's price, which PositionSizingNode resolves internally)."
         ),
         "common_combinations": [
             "KoreaStockMarketDataNode.values → TableDisplayNode.data (KRX price monitor)",
@@ -189,7 +189,12 @@ class KoreaStockMarketDataNode(BaseNode):
     ]
     _outputs: List[OutputPort] = [
         OutputPort(name="value", type="market_data", description="i18n:ports.market_data_value", fields=KOREA_STOCK_PRICE_DATA_FIELDS),
-        OutputPort(name="values", type="array", description="Array of per-symbol market quotes"),
+        OutputPort(
+            name="values",
+            type="array",
+            description="Array of per-symbol market quotes — [{symbol, exchange, name, price, change, change_pct, ...}, ...]",
+            fields=KOREA_STOCK_PRICE_DATA_FIELDS,
+        ),
     ]
 
     _version: ClassVar[str] = "1.0.0"

--- a/src/core/programgarden_core/nodes/data_stock.py
+++ b/src/core/programgarden_core/nodes/data_stock.py
@@ -74,7 +74,7 @@ class OverseasStockMarketDataNode(BaseNode):
         ],
     }
     _features: ClassVar[List[str]] = [
-        "Returns a single symbol's snapshot: current_price, volume, change_percent, bid, ask, per, eps, 52w_high, 52w_low",
+        "Returns a single symbol's snapshot: symbol, exchange, price, change, change_pct, volume, open, high, low, close, per, eps",
         "Item-based execution: receives one {exchange, symbol} dict per call and emits one value dict — pair with SplitNode for multi-symbol queries",
         "is_tool_enabled=True — AI Agent can call this node to look up live prices autonomously",
         "Broker connection is auto-injected via DAG traversal — no explicit binding needed",
@@ -121,7 +121,7 @@ class OverseasStockMarketDataNode(BaseNode):
                     }
                 ],
             },
-            "expected_output": "values port: array of {symbol, exchange, current_price, volume, change_percent, bid, ask, per, eps} for each symbol.",
+            "expected_output": "values port: array of {symbol, exchange, price, change, change_pct, volume, open, high, low, close, per, eps} for each symbol.",
         },
         {
             "title": "Price lookup feeding PositionSizingNode",
@@ -164,12 +164,11 @@ class OverseasStockMarketDataNode(BaseNode):
             "The node auto-receives the broker connection via DAG traversal from OverseasStockBrokerNode."
         ),
         "output_consumption": (
-            "Consume the `values` port ONLY — an array of {symbol, exchange, current_price, volume, change_percent, "
-            "bid, ask, per, eps, 52w_high, 52w_low}. "
+            "Consume the `values` port ONLY — an array of {symbol, exchange, price, change, change_pct, volume, open, high, low, close, per, eps}. "
             "⚠️ The `value` (singular) port is NOT populated at runtime — the executor emits `values` only; "
-            "binding `{{ nodes.market.value }}` (or `.value.current_price`) silently resolves to None. "
+            "binding `{{ nodes.market.value }}` (or `.value.price`) silently resolves to None. "
             "TableDisplayNode.data ← `{{ nodes.market.values }}`; PositionSizingNode.market_data ← `{{ nodes.market.values }}` "
-            "(the array carries each symbol's current_price, resolved internally)."
+            "(the array carries each symbol's price, resolved internally)."
         ),
         "common_combinations": [
             "WatchlistNode/SymbolQueryNode → OverseasStockMarketDataNode.symbols (multi-symbol price fetch)",
@@ -194,11 +193,16 @@ class OverseasStockMarketDataNode(BaseNode):
             description="i18n:ports.market_data_value",
             fields=PRICE_DATA_FIELDS,
             example={
-                "exchange": "NASDAQ",
                 "symbol": "AAPL",
-                "current_price": 187.45,
+                "exchange": "NASDAQ",
+                "price": 187.45,
+                "change": -2.34,
+                "change_pct": -1.23,
                 "volume": 12_345_678,
-                "change_percent": -1.23,
+                "open": 189.10,
+                "high": 190.02,
+                "low": 186.90,
+                "close": 187.45,
                 "per": 28.5,
                 "eps": 6.57,
             },
@@ -206,7 +210,8 @@ class OverseasStockMarketDataNode(BaseNode):
         OutputPort(
             name="values",
             type="array",
-            description="Array of per-symbol market quotes — [{symbol, exchange, current_price, ...}, ...]",
+            description="Array of per-symbol market quotes — [{symbol, exchange, price, change, change_pct, ...}, ...]",
+            fields=PRICE_DATA_FIELDS,
         ),
     ]
 

--- a/src/core/programgarden_core/nodes/realtime_futures.py
+++ b/src/core/programgarden_core/nodes/realtime_futures.py
@@ -21,11 +21,10 @@ from programgarden_core.nodes.base import (
     ProductScope,
     BrokerProvider,
     OVERSEAS_FUTURES_REAL_BALANCE_FIELDS,
-    MARKET_DATA_FULL_FIELDS,
     OHLCV_DATA_FIELDS,
     ORDER_EVENT_FIELDS,
     ORDER_LIST_FIELDS,
-    POSITION_FIELDS,
+    OVERSEAS_FUTURES_REAL_POSITION_FIELDS,
     SYMBOL_LIST_FIELDS,
     PRICE_DATA_FIELDS,
 )
@@ -65,7 +64,7 @@ class OverseasFuturesRealMarketDataNode(BaseNode):
         ],
     }
     _features: ClassVar[List[str]] = [
-        "Streams real-time trade events from LS Securities WebSocket — ohlcv_data port emits aggregated candles; data port emits raw tick dicts",
+        "Streams real-time trade events from LS Securities WebSocket — ohlcv_data 포트가 집계된 봉을 내보낸다 (data 포트는 같은 객체의 별칭)",
         "stay_connected=True keeps the WebSocket subscription live between cycles (recommended for realtime strategies)",
         "Supports CME, EUREX, SGX, HKEX contracts — symbol must include contract month code (e.g., ESH26)",
         "Item-based execution: one subscription per node; use multiple nodes to watch multiple contracts",
@@ -179,8 +178,11 @@ class OverseasFuturesRealMarketDataNode(BaseNode):
             "Use OverseasFuturesBrokerNode as the upstream broker."
         ),
         "output_consumption": (
-            "The `ohlcv_data` port emits aggregated candle dicts: {symbol, exchange, open, high, low, close, volume}. "
-            "The `data` port emits the raw full tick dict. "
+            "`ohlcv_data` 와 `data` 는 **같은 객체**다 — `data` 는 별칭이다. "
+            "(예전 문서는 `data` 가 bid/ask 를 담은 raw tick dict 이라고 했지만, 그 값을 만드는 코드는 "
+            "아무도 호출하지 않는 죽은 코드였다. 런타임에 bid/ask/current_price/change_percent 는 없다.) "
+            "값의 모양: {\"AAPL\": [{date, open, high, low, close, volume}, ...]} — 종목코드로 키를 잡은 dict 이고, "
+            "봉 한 줄에는 exchange/symbol/timestamp 가 없다. "
             "ALWAYS insert ThrottleNode before any order or AI node downstream."
         ),
         "common_combinations": [
@@ -210,7 +212,8 @@ class OverseasFuturesRealMarketDataNode(BaseNode):
     ]
     _outputs: List[OutputPort] = [
         OutputPort(name="ohlcv_data", type="ohlcv_data", description="i18n:ports.ohlcv_data", fields=OHLCV_DATA_FIELDS),
-        OutputPort(name="data", type="market_data_full", description="i18n:ports.market_data_full", fields=MARKET_DATA_FULL_FIELDS),
+        OutputPort(name="data", type="ohlcv_data", description="i18n:ports.market_data_full", fields=OHLCV_DATA_FIELDS),
+        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=SYMBOL_LIST_FIELDS),
     ]
 
     _version: ClassVar[str] = "1.0.0"
@@ -401,7 +404,7 @@ class OverseasFuturesRealAccountNode(BaseNode):
         OutputPort(name="held_symbols", type="symbol_list", description="i18n:ports.held_symbols", fields=SYMBOL_LIST_FIELDS),
         OutputPort(name="balance", type="balance_data", description="i18n:ports.balance", fields=OVERSEAS_FUTURES_REAL_BALANCE_FIELDS),
         OutputPort(name="open_orders", type="order_list", description="i18n:ports.open_orders", fields=ORDER_LIST_FIELDS),
-        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=POSITION_FIELDS),
+        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=OVERSEAS_FUTURES_REAL_POSITION_FIELDS),
     ]
 
     _version: ClassVar[str] = "1.0.0"

--- a/src/core/programgarden_core/nodes/realtime_korea_stock.py
+++ b/src/core/programgarden_core/nodes/realtime_korea_stock.py
@@ -21,11 +21,10 @@ from programgarden_core.nodes.base import (
     ProductScope,
     BrokerProvider,
     KOREA_STOCK_REAL_BALANCE_FIELDS,
-    MARKET_DATA_FULL_FIELDS,
     OHLCV_DATA_FIELDS,
     ORDER_EVENT_FIELDS,
     ORDER_LIST_FIELDS,
-    POSITION_FIELDS,
+    KOREA_STOCK_REAL_POSITION_FIELDS,
     SYMBOL_LIST_FIELDS,
 )
 
@@ -64,7 +63,7 @@ class KoreaStockRealMarketDataNode(BaseNode):
         ],
     }
     _features: ClassVar[List[str]] = [
-        "Streams real-time trade events from LS Securities WebSocket for KRX stocks — ohlcv_data port emits aggregated candles; data port emits raw tick dicts",
+        "Streams real-time trade events from LS Securities WebSocket for KRX stocks — ohlcv_data 포트가 집계된 봉을 내보낸다 (data 포트는 같은 객체의 별칭)",
         "stay_connected=True keeps the WebSocket subscription live between cycles (recommended for realtime strategies)",
         "Symbol format: 6-digit KRX code (e.g., '005930') without exchange field — domestic market implied",
         "Item-based execution: one subscription per node; use multiple nodes to watch multiple domestic stocks",
@@ -178,8 +177,11 @@ class KoreaStockRealMarketDataNode(BaseNode):
             "Use KoreaStockBrokerNode as the upstream broker."
         ),
         "output_consumption": (
-            "The `ohlcv_data` port emits aggregated candle dicts: {symbol, open, high, low, close, volume}. "
-            "The `data` port emits the raw full tick dict including bid/ask. "
+            "`ohlcv_data` 와 `data` 는 **같은 객체**다 — `data` 는 별칭이다. "
+            "(예전 문서는 `data` 가 bid/ask 를 담은 raw tick dict 이라고 했지만, 그 값을 만드는 코드는 "
+            "아무도 호출하지 않는 죽은 코드였다. 런타임에 bid/ask/current_price/change_percent 는 없다.) "
+            "값의 모양: {\"AAPL\": [{date, open, high, low, close, volume}, ...]} — 종목코드로 키를 잡은 dict 이고, "
+            "봉 한 줄에는 exchange/symbol/timestamp 가 없다. "
             "ALWAYS insert ThrottleNode before any order or AI node downstream."
         ),
         "common_combinations": [
@@ -209,7 +211,8 @@ class KoreaStockRealMarketDataNode(BaseNode):
     ]
     _outputs: List[OutputPort] = [
         OutputPort(name="ohlcv_data", type="ohlcv_data", description="i18n:ports.ohlcv_data", fields=OHLCV_DATA_FIELDS),
-        OutputPort(name="data", type="market_data_full", description="i18n:ports.market_data_full", fields=MARKET_DATA_FULL_FIELDS),
+        OutputPort(name="data", type="ohlcv_data", description="i18n:ports.market_data_full", fields=OHLCV_DATA_FIELDS),
+        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=SYMBOL_LIST_FIELDS),
     ]
 
     _version: ClassVar[str] = "1.0.0"
@@ -404,7 +407,7 @@ class KoreaStockRealAccountNode(BaseNode):
         OutputPort(name="held_symbols", type="symbol_list", description="i18n:ports.held_symbols", fields=SYMBOL_LIST_FIELDS),
         OutputPort(name="balance", type="balance_data", description="i18n:ports.balance", fields=KOREA_STOCK_REAL_BALANCE_FIELDS),
         OutputPort(name="open_orders", type="order_list", description="i18n:ports.open_orders", fields=ORDER_LIST_FIELDS),
-        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=POSITION_FIELDS),
+        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=KOREA_STOCK_REAL_POSITION_FIELDS),
     ]
 
     _version: ClassVar[str] = "1.0.0"

--- a/src/core/programgarden_core/nodes/realtime_stock.py
+++ b/src/core/programgarden_core/nodes/realtime_stock.py
@@ -21,11 +21,10 @@ from programgarden_core.nodes.base import (
     ProductScope,
     BrokerProvider,
     OVERSEAS_STOCK_REAL_BALANCE_FIELDS,
-    MARKET_DATA_FULL_FIELDS,
     OHLCV_DATA_FIELDS,
     ORDER_EVENT_FIELDS,
     ORDER_LIST_FIELDS,
-    POSITION_FIELDS,
+    OVERSEAS_STOCK_REAL_POSITION_FIELDS,
     SYMBOL_LIST_FIELDS,
     PRICE_DATA_FIELDS,
 )
@@ -66,7 +65,7 @@ class OverseasStockRealMarketDataNode(BaseNode):
         ],
     }
     _features: ClassVar[List[str]] = [
-        "Streams GSC (trade/tick) events from LS Securities WebSocket — ohlcv_data port emits aggregated candles; data port emits raw tick dicts",
+        "Streams GSC (trade/tick) events from LS Securities WebSocket — ohlcv_data 포트가 집계된 봉을 내보낸다 (data 포트는 같은 객체의 별칭)",
         "stay_connected=True keeps the WebSocket subscription live between cycles (recommended for realtime strategies)",
         "Item-based execution: one subscription per node; use multiple nodes or SplitNode to watch several symbols",
         "Automatically re-subscribes after WebSocket reconnection events",
@@ -180,8 +179,11 @@ class OverseasStockRealMarketDataNode(BaseNode):
             "Set stay_connected=True (default) to avoid reconnection overhead on every cycle."
         ),
         "output_consumption": (
-            "The `ohlcv_data` port emits aggregated candle dicts: {symbol, exchange, open, high, low, close, volume}. "
-            "The `data` port emits the raw full tick dict including bid/ask fields. "
+            "`ohlcv_data` 와 `data` 는 **같은 객체**다 — `data` 는 별칭이다. "
+            "(예전 문서는 `data` 가 bid/ask 를 담은 raw tick dict 이라고 했지만, 그 값을 만드는 코드는 "
+            "아무도 호출하지 않는 죽은 코드였다. 런타임에 bid/ask/current_price/change_percent 는 없다.) "
+            "값의 모양: {\"AAPL\": [{date, open, high, low, close, volume}, ...]} — 종목코드로 키를 잡은 dict 이고, "
+            "봉 한 줄에는 exchange/symbol/timestamp 가 없다. "
             "ALWAYS insert ThrottleNode before any order or AI node downstream."
         ),
         "common_combinations": [
@@ -211,7 +213,8 @@ class OverseasStockRealMarketDataNode(BaseNode):
     ]
     _outputs: List[OutputPort] = [
         OutputPort(name="ohlcv_data", type="ohlcv_data", description="i18n:ports.ohlcv_data", fields=OHLCV_DATA_FIELDS),
-        OutputPort(name="data", type="market_data_full", description="i18n:ports.market_data_full", fields=MARKET_DATA_FULL_FIELDS),
+        OutputPort(name="data", type="ohlcv_data", description="i18n:ports.market_data_full", fields=OHLCV_DATA_FIELDS),
+        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=SYMBOL_LIST_FIELDS),
     ]
 
     _version: ClassVar[str] = "1.0.0"
@@ -406,7 +409,7 @@ class OverseasStockRealAccountNode(BaseNode):
         OutputPort(name="held_symbols", type="symbol_list", description="i18n:ports.held_symbols", fields=SYMBOL_LIST_FIELDS),
         OutputPort(name="balance", type="balance_data", description="i18n:ports.balance", fields=OVERSEAS_STOCK_REAL_BALANCE_FIELDS),
         OutputPort(name="open_orders", type="order_list", description="i18n:ports.open_orders", fields=ORDER_LIST_FIELDS),
-        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=POSITION_FIELDS),
+        OutputPort(name="positions", type="position_data", description="i18n:ports.positions", fields=OVERSEAS_STOCK_REAL_POSITION_FIELDS),
     ]
 
     _version: ClassVar[str] = "1.0.0"

--- a/src/core/programgarden_core/nodes/symbol.py
+++ b/src/core/programgarden_core/nodes/symbol.py
@@ -24,6 +24,8 @@ from programgarden_core.nodes.base import (
     InputPort,
     OutputPort,
     SYMBOL_LIST_FIELDS,
+    SCREENER_SYMBOL_FIELDS,
+    MARKET_UNIVERSE_SYMBOL_FIELDS,
 )
 from programgarden_core.models.exchange import SymbolEntry, ProductType
 
@@ -251,7 +253,7 @@ class MarketUniverseNode(BaseNode):
 
     _inputs: List[InputPort] = []
     _outputs: List[OutputPort] = [
-        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=SYMBOL_LIST_FIELDS),
+        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=MARKET_UNIVERSE_SYMBOL_FIELDS),
         OutputPort(name="count", type="integer", description="종목 수"),
     ]
 
@@ -453,7 +455,7 @@ class ScreenerNode(BaseNode):
         ),
     ]
     _outputs: List[OutputPort] = [
-        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=SYMBOL_LIST_FIELDS),
+        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=SCREENER_SYMBOL_FIELDS),
         OutputPort(name="count", type="integer", description="결과 종목 수"),
     ]
 

--- a/src/core/programgarden_core/nodes/symbol_futures.py
+++ b/src/core/programgarden_core/nodes/symbol_futures.py
@@ -20,6 +20,7 @@ from programgarden_core.nodes.base import (
     ProductScope,
     BrokerProvider,
     SYMBOL_LIST_FIELDS,
+    OVERSEAS_FUTURES_SYMBOL_QUERY_FIELDS,
 )
 
 
@@ -182,7 +183,7 @@ class OverseasFuturesSymbolQueryNode(BaseNode):
 
     _inputs: List[InputPort] = []
     _outputs: List[OutputPort] = [
-        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=SYMBOL_LIST_FIELDS),
+        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=OVERSEAS_FUTURES_SYMBOL_QUERY_FIELDS),
         OutputPort(name="count", type="integer", description="Total symbol count"),
     ]
 

--- a/src/core/programgarden_core/nodes/symbol_korea_stock.py
+++ b/src/core/programgarden_core/nodes/symbol_korea_stock.py
@@ -18,7 +18,7 @@ from programgarden_core.nodes.base import (
     OutputPort,
     ProductScope,
     BrokerProvider,
-    SYMBOL_LIST_FIELDS,
+    KOREA_STOCK_SYMBOL_QUERY_FIELDS,
 )
 
 
@@ -169,7 +169,7 @@ class KoreaStockSymbolQueryNode(BaseNode):
 
     _inputs: List[InputPort] = []
     _outputs: List[OutputPort] = [
-        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=SYMBOL_LIST_FIELDS),
+        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=KOREA_STOCK_SYMBOL_QUERY_FIELDS),
         OutputPort(name="count", type="integer", description="Total symbol count"),
     ]
 

--- a/src/core/programgarden_core/nodes/symbol_stock.py
+++ b/src/core/programgarden_core/nodes/symbol_stock.py
@@ -18,7 +18,7 @@ from programgarden_core.nodes.base import (
     OutputPort,
     ProductScope,
     BrokerProvider,
-    SYMBOL_LIST_FIELDS,
+    OVERSEAS_STOCK_SYMBOL_QUERY_FIELDS,
 )
 
 
@@ -177,7 +177,7 @@ class OverseasStockSymbolQueryNode(BaseNode):
 
     _inputs: List[InputPort] = []
     _outputs: List[OutputPort] = [
-        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=SYMBOL_LIST_FIELDS),
+        OutputPort(name="symbols", type="symbol_list", description="i18n:ports.symbols", fields=OVERSEAS_STOCK_SYMBOL_QUERY_FIELDS),
         OutputPort(name="count", type="integer", description="Total symbol count"),
     ]
 

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-core"
-version = "1.19.0"
+version = "1.20.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 readme = "README.md"

--- a/src/core/tests/test_node_schema_completeness.py
+++ b/src/core/tests/test_node_schema_completeness.py
@@ -24,7 +24,9 @@ except ImportError:
     _COMMUNITY_AVAILABLE = False
 
 
-CORE_NODE_COUNT = 70
+# 1.27.0 에서 FuturesContractNode 가 추가됐는데 이 수를 안 올려서 가드가 계속 빨간 상태였다
+# (빨간 가드는 새 노드가 실수로 끼어드는 것도 못 잡는다).
+CORE_NODE_COUNT = 71
 COMMUNITY_NODE_COUNT = 4
 EXPECTED_TOTAL = CORE_NODE_COUNT + (COMMUNITY_NODE_COUNT if _COMMUNITY_AVAILABLE else 0)
 

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,5 +1,55 @@
 ## [Unreleased]
 
+## [1.28.0] - 2026-07-14
+> 라이브 E2E(pg-test-9)가 잡은 결함 3건 + **선언 드리프트 후속**.
+> 관통 불변식: **노드가 선언한 출력 포트는 런타임이 실제로, 어느 갈래에서든 같은 키로 내보낸다.**
+> resolver 는 선언으로 필드 존재를 정적 검증하므로, 선언이 런타임과 어긋나면 검증이 양방향으로
+> 다 틀린다 — 있는 필드는 부당 거부하고, 없는 필드는 통과시킨 뒤 런타임에 조용히 None 이 된다.
+
+### Fixed
+- **해외주식 전일대비(`change`) 부호 유실** — 하락장에서 등락폭이 **항상 양수**로 나왔다.
+  g3101 의 `diff` 는 절댓값이고 부호는 `sign`(2=상승, 5=하락)에 따로 온다(실 TR 16종목 실측).
+  해외선물 o3105 는 반대로 `YdiffP` 가 이미 부호를 포함한다(LS 문서의 "Absolute" 표기가 오기).
+  멱등 헬퍼 `_ls_signed_change` 로 통일 — 국내(t1102)도 같은 규칙.
+- **브로커 자격증명이 노드 출력으로 새어 나갔다** — `connection` 출력에 appkey/appsecret 이 실려
+  SSE·`get_state` 로 외부에 노출됐다. 출력에서 제거하고 시크릿 저장소 조회로 이관.
+  동반: 다중 브로커 슬롯 충돌(단일 리터럴 슬롯 → product 별 슬롯 분리).
+- **시세 노드 선언이 런타임과 달랐다** — 선언은 `current_price`/`change_percent`, 런타임은
+  `price`/`change_pct`. "엔비디아 현재가 보여줘" 표의 현재가 칸이 `-` 로 비었는데 워크플로우는
+  `completed / errors=0` 이었다. 선언 정정 + Display 컬럼 가드 + AST 계약 검사 신설.
+- **`held_symbols` 를 아무도 내보내지 않았다** — 계좌 노드 6종(REST 3 + 실시간 3)이 전부 이 출력
+  포트를 선언하는데, executor 는 값을 계산만 하고 **반환 dict 에 싣지 않았다**(죽은 지역변수).
+  국내주식 분기는 계산조차 없었다. 그래서 `nodes.account.held_symbols` 바인딩은 정적 검증을 통과한 뒤
+  런타임엔 늘 비었고, RealMarketDataNode 의 "보유 종목 자동 구독" 경로가 **항상 아무것도 구독하지
+  않으면서** 워크플로우는 `completed / errors=0` 으로 보고했다. 이제 6종 모두 `[{exchange, symbol}]`
+  로 실제 반환한다(실패 경로 `_empty_result` 포함).
+- **실시간 계좌 `positions` 가 시점마다 다른 모양이었다** — REST 스냅샷 갈래는 `exchange`/`quantity`/
+  `price` 를, WebSocket tracker 갈래는 `qty`/`market_code` 를 내보냈다. 주문 노드는 `exchange`/
+  `quantity` 를 읽으므로 **실시간 틱이 오는 순간 조용히 깨졌다.** 상품별로 두 갈래의 키 집합을 통일.
+- **계좌 `positions` 선언이 `pnl` / `pnl_percent` 를 약속했지만 런타임에 그런 키는 없다**
+  (실제는 `pnl_amount` / `pnl_rate`). 챗봇은 카탈로그를 보고 저작하므로 라이브러리가 **없는 이름을
+  쓰도록 강제**하고 있었다. 동봉 예제 2건이 실제로 그 열을 `-` 로 찍고 있었다(22, 49 → 수정).
+- **실시간 `data` 포트가 약속하던 `current_price`/`bid_price`/`ask_price`/`change_percent` 는
+  런타임에 없다.** `data` 는 `ohlcv_data` 의 **별칭**이고 값은 `{종목: [봉]}` dict 이다. 그 값을
+  만든다던 `_build_full_data` 는 **아무도 호출하지 않는 죽은 코드**였다 → 제거. 실시간 노드의
+  `symbols` 출력은 선언조차 없어 바인딩하면 부당 거부됐다 → 선언 추가.
+- **ScreenerNode 가 상류의 종목명을 버렸다** — SymbolQueryNode 가 준 `name`/`market` 을 중간에서
+  떨어뜨려, 종목명 열을 넣은 예제(78/79)가 `-` 만 찍었다. 이제 통과시킨다.
+
+### Changed
+- 공유 상수 `SYMBOL_LIST_FIELDS`(11파일 20포트) / `POSITION_FIELDS`(6노드) / `MARKET_DATA_FULL_FIELDS`
+  를 **노드별 상수로 분리**. 상수를 공유하면 한 노드를 맞추는 순간 다른 노드가 반대로 거짓말한다
+  (Screener 를 맞추려 `price` 를 넣으면 Watchlist 가 안 내보내는 필드를 선언하게 된다).
+- resolver 의 Display 컬럼 가드(`VERIFIED_PORTS`) 6 → 24 포트. **계약 검사로 선언 == 런타임 이
+  증명된 포트만** 등록한다(오탐 0 원칙). 실시간 `ohlcv_data`/`data` 는 값이 dict-of-bars 라
+  열의 의미가 정해져 있지 않아 일부러 제외.
+
+### Added
+- `tests/test_output_schema_contract.py` 확대 (47 passed) — executor 의 런타임 dict 리터럴을 AST 로
+  뽑아 선언과 대조한다. 신규 검사 2종:
+  - `test_declared_ports_are_actually_returned` — 선언한 포트를 **반환에 싣는지** (위 held_symbols 결함).
+  - `test_producers_of_one_port_agree` — 한 포트를 만드는 갈래가 여럿이면 키 집합이 같아야 한다.
+
 ## [1.27.0] - 2026-07-13
 > 두 갈래 작업이 한 릴리스로 합쳐졌다: ① 선물 월물 자동 해소(FuturesContractNode)
 > ② 노드 출력-스키마 정합 + 하드실패 raise + SplitNode 정적 가드.

--- a/src/programgarden/examples/workflows/22-display-table.json
+++ b/src/programgarden/examples/workflows/22-display-table.json
@@ -37,10 +37,10 @@
         "symbol",
         "exchange",
         "quantity",
-        "pnl"
+        "pnl_amount"
       ],
       "limit": 10,
-      "sort_by": "pnl",
+      "sort_by": "pnl_amount",
       "sort_order": "desc",
       "position": {
         "x": 600,

--- a/src/programgarden/examples/workflows/49-korea-stock-account.json
+++ b/src/programgarden/examples/workflows/49-korea-stock-account.json
@@ -39,7 +39,7 @@
         "avg_price",
         "current_price",
         "eval_amount",
-        "pnl",
+        "pnl_amount",
         "pnl_rate"
       ],
       "data": "{{ nodes.account.positions }}",

--- a/src/programgarden/programgarden/__init__.py
+++ b/src/programgarden/programgarden/__init__.py
@@ -91,7 +91,7 @@ except ImportError:
     # Community package not installed
     pass
 
-__version__ = "1.27.0"
+__version__ = "1.28.0"
 __all__ = [
     # Core
     "ProgramGarden",

--- a/src/programgarden/programgarden/context.py
+++ b/src/programgarden/programgarden/context.py
@@ -2626,25 +2626,45 @@ class ExecutionContext:
             logger.warning(f"Failed to sync fills from history: {e}")
             return 0
 
+    # 노드 출력에 실려 외부로 나가면 안 되는 키 (부분일치, 소문자 비교).
+    # BrokerNode 는 `connection.appkey/appsecret` 을 하류 노드에 넘기기 위해 **출력에 싣는다**
+    # (내부 전송 경로라 지울 수 없다). 따라서 외부로 나가는 모든 경계에서 가려야 한다.
+    SENSITIVE_OUTPUT_KEYS = frozenset(
+        {"appkey", "appsecret", "secret", "password", "token", "api_key", "apikey", "private_key"}
+    )
+
+    def _sanitize_value(self, value: Any) -> Any:
+        """dict/list 를 재귀적으로 훑어 민감 키를 가린다."""
+        if isinstance(value, dict):
+            return self._sanitize_outputs(value)
+        if isinstance(value, (list, tuple)):
+            # 리스트 안의 dict 도 가려야 한다 (예: credentials[] 배열).
+            sanitized_items = [self._sanitize_value(item) for item in value]
+            return type(value)(sanitized_items) if isinstance(value, tuple) else sanitized_items
+        return value
+
     def _sanitize_outputs(self, outputs: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Remove sensitive information from outputs."""
         # None은 None으로 반환, 빈 딕셔너리 {}는 그대로 유지
         if outputs is None:
             return None
-        
-        # Filter sensitive keywords
-        sensitive_keys = {"appkey", "appsecret", "secret", "password", "token", "api_key"}
+
         sanitized = {}
-        
         for k, v in outputs.items():
-            if any(sk in k.lower() for sk in sensitive_keys):
+            if any(sk in str(k).lower() for sk in self.SENSITIVE_OUTPUT_KEYS):
                 sanitized[k] = "[REDACTED]"
-            elif isinstance(v, dict):
-                sanitized[k] = self._sanitize_outputs(v)
             else:
-                sanitized[k] = v
-        
+                sanitized[k] = self._sanitize_value(v)
+
         return sanitized
+
+    def get_all_outputs_sanitized(self, node_id: str) -> Dict[str, Any]:
+        """외부로 내보낼 노드 출력 — 민감 키가 가려진 사본.
+
+        내부 전송(바인딩 해석 · broker connection auto-inject)은 `get_all_outputs()` 의
+        raw 값을 그대로 쓰고, **외부 노출면**(리스너 이벤트 · `get_state()`)만 이걸 쓴다.
+        """
+        return self._sanitize_outputs(self.get_all_outputs(node_id)) or {}
 
     # === Logging ===
 

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -9297,6 +9297,36 @@ class IfNodeExecutor(NodeExecutorBase):
         return False
 
 
+# 전일대비(delta)의 부호 규칙은 LS TR 마다 다르다 — 실측으로만 확정된다 (2026-07-13):
+#   g3101 (해외주식) : diff   = 절댓값,   부호는 sign 에 별도    → NVDA sign='5' diff='2.41'  rate=-1.14
+#   t1102 (국내주식) : change = 절댓값,   부호는 sign 에 별도    → 삼성 sign='5' change=30500 diff=-10.70
+#   o3105 (해외선물) : YdiffP = 이미 부호 포함(문서의 "Absolute" 는 오기) → HBIN26 sign='5' YdiffP=-105.0
+# 등락률(%)은 세 TR 모두 부호를 갖는다.
+#
+# 그래서 "무조건 abs() 후 sign 적용"은 위험하다 — o3105 처럼 이미 음수인 값을 양수로 뒤집는다.
+# 방향 코드가 명확할 때만 크기를 그 방향으로 맞추고, 불명이면 원값의 부호를 신뢰한다.
+_LS_DOWN_SIGNS = ("4", "5", "-")  # 4=하한, 5=하락
+_LS_UP_SIGNS = ("1", "2", "+")    # 1=상한, 2=상승  (3=보합 → 값이 0 이라 통과시켜도 무해)
+
+
+def _ls_signed_change(magnitude: Any, sign: Any) -> float:
+    """LS 전일대비(delta)를 방향 코드에 맞춰 부호 있는 값으로 정규화한다.
+
+    멱등하다 — 이미 부호가 실려 온 값(o3105)에 다시 적용해도 결과가 바뀌지 않는다.
+    방향 코드가 비었거나 알 수 없으면 **원값을 그대로** 둔다(멋대로 양수로 만들지 않는다).
+    """
+    try:
+        v = float(magnitude or 0)
+    except (TypeError, ValueError):
+        return 0.0
+    s = str(sign or "").strip()
+    if s in _LS_DOWN_SIGNS:
+        return -abs(v)
+    if s in _LS_UP_SIGNS:
+        return abs(v)
+    return v
+
+
 class MarketDataNodeExecutor(NodeExecutorBase):
     """
     MarketDataNode executor - REST API 현재가 조회 (당일 데이터만)
@@ -9509,7 +9539,8 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                             "symbol": symbol,
                             "exchange": resolved_exchange,
                             "price": float(out_block.price or 0),
-                            "change": float(out_block.diff or 0),
+                            # g3101 `diff` 는 절댓값 — 부호는 `sign` 에 따로 온다.
+                            "change": _ls_signed_change(out_block.diff, getattr(out_block, "sign", "")),
                             "change_pct": float(out_block.rate or 0),
                             "volume": int(out_block.volume or 0),
                             "open": float(out_block.open or 0),
@@ -9594,7 +9625,9 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                             "exchange": exchange,
                             "symbol_name": out_block.SymbolNm or symbol,
                             "price": float(out_block.TrdP or 0),
-                            "change": float(out_block.YdiffP or 0),
+                            # o3105 `YdiffP` 는 이미 부호를 포함한다(실측). 헬퍼는 멱등이라 값이 안 바뀌며,
+                            # LS 가 언젠가 절댓값으로 바꿔 보내도 `YdiffSign` 으로 방어된다.
+                            "change": _ls_signed_change(out_block.YdiffP, getattr(out_block, "YdiffSign", "")),
                             "change_pct": float(out_block.Diff or 0),
                             "volume": int(out_block.TotQ or 0),
                             "open": float(out_block.OpenP or 0),
@@ -9667,9 +9700,9 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                         blk = response.block
 
                         # sign: 1=상한/2=상승 → 양수, 4=하한/5=하락 → 음수
-                        change_val = int(blk.change or 0)
-                        if blk.sign in ("4", "5"):
-                            change_val = -change_val
+                        # 국내 현재가 `change` 도 절댓값 — 부호는 `sign` 에 따로 온다 (해외와 동일 규칙).
+                        # 국내 호가는 원 단위 정수라 기존 int 출력 타입을 유지한다.
+                        change_val = int(_ls_signed_change(blk.change, getattr(blk, "sign", "")))
 
                         values.append({
                             "symbol": symbol,

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -2011,6 +2011,12 @@ class ScreenerNodeExecutor(NodeExecutorBase):
                 "market_cap": mcap,
                 # g3101 enrich 시 volume 이 채워졌을 수 있음
                 "volume": int(sym.get("volume") or 0),
+                # 상류가 준 값 통과 (없으면 빈 문자열). LS 마스터에는 섹터가 없다.
+                # 그래도 키는 내보낸다 — yfinance 분기와 키 집합이 다르면 같은 포트가
+                # 분기마다 다른 모양이 되고, 선언이 어느 쪽을 적든 반대 분기에서 거짓말이 된다.
+                "name": sym.get("name", "") or "",
+                "market": sym.get("market", "") or "",
+                "sector": sym.get("sector", "") or "",
             })
 
         # 2단계: volume_min 명시 시 g3101로 거래량 확인 (이미 enrich 된 경우 skip)
@@ -2255,8 +2261,11 @@ class ScreenerNodeExecutor(NodeExecutorBase):
                 return entry.get("symbol", "")
             return entry
 
+        # 상류(SymbolQueryNode 등)가 준 name / market 을 그대로 통과시키려면 원본 dict 이 필요하다.
+        # 예전엔 (원본코드, yf티커) 두 개만 들고 다녀서 종목명이 **여기서 소실**됐다 —
+        # 표에 종목명 열을 넣은 예제가 조용히 '-' 만 찍고 있었다.
         lookup_pairs = [
-            (_original_symbol(s), _to_yfinance_ticker(s))
+            (_original_symbol(s), _to_yfinance_ticker(s), s if isinstance(s, dict) else {})
             for s in symbols
         ]
 
@@ -2267,7 +2276,7 @@ class ScreenerNodeExecutor(NodeExecutorBase):
             attempted = 0
             info_succeeded = 0
 
-            for original_sym, yf_ticker in lookup_pairs[:max_results * 2]:  # 여유분
+            for original_sym, yf_ticker, src in lookup_pairs[:max_results * 2]:  # 여유분
                 if not yf_ticker:
                     continue
                 attempted += 1
@@ -2317,6 +2326,8 @@ class ScreenerNodeExecutor(NodeExecutorBase):
                     filtered.append({
                         "exchange": mapped_exchange,
                         "symbol": original_sym,
+                        "name": src.get("name") or info.get("shortName") or info.get("longName") or "",
+                        "market": src.get("market", "") or "",
                         "market_cap": mcap,
                         "volume": vol,
                         "price": price,
@@ -4450,7 +4461,11 @@ class AccountNodeExecutor(NodeExecutorBase):
                 "purchase_amount": item.FcurrBuyAmt,
             })
 
-        held_symbols = [p["symbol"] for p in positions]
+        # held_symbols 는 선언된 출력 포트다. 예전엔 여기서 계산만 하고 **반환 dict 에 싣지
+        # 않아** 늘 비어 있었다 — 바인딩하면 정적 검증은 통과하고 런타임엔 None 이었다.
+        held_symbols = [
+            {"exchange": p.get("exchange", ""), "symbol": p["symbol"]} for p in positions
+        ]
         
         # block2 = 전체 평가 요약. `orderable_amount` is set later by
         # COSOQ02701; pre-seed it as None so consumers can distinguish
@@ -4513,6 +4528,7 @@ class AccountNodeExecutor(NodeExecutorBase):
 
         context.log("info", f"AccountNode: {len(positions)} positions fetched", node_id)
         return {
+            "held_symbols": held_symbols,
             "positions": positions,
             "balance": balance_info,
         }
@@ -4634,6 +4650,10 @@ class AccountNodeExecutor(NodeExecutorBase):
 
             context.log("info", f"AccountNode (korea_stock): {len(positions)} positions fetched", node_id)
             return {
+                "held_symbols": [
+                    {"exchange": p.get("exchange", "KRX"), "symbol": p["symbol"]}
+                    for p in positions
+                ],
                 "positions": positions,
                 "balance": balance_info,
             }
@@ -4700,7 +4720,7 @@ class AccountNodeExecutor(NodeExecutorBase):
                     "pnl_amount": float(item.AbrdFutsEvalPnlAmt) if item.AbrdFutsEvalPnlAmt else 0.0,
                     "currency": item.CrcyCodeVal.strip() if item.CrcyCodeVal else "USD",
                 })
-                held_symbols.append(symbol)
+                held_symbols.append({"exchange": "HKEX", "symbol": symbol})
 
             # 2. CIDBQ05300: 예탁자산 조회 (CIDBQ03000 상위호환).
             # Wrapped in its own try so a balance failure no longer drops
@@ -4782,6 +4802,7 @@ class AccountNodeExecutor(NodeExecutorBase):
 
             context.log("info", f"AccountNode (futures): {len(positions)} positions, {len(balance_by_currency)} currencies", node_id)
             return {
+                "held_symbols": held_symbols,
                 "positions": positions,
                 "balance": balance_info,
             }
@@ -4798,6 +4819,7 @@ class AccountNodeExecutor(NodeExecutorBase):
         other consumers can refuse to coerce missing balances to 0.0.
         """
         result: Dict[str, Any] = {
+            "held_symbols": [],
             "positions": [],
             "balance": {
                 "cash": 0.0,
@@ -5341,7 +5363,9 @@ class RealAccountNodeExecutor(NodeExecutorBase):
                     serialized_positions.append({
                         "symbol": sym,
                         "exchange": getattr(pos, 'market_code', 'NASDAQ'),
+                        "market_code": getattr(pos, 'market_code', ''),
                         "name": getattr(pos, 'symbol_name', sym),
+                        "qty": quantity,
                         "quantity": quantity,  # NewOrderNode 호환
                         "price": current_price,  # NewOrderNode 호환
                         "avg_price": float(pos.buy_price),
@@ -5349,6 +5373,7 @@ class RealAccountNodeExecutor(NodeExecutorBase):
                         "pnl_rate": float(pos.pnl_rate) if pos.pnl_rate else 0,
                         "pnl_amount": float(pos.pnl_amount) if pos.pnl_amount else 0,
                         "currency": getattr(pos, 'currency_code', 'USD'),
+                        "eval_amount": float(pos.eval_amount) if pos.eval_amount else 0,
                         "product": "overseas_stock",  # 상품 유형
                     })
 
@@ -5727,13 +5752,17 @@ class RealAccountNodeExecutor(NodeExecutorBase):
                     serialized_positions.append({
                         "symbol": sym,
                         "exchange": "KRX",
+                        "market_code": getattr(pos, 'market', ''),
                         "name": getattr(pos, 'symbol_name', sym),
+                        "qty": quantity,
                         "quantity": quantity,
                         "price": current_price,
                         "avg_price": float(pos.buy_price),
                         "current_price": current_price,
                         "pnl_rate": float(pos.pnl_rate) if pos.pnl_rate else 0,
                         "pnl_amount": float(pos.pnl_amount) if pos.pnl_amount else 0,
+                        "currency": "KRW",
+                        "eval_amount": float(pos.eval_amount) if pos.eval_amount else 0,
                         "product": "korea_stock",
                     })
 
@@ -5797,20 +5826,31 @@ class RealAccountNodeExecutor(NodeExecutorBase):
         """해외주식 Tracker에서 현재 데이터 추출 (리스트 형태로 반환)"""
         positions = []
         for symbol, pos in tracker.get_positions().items():
+            quantity = pos.quantity
+            current_price = float(pos.current_price)
             positions.append({
                 "symbol": symbol,
                 "name": getattr(pos, 'name', getattr(pos, 'symbol_name', symbol)),
-                "qty": pos.quantity,
+                # REST 스냅샷 갈래(_ls_stock_with_tracker)와 **같은 키 집합**이어야 한다.
+                # 안 그러면 같은 포트가 스냅샷일 땐 exchange/quantity 를 주고 실시간 틱일 땐
+                # 안 주는, 시점마다 모양이 바뀌는 출력이 된다 (주문 노드가 조용히 깨진다).
+                "exchange": getattr(pos, 'market_code', 'NASDAQ'),
+                "market_code": getattr(pos, 'market_code', ''),
+                "qty": quantity,
+                "quantity": quantity,  # NewOrderNode 호환
+                "price": current_price,  # NewOrderNode 호환
                 "avg_price": float(pos.buy_price),
-                "current_price": float(pos.current_price),
+                "current_price": current_price,
                 "pnl_rate": float(pos.pnl_rate) if pos.pnl_rate else 0,
                 "pnl_amount": float(pos.pnl_amount) if pos.pnl_amount else 0,
                 "currency": getattr(pos, 'currency_code', 'USD'),
                 "eval_amount": float(pos.eval_amount) if pos.eval_amount else 0,
-                "market_code": getattr(pos, 'market_code', ''),
+                "product": "overseas_stock",
             })
 
-        symbols = [p["symbol"] for p in positions]
+        held_symbols = [
+            {"exchange": p["exchange"], "symbol": p["symbol"]} for p in positions
+        ]
         
         # balance를 JSON 직렬화 가능한 형태로 변환
         # get_balances()는 Dict[str, StockBalanceInfo]를 반환 (통화별)
@@ -5867,6 +5907,7 @@ class RealAccountNodeExecutor(NodeExecutorBase):
                 }
         
         return {
+            "held_symbols": held_symbols,
             "positions": positions,
             "balance": balance,
             "open_orders": open_orders,
@@ -5900,8 +5941,11 @@ class RealAccountNodeExecutor(NodeExecutorBase):
                 "name": getattr(pos, 'symbol_name', symbol),
                 "direction": "long" if is_long else "short",
                 "close_side": "sell" if is_long else "buy",
+                # REST 스냅샷 갈래(_ls_futureoption_with_tracker)와 같은 키 집합
+                "qty": quantity,
                 "quantity": quantity,  # qty → quantity (NewOrderNode 호환)
                 "price": current_price,  # current_price → price (NewOrderNode 호환)
+                "product": "overseas_futures",
                 "entry_price": float(getattr(pos, 'entry_price', 0)),
                 "current_price": current_price,
                 "pnl_amount": float(getattr(pos, 'pnl_amount', 0) or 0),
@@ -5944,6 +5988,10 @@ class RealAccountNodeExecutor(NodeExecutorBase):
                 }
         
         return {
+            "held_symbols": [
+                {"exchange": pos.get("exchange", ""), "symbol": pos["symbol"]}
+                for pos in positions
+            ],
             "positions": positions,
             "balance": balance,
             "open_orders": open_orders,
@@ -5953,17 +6001,24 @@ class RealAccountNodeExecutor(NodeExecutorBase):
         """국내주식 KrStockAccountTracker에서 현재 데이터 추출"""
         positions = []
         for symbol, pos in tracker.get_positions().items():
+            quantity = pos.quantity
+            current_price = float(pos.current_price)
             positions.append({
                 "symbol": symbol,
                 "name": getattr(pos, 'symbol_name', symbol),
-                "qty": pos.quantity,
+                # REST 스냅샷 갈래(_ls_korea_stock_with_tracker)와 같은 키 집합
+                "exchange": "KRX",
+                "market_code": getattr(pos, 'market', ''),
+                "qty": quantity,
+                "quantity": quantity,  # NewOrderNode 호환
+                "price": current_price,  # NewOrderNode 호환
                 "avg_price": float(pos.buy_price),
-                "current_price": float(pos.current_price),
+                "current_price": current_price,
                 "pnl_rate": pos.pnl_rate,
                 "pnl_amount": float(pos.pnl_amount),
                 "currency": "KRW",
                 "eval_amount": float(pos.eval_amount),
-                "market_code": getattr(pos, 'market', ''),
+                "product": "korea_stock",
             })
 
         # KrStockAccountTracker.get_balance() → KrStockBalanceInfo (단일 객체)
@@ -5998,6 +6053,10 @@ class RealAccountNodeExecutor(NodeExecutorBase):
                 }
 
         return {
+            "held_symbols": [
+                {"exchange": pos.get("exchange", ""), "symbol": pos["symbol"]}
+                for pos in positions
+            ],
             "positions": positions,
             "balance": balance,
             "open_orders": open_orders,
@@ -6021,6 +6080,7 @@ class RealAccountNodeExecutor(NodeExecutorBase):
         consumers do not silently treat the unavailable balance as 0.
         """
         result: Dict[str, Any] = {
+            "held_symbols": [],
             "positions": [],
             "balance": {
                 "cash": 0.0,
@@ -6671,43 +6731,6 @@ class RealMarketDataNodeExecutor(NodeExecutorBase):
         
         return []
     
-    def _build_full_data(
-        self,
-        symbols_raw: List[Dict[str, str]],
-        prices: Dict[str, float],
-        volumes: Dict[str, int],
-        bids: Dict[str, float],
-        asks: Dict[str, float],
-    ) -> Dict[str, Dict[str, Any]]:
-        """
-        종목별 전체 시세 데이터 구조 생성
-        
-        Returns:
-            {
-                "AAPL": {"symbol": "AAPL", "exchange": "NASDAQ", "price": 192.30, ...},
-                "TSLA": {...},
-            }
-        """
-        data = {}
-        for entry in symbols_raw:
-            if isinstance(entry, dict):
-                symbol = entry.get("symbol", "")
-                exchange = entry.get("exchange", "")
-            else:
-                symbol = entry
-                exchange = ""
-            
-            if symbol:
-                data[symbol] = {
-                    "symbol": symbol,
-                    "exchange": exchange,
-                    "price": prices.get(symbol),
-                    "volume": volumes.get(symbol),
-                    "bid": bids.get(symbol),
-                    "ask": asks.get(symbol),
-                }
-        return data
-
 
 class RealOrderEventNodeExecutor(NodeExecutorBase):
     """

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -373,6 +373,43 @@ class LSClientManager:
         cls._credentials.clear()
 
 
+def broker_credential_key(product: Optional[str]) -> str:
+    """BrokerNode 자격증명의 시크릿 저장소 키 (product 별 분리).
+
+    단일 슬롯이면 한 워크플로우에 브로커가 둘 이상일 때(해외주식 + 국내주식) 뒤에 실행된
+    BrokerNode 가 앞의 자격증명을 덮어써, 하류가 **다른 계좌의 앱키**로 로그인하게 된다.
+    """
+    return f"broker_credentials:{product or 'unknown'}"
+
+
+def _resolve_broker_credentials(
+    broker_connection: Optional[Dict[str, Any]],
+    context: "ExecutionContext",
+) -> tuple:
+    """브로커 자격증명 조회 → ``(appkey, appsecret, paper_trading)``.
+
+    정본은 **시크릿 저장소**다 — 자격증명은 노드 출력에 실리지 않는다(평문 유출 방지).
+    조회 순서:
+      1. product 별 슬롯 (정확 — 다중 브로커 워크플로우에서도 안 섞인다)
+      2. 레거시 단일 슬롯 (product 를 모를 때)
+      3. ``connection`` 안의 평문 키 — **레거시 폴백**. 옛 워크플로우/외부 호출자와
+         deep_validate 픽스처가 아직 이 모양을 쓴다.
+    """
+    conn = broker_connection or {}
+    product = conn.get("product")
+
+    cred: Dict[str, Any] = {}
+    if product:
+        cred = context.get_credential(broker_credential_key(product)) or {}
+    if not cred:
+        cred = context.get_credential() or {}
+
+    appkey = cred.get("appkey") or conn.get("appkey", "")
+    appsecret = cred.get("appsecret") or conn.get("appsecret", "")
+    paper_trading = cred.get("paper_trading", conn.get("paper_trading", False))
+    return appkey, appsecret, paper_trading
+
+
 def ensure_ls_login(
     appkey: str,
     appsecret: str,
@@ -3156,11 +3193,17 @@ class BrokerNodeExecutor(NodeExecutorBase):
             paper_trading = config.get("paper_trading", paper_trading)
         
         if appkey and appsecret:
-            context.set_secret("credential_id", {
+            cred_payload = {
                 "appkey": appkey,
                 "appsecret": appsecret,
                 "paper_trading": paper_trading,
-            })
+            }
+            # 자격증명은 **시크릿 저장소에만** 둔다 — 노드 출력(`connection`)에 실으면
+            # 리스너(SSE) · get_state · 체크포인트로 평문이 새어 나간다.
+            # product 별 슬롯: 한 워크플로우에 브로커가 둘 이상이면(해외+국내) 단일 슬롯은 덮어써진다.
+            context.set_secret(broker_credential_key(product), cred_payload)
+            # 레거시 단일 슬롯 — 아직 product 별 조회로 이관되지 않은 소비처를 위해 유지한다.
+            context.set_secret("credential_id", cred_payload)
             context.log("info", f"Broker credentials stored (paper_trading={paper_trading})", node_id)
         else:
             context.log("warning", "No credentials found - some features may not work", node_id)
@@ -3255,14 +3298,15 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 context=context,
             )
         
+        # 🔐 `connection` 은 노드 출력이라 리스너(SSE) · get_state · 체크포인트로 외부에 나간다.
+        # 자격증명은 싣지 않는다 — 하류는 `product` 로 시크릿 저장소에서 꺼낸다
+        # (`_resolve_broker_credentials`). 여기 있던 평문 appkey/appsecret 이 실제로 새고 있었다.
         return {
             "connected": True,
             "connection": {
                 "provider": provider,
                 "product": product,
                 "paper_trading": paper_trading,
-                "appkey": appkey,
-                "appsecret": appsecret,
             }
         }
 
@@ -6122,9 +6166,8 @@ class RealMarketDataNodeExecutor(NodeExecutorBase):
         import asyncio
         from datetime import datetime
         
-        appkey = broker_connection.get("appkey", "")
-        appsecret = broker_connection.get("appsecret", "")
-        paper_trading = broker_connection.get("paper_trading", False)
+        # 🔐 자격증명은 시크릿 저장소에서 — `connection` 출력에는 더 이상 싣지 않는다.
+        appkey, appsecret, paper_trading = _resolve_broker_credentials(broker_connection, context)
         
         # 현재 이벤트 루프 캡처 (콜백에서 사용)
         loop = asyncio.get_running_loop()
@@ -6290,9 +6333,8 @@ class RealMarketDataNodeExecutor(NodeExecutorBase):
         import asyncio
         from datetime import datetime
         
-        appkey = broker_connection.get("appkey", "")
-        appsecret = broker_connection.get("appsecret", "")
-        paper_trading = broker_connection.get("paper_trading", False)
+        # 🔐 자격증명은 시크릿 저장소에서 — `connection` 출력에는 더 이상 싣지 않는다.
+        appkey, appsecret, paper_trading = _resolve_broker_credentials(broker_connection, context)
         
         # 현재 이벤트 루프 캡처 (콜백에서 사용)
         loop = asyncio.get_running_loop()
@@ -6465,8 +6507,8 @@ class RealMarketDataNodeExecutor(NodeExecutorBase):
         import asyncio
         from datetime import datetime
 
-        appkey = broker_connection.get("appkey", "")
-        appsecret = broker_connection.get("appsecret", "")
+        # 🔐 자격증명은 시크릿 저장소에서 — `connection` 출력에는 더 이상 싣지 않는다.
+        appkey, appsecret, _paper = _resolve_broker_credentials(broker_connection, context)
 
         loop = asyncio.get_running_loop()
 
@@ -7539,9 +7581,9 @@ class MarketStatusNodeExecutor(NodeExecutorBase):
             )
 
         # 2. LS 로그인 (broker 와 동일 instance 재사용)
-        appkey = broker_connection.get("appkey", "")
-        appsecret = broker_connection.get("appsecret", "")
-        paper_trading = bool(broker_connection.get("paper_trading", False))
+        # 🔐 자격증명은 시크릿 저장소에서 — `connection` 출력에는 더 이상 싣지 않는다.
+        appkey, appsecret, paper_trading = _resolve_broker_credentials(broker_connection, context)
+        paper_trading = bool(paper_trading)
         broker_product = broker_connection.get("product", "overseas_stock")
 
         ls, success, error = ensure_ls_login(
@@ -19312,7 +19354,9 @@ class WorkflowJob:
             entry: Dict[str, Any] = {
                 "state": cached_state.value,
                 "node_type": node.node_type,
-                "outputs": self.context.get_all_outputs(node_id),
+                # 🔐 외부 노출면 — BrokerNode 는 하류 전송용으로 connection.appkey/appsecret 을
+                # 출력에 싣는다. 리스너 경로는 이미 가리는데 여기만 raw 로 새고 있었다.
+                "outputs": self.context.get_all_outputs_sanitized(node_id),
             }
             if node_id in self._node_errors:
                 entry["error"] = self._node_errors[node_id]

--- a/src/programgarden/programgarden/resolver.py
+++ b/src/programgarden/programgarden/resolver.py
@@ -326,6 +326,9 @@ class WorkflowResolver:
         # 10.7 AIAgentNode ai_model 엣지 필수 검증 (LLM 없이는 애초에 동작 불가)
         self._validate_ai_agent_nodes(workflow, result)
 
+        # 10.8 Display 노드 columns 키가 상류 출력 스키마에 실재하는지 (없는 키는 표에 '-' 만 찍힌다)
+        self._validate_display_columns(workflow, registry, result)
+
         # 11. Static recommendations (topology analysis)
         for rec in run_static_recommendation_rules(
             workflow,
@@ -1278,6 +1281,100 @@ class WorkflowResolver:
                     ),
                 )
             )
+
+    def _validate_display_columns(self, workflow, registry, result: ValidationResult) -> None:
+        """Display 노드의 `columns` 키가 상류 출력 스키마에 실재하는지 검증한다.
+
+        `columns` 는 `{{ }}` 바인딩이 아니라 **평범한 문자열 목록**이라 표현식 검증
+        (`_validate_expression_references`)의 사정권 밖이었다. 그래서 상류가 내보내지 않는
+        이름을 적어도 아무도 막지 않았고, 표는 그 칸에 조용히 `-` 만 찍은 채 워크플로우는
+        `completed / errors=0` 으로 보고했다.
+        (실측 2026-07-13: 챗봇이 `current_price`/`change_percent` 로 저작 → 시세 노드는
+        `price`/`change_pct` 를 내보냄 → 사용자가 요청한 '현재가'가 표에서 사라졌다.)
+
+        🔴 **오탐 0 원칙 — 검증된 포트에만 건다.**
+        `fields` 를 선언했다는 것만으로는 부족하다. 라이브러리 곳곳의 선언이 런타임보다
+        **불완전**하다(예: `ScreenerNode.symbols` 런타임은 price/market_cap/volume/sector 를
+        담는데 `SYMBOL_LIST_FIELDS` 는 exchange/symbol 둘만 선언). 그런 포트에 이 가드를 걸면
+        **정상 워크플로우를 대량 오탐**한다(동봉 예제 7건이 실제로 걸렸다).
+
+        그래서 `tests/test_output_schema_contract.py` 로 **선언 == 런타임** 이 증명된 포트만
+        여기 등록한다. 다른 포트의 선언을 바로잡을 때마다 계약 검사에 추가하고 이 목록을 넓힌다.
+        """
+        import re as _re
+
+        # (node_type, port) — 계약 검사로 선언 == 런타임 이 증명된 포트만.
+        VERIFIED_PORTS = {
+            ("OverseasStockMarketDataNode", "value"),
+            ("OverseasStockMarketDataNode", "values"),
+            ("OverseasFuturesMarketDataNode", "value"),
+            ("OverseasFuturesMarketDataNode", "values"),
+            ("KoreaStockMarketDataNode", "value"),
+            ("KoreaStockMarketDataNode", "values"),
+        }
+
+        DISPLAY_TYPES = {"TableDisplayNode", "ChartDisplayNode"}
+        nodes_by_id = {
+            n.get("id"): n for n in workflow.nodes
+            if isinstance(n, dict) and n.get("id")
+        }
+
+        for node in workflow.nodes:
+            if not isinstance(node, dict) or node.get("type") not in DISPLAY_TYPES:
+                continue
+            columns = node.get("columns")
+            data_expr = node.get("data")
+            if not columns or not isinstance(columns, list) or not isinstance(data_expr, str):
+                continue
+
+            m = _re.search(r"nodes\.([A-Za-z0-9_]+)\.([A-Za-z0-9_]+)", data_expr)
+            if not m:
+                continue
+            src_id, port = m.group(1), m.group(2)
+            src_node = nodes_by_id.get(src_id)
+            if not src_node:
+                continue  # 노드 부재는 _validate_expression_references 가 잡는다
+            if (src_node.get("type"), port) not in VERIFIED_PORTS:
+                continue  # 선언이 런타임과 일치한다고 증명되지 않은 포트 → 검사하지 않는다
+
+            schema = registry.get_schema(src_node.get("type"))
+            if not schema:
+                continue
+            declared: Set[str] = set()
+            for out in (getattr(schema, "outputs", None) or []):
+                nm = out.get("name") if isinstance(out, dict) else getattr(out, "name", None)
+                if nm != port:
+                    continue
+                fields = out.get("fields") if isinstance(out, dict) else getattr(out, "fields", None)
+                for f in (fields or []):
+                    fn = f.get("name") if isinstance(f, dict) else getattr(f, "name", None)
+                    if fn:
+                        declared.add(fn)
+                break
+            if not declared:
+                continue  # 출력 모양이 열려 있음 → 검사 근거 없음 (오탐 방지)
+
+            for col in columns:
+                key = col.get("key") if isinstance(col, dict) else col
+                if not isinstance(key, str) or not key or key in declared:
+                    continue
+                result.add(
+                    build_error(
+                        ErrorCode.INVALID_EXPRESSION_REF,
+                        f"{node.get('type')} '{node.get('id')}' lists column '{key}', but node "
+                        f"'{src_id}' does not output a field with that name on port '{port}'. "
+                        f"The column would render as '-' while the workflow still reports success.",
+                        location=ErrorLocation(
+                            node_id=node.get("id"),
+                            node_type=node.get("type"),
+                            field_path="columns",
+                        ),
+                        suggestion=(
+                            f"Use one of the fields '{src_id}.{port}' actually outputs: "
+                            f"{', '.join(sorted(declared))}."
+                        ),
+                    )
+                )
 
     def _validate_credential_references(
         self,

--- a/src/programgarden/programgarden/resolver.py
+++ b/src/programgarden/programgarden/resolver.py
@@ -1293,10 +1293,10 @@ class WorkflowResolver:
         `price`/`change_pct` 를 내보냄 → 사용자가 요청한 '현재가'가 표에서 사라졌다.)
 
         🔴 **오탐 0 원칙 — 검증된 포트에만 건다.**
-        `fields` 를 선언했다는 것만으로는 부족하다. 라이브러리 곳곳의 선언이 런타임보다
-        **불완전**하다(예: `ScreenerNode.symbols` 런타임은 price/market_cap/volume/sector 를
-        담는데 `SYMBOL_LIST_FIELDS` 는 exchange/symbol 둘만 선언). 그런 포트에 이 가드를 걸면
-        **정상 워크플로우를 대량 오탐**한다(동봉 예제 7건이 실제로 걸렸다).
+        `fields` 를 선언했다는 것만으로는 부족하다. 예전엔 라이브러리 곳곳의 선언이 런타임보다
+        **불완전**했다(예: `ScreenerNode.symbols` 런타임은 price/market_cap/volume/sector 를
+        담는데 공유 상수 `SYMBOL_LIST_FIELDS` 는 exchange/symbol 둘만 선언 — 2026-07-14 노드별
+        상수로 쪼개서 해소). 증명 안 된 포트에 이 가드를 걸면 **정상 워크플로우를 대량 오탐**한다.
 
         그래서 `tests/test_output_schema_contract.py` 로 **선언 == 런타임** 이 증명된 포트만
         여기 등록한다. 다른 포트의 선언을 바로잡을 때마다 계약 검사에 추가하고 이 목록을 넓힌다.
@@ -1304,6 +1304,9 @@ class WorkflowResolver:
         import re as _re
 
         # (node_type, port) — 계약 검사로 선언 == 런타임 이 증명된 포트만.
+        # 증명 위치: `tests/test_output_schema_contract.py::CASES`
+        # 🔴 실시간 시세의 `ohlcv_data` / `data` 는 **일부러 뺐다** — 값이 `{종목: [봉]}` dict 라
+        #    표의 열(column)이 봉 필드인지 종목코드인지 정해져 있지 않다. 근거 없이 걸면 오탐이다.
         VERIFIED_PORTS = {
             ("OverseasStockMarketDataNode", "value"),
             ("OverseasStockMarketDataNode", "values"),
@@ -1311,6 +1314,27 @@ class WorkflowResolver:
             ("OverseasFuturesMarketDataNode", "values"),
             ("KoreaStockMarketDataNode", "value"),
             ("KoreaStockMarketDataNode", "values"),
+            # 종목 리스트
+            ("WatchlistNode", "symbols"),
+            ("MarketUniverseNode", "symbols"),
+            ("ScreenerNode", "symbols"),
+            ("OverseasStockSymbolQueryNode", "symbols"),
+            ("KoreaStockSymbolQueryNode", "symbols"),
+            ("OverseasFuturesSymbolQueryNode", "symbols"),
+            # 계좌 (REST)
+            ("OverseasStockAccountNode", "positions"),
+            ("KoreaStockAccountNode", "positions"),
+            ("OverseasFuturesAccountNode", "positions"),
+            ("OverseasStockAccountNode", "held_symbols"),
+            ("KoreaStockAccountNode", "held_symbols"),
+            ("OverseasFuturesAccountNode", "held_symbols"),
+            # 계좌 (실시간)
+            ("OverseasStockRealAccountNode", "positions"),
+            ("KoreaStockRealAccountNode", "positions"),
+            ("OverseasFuturesRealAccountNode", "positions"),
+            ("OverseasStockRealAccountNode", "held_symbols"),
+            ("KoreaStockRealAccountNode", "held_symbols"),
+            ("OverseasFuturesRealAccountNode", "held_symbols"),
         }
 
         DISPLAY_TYPES = {"TableDisplayNode", "ChartDisplayNode"}

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.27.0"
+version = "1.28.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
@@ -29,7 +29,7 @@ lxml = "^6.0.2"
 pytickersymbols = {version = ">=1.17.5", python = ">=3.12,<4.0"}
 aiosqlite = "^0.20.0"
 litellm = ">=1.40.0"
-programgarden-core = "^1.18.0"
+programgarden-core = "^1.20.0"
 programgarden-finance = "^1.6.14"
 programgarden-community = "^1.13.11"
 

--- a/src/programgarden/tests/test_market_change_sign.py
+++ b/src/programgarden/tests/test_market_change_sign.py
@@ -1,0 +1,99 @@
+"""전일대비(change) 부호 정규화 — LS TR 별 부호 규칙 차이를 흡수한다.
+
+실측 근거 (2026-07-13, 실 LS 키로 직접 TR 호출):
+    g3101 (해외주식) NVDA   sign='5'  diff='2.4100'   rate=-1.14   → diff 는 절댓값
+    t1102 (국내주식) 005930 sign='5'  change=30500    diff=-10.70  → change 는 절댓값
+    o3105 (해외선물) HBIN26 YdiffSign='5' YdiffP=-105.0 Diff=-0.75 → YdiffP 는 이미 부호 포함
+
+핵심 불변식: **change 의 부호와 change_pct(등락률)의 부호는 항상 같다.**
+(등락률은 세 TR 모두 부호를 갖고 오므로, change 가 틀어지면 둘의 부호가 어긋난다.)
+"""
+import pytest
+
+from programgarden.executor import _ls_signed_change
+
+
+class TestAbsoluteMagnitudeGetsSign:
+    """g3101 / t1102 — 크기가 절댓값이라 sign 을 적용해야 한다."""
+
+    def test_g3101_down_makes_change_negative(self):
+        # NVDA 실측: sign='5'(하락), diff='2.4100' (절댓값)
+        assert _ls_signed_change("2.4100", "5") == -2.41
+
+    def test_g3101_up_keeps_change_positive(self):
+        # AAPL 실측: sign='2'(상승), diff='5.1400'
+        assert _ls_signed_change("5.1400", "2") == 5.14
+
+    def test_t1102_down_makes_change_negative(self):
+        # 삼성전자 실측: sign='5', change=30500 (절댓값)
+        assert _ls_signed_change(30500, "5") == -30500.0
+
+    @pytest.mark.parametrize("sign", ["4", "5", "-"])
+    def test_all_down_codes_force_negative(self, sign):
+        assert _ls_signed_change(10, sign) == -10.0
+
+    @pytest.mark.parametrize("sign", ["1", "2", "+"])
+    def test_all_up_codes_force_positive(self, sign):
+        assert _ls_signed_change(10, sign) == 10.0
+
+
+class TestAlreadySignedMagnitudeIsPreserved:
+    """o3105 — 이미 부호가 실려 오므로 뒤집으면 안 된다 (멱등)."""
+
+    def test_o3105_signed_negative_stays_negative(self):
+        # HBIN26 실측: YdiffSign='5', YdiffP=-105.0 (이미 음수)
+        assert _ls_signed_change(-105.0, "5") == -105.0
+
+    def test_o3105_signed_positive_stays_positive(self):
+        assert _ls_signed_change(0.0052, "2") == 0.0052
+
+    def test_idempotent(self):
+        once = _ls_signed_change(-105.0, "5")
+        twice = _ls_signed_change(once, "5")
+        assert once == twice == -105.0
+
+
+class TestUnknownSignDoesNotCorrupt:
+    """방향 코드가 없거나 알 수 없으면 원값의 부호를 신뢰한다 (멋대로 양수화 금지)."""
+
+    @pytest.mark.parametrize("sign", ["", None, "9", "  "])
+    def test_unknown_sign_passes_value_through(self, sign):
+        assert _ls_signed_change(-105.0, sign) == -105.0
+        assert _ls_signed_change(105.0, sign) == 105.0
+
+    def test_flat_sign_zero(self):
+        # 3 = 보합 → 값이 0 이라 통과시켜도 무해
+        assert _ls_signed_change(0, "3") == 0.0
+
+
+class TestMalformedInput:
+    def test_none_magnitude(self):
+        assert _ls_signed_change(None, "5") == 0.0
+
+    def test_empty_string_magnitude(self):
+        assert _ls_signed_change("", "5") == 0.0
+
+    def test_garbage_magnitude(self):
+        assert _ls_signed_change("N/A", "5") == 0.0
+
+
+class TestSignInvariant:
+    """이 결함의 본질 — change 와 change_pct 의 부호는 항상 같아야 한다."""
+
+    @pytest.mark.parametrize(
+        "magnitude,sign,rate",
+        [
+            ("2.4100", "5", -1.14),   # g3101 NVDA (절댓값 + 하락)
+            ("5.1400", "2", 1.63),    # g3101 AAPL (절댓값 + 상승)
+            (30500, "5", -10.70),     # t1102 삼성전자 (절댓값 + 하락)
+            (-105.0, "5", -0.75),     # o3105 HBIN26 (이미 부호 + 하락)
+            (0.0052, "2", 0.08),      # o3105 CUSQ26 (이미 부호 + 상승)
+        ],
+    )
+    def test_change_and_pct_agree_in_sign(self, magnitude, sign, rate):
+        change = _ls_signed_change(magnitude, sign)
+        assert change != 0
+        assert (change < 0) == (rate < 0), (
+            f"change={change} 와 등락률={rate} 의 부호가 어긋났다 "
+            f"(magnitude={magnitude!r}, sign={sign!r})"
+        )

--- a/src/programgarden/tests/test_output_schema_contract.py
+++ b/src/programgarden/tests/test_output_schema_contract.py
@@ -19,11 +19,20 @@ from typing import Dict, Set
 
 import pytest
 
-from programgarden.executor import MarketDataNodeExecutor
+from programgarden.executor import (
+    AccountNodeExecutor,
+    MarketDataNodeExecutor,
+    MarketUniverseNodeExecutor,
+    RealAccountNodeExecutor,
+    RealMarketDataNodeExecutor,
+    ScreenerNodeExecutor,
+    SymbolQueryNodeExecutor,
+    WatchlistNodeExecutor,
+)
 
 
-def _runtime_keys(cls, method_name: str) -> Set[str]:
-    """executor 메서드 안의 ``values.append({...})`` dict 리터럴 키를 뽑는다."""
+def _runtime_keys(cls, method_name: str, var: str = "values") -> Set[str]:
+    """executor 메서드 안의 ``<var>.append({...})`` dict 리터럴 키를 뽑는다."""
     src = inspect.getsource(getattr(cls, method_name))
     tree = ast.parse(inspect.cleandoc(src) if not src.startswith("    ") else _dedent(src))
 
@@ -34,7 +43,7 @@ def _runtime_keys(cls, method_name: str) -> Set[str]:
         func = node.func
         if not (isinstance(func, ast.Attribute) and func.attr == "append"):
             continue
-        if not (isinstance(func.value, ast.Name) and func.value.id == "values"):
+        if not (isinstance(func.value, ast.Name) and func.value.id == var):
             continue
         for arg in node.args:
             if isinstance(arg, ast.Dict):
@@ -42,9 +51,81 @@ def _runtime_keys(cls, method_name: str) -> Set[str]:
     return keys
 
 
+def _runtime_keys_of_assigned_dict(cls, method_name: str, var: str) -> Set[str]:
+    """``<var>[...] = {...}`` 형태로 만들어지는 dict 리터럴 키를 뽑는다.
+
+    실시간 시세 노드의 봉(bar)이 이 모양이다: ``ohlcv_bars[symbol] = {...}``.
+    """
+    src = inspect.getsource(getattr(cls, method_name))
+    tree = ast.parse(_dedent(src))
+
+    keys: Set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign) or not isinstance(node.value, ast.Dict):
+            continue
+        for tgt in node.targets:
+            if (
+                isinstance(tgt, ast.Subscript)
+                and isinstance(tgt.value, ast.Name)
+                and tgt.value.id == var
+            ):
+                keys |= {
+                    k.value for k in node.value.keys if isinstance(k, ast.Constant)
+                }
+    return keys
+
+
 def _dedent(src: str) -> str:
     import textwrap
     return textwrap.dedent(src)
+
+
+def _listcomp_dict_keys(cls, method_name: str, var: str) -> Set[str]:
+    """``<var> = [{...} for x in ...]`` 또는 ``return {"<var>": [{...} for ...]}`` 의 키를 뽑는다.
+
+    held_symbols 는 append 가 아니라 리스트 컴프리헨션으로 만들어진다.
+    """
+    src = inspect.getsource(getattr(cls, method_name))
+    tree = ast.parse(_dedent(src))
+
+    def _elt_keys(node) -> Set[str]:
+        if isinstance(node, ast.ListComp) and isinstance(node.elt, ast.Dict):
+            return {k.value for k in node.elt.keys if isinstance(k, ast.Constant)}
+        return set()
+
+    keys: Set[str] = set()
+    for node in ast.walk(tree):
+        # <var> = [{...} for ...]
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name) and tgt.id == var:
+                    keys |= _elt_keys(node.value)
+        # return {"<var>": [{...} for ...], ...}
+        if isinstance(node, ast.Return) and isinstance(node.value, ast.Dict):
+            for k, v in zip(node.value.keys, node.value.values):
+                if isinstance(k, ast.Constant) and k.value == var:
+                    keys |= _elt_keys(v)
+    return keys
+
+
+def _port_runtime_keys(producers) -> Dict[str, Set[str]]:
+    """포트 하나를 만드는 **모든 갈래**의 런타임 키를 갈래별로 돌려준다.
+
+    같은 포트인데 갈래(REST 스냅샷 / WebSocket tracker / LS / yfinance)마다 키가 다르면
+    출력 모양이 시점마다 바뀐다 — 선언이 어느 쪽을 적든 반대 갈래에서 거짓말이 된다.
+    """
+    out: Dict[str, Set[str]] = {}
+    for cls, method, var, kind in producers:
+        if kind == "append":
+            keys = _runtime_keys(cls, method, var)
+        elif kind == "listcomp":
+            keys = _listcomp_dict_keys(cls, method, var)
+        elif kind == "subscript":
+            keys = _runtime_keys_of_assigned_dict(cls, method, var)
+        else:  # pragma: no cover
+            raise AssertionError(f"unknown producer kind: {kind}")
+        out[f"{cls.__name__}.{method}"] = keys
+    return out
 
 
 def _declared_fields(node_type: str, port: str) -> Set[str]:
@@ -64,18 +145,101 @@ def _declared_fields(node_type: str, port: str) -> Set[str]:
     pytest.fail(f"{node_type} 에 '{port}' 출력 포트 선언이 없다")
 
 
-# (노드 타입, executor 메서드, 검사할 출력 포트)
+# (노드 타입, 출력 포트, [런타임을 만드는 갈래들])
+#   갈래 = (executor 클래스, 메서드, 누적 변수, 추출 방식)
+# 한 포트를 여러 갈래가 만들면 **전부** 적는다 — 갈래끼리 키가 어긋나는 것도 결함이다.
+M = MarketDataNodeExecutor
 CASES = [
-    ("OverseasStockMarketDataNode", "_fetch_overseas_stock", "value"),
-    ("OverseasFuturesMarketDataNode", "_fetch_overseas_futures", "value"),
-    ("KoreaStockMarketDataNode", "_fetch_korea_stock", "value"),
+    ("OverseasStockMarketDataNode", "value", [(M, "_fetch_overseas_stock", "values", "append")]),
+    ("OverseasFuturesMarketDataNode", "value", [(M, "_fetch_overseas_futures", "values", "append")]),
+    ("KoreaStockMarketDataNode", "value", [(M, "_fetch_korea_stock", "values", "append")]),
+
+    # ── 종목 리스트 ──
+    ("WatchlistNode", "symbols", [(WatchlistNodeExecutor, "execute", "processed_symbols", "append")]),
+    ("MarketUniverseNode", "symbols", [(MarketUniverseNodeExecutor, "_fetch_index_constituents", "symbols", "append")]),
+    ("ScreenerNode", "symbols", [
+        (ScreenerNodeExecutor, "_filter_via_ls_overseas_stock", "prefilter", "append"),  # LS 분기
+        (ScreenerNodeExecutor, "_filter_symbols", "filtered", "append"),                 # yfinance 분기
+    ]),
+    ("OverseasStockSymbolQueryNode", "symbols", [(SymbolQueryNodeExecutor, "_execute_stock_master", "all_symbols", "append")]),
+    ("KoreaStockSymbolQueryNode", "symbols", [(SymbolQueryNodeExecutor, "_execute_korea_stock_master", "all_symbols", "append")]),
+    ("OverseasFuturesSymbolQueryNode", "symbols", [(SymbolQueryNodeExecutor, "_execute_futures_master", "all_symbols", "append")]),
+
+    # ── 계좌 (REST) ──
+    ("OverseasStockAccountNode", "positions", [(AccountNodeExecutor, "_ls_overseas_stock", "positions", "append")]),
+    ("KoreaStockAccountNode", "positions", [(AccountNodeExecutor, "_ls_korea_stock", "positions", "append")]),
+    ("OverseasFuturesAccountNode", "positions", [(AccountNodeExecutor, "_ls_overseas_futureoption", "positions", "append")]),
+    ("OverseasStockAccountNode", "held_symbols", [(AccountNodeExecutor, "_ls_overseas_stock", "held_symbols", "listcomp")]),
+    ("KoreaStockAccountNode", "held_symbols", [(AccountNodeExecutor, "_ls_korea_stock", "held_symbols", "listcomp")]),
+    ("OverseasFuturesAccountNode", "held_symbols", [(AccountNodeExecutor, "_ls_overseas_futureoption", "held_symbols", "append")]),
+
+    # ── 계좌 (실시간) — REST 스냅샷 갈래와 WebSocket tracker 갈래가 같은 포트를 만든다 ──
+    ("OverseasStockRealAccountNode", "positions", [
+        (RealAccountNodeExecutor, "_get_overseas_stock_tracker_data", "positions", "append"),
+        (RealAccountNodeExecutor, "_ls_stock_with_tracker", "serialized_positions", "append"),
+    ]),
+    ("KoreaStockRealAccountNode", "positions", [
+        (RealAccountNodeExecutor, "_get_korea_stock_tracker_data", "positions", "append"),
+        (RealAccountNodeExecutor, "_ls_korea_stock_with_tracker", "serialized_positions", "append"),
+    ]),
+    ("OverseasFuturesRealAccountNode", "positions", [
+        (RealAccountNodeExecutor, "_get_overseas_futures_tracker_data", "positions", "append"),
+        (RealAccountNodeExecutor, "_ls_futureoption_with_tracker", "serialized_positions", "append"),
+    ]),
+    ("OverseasStockRealAccountNode", "held_symbols", [(RealAccountNodeExecutor, "_get_overseas_stock_tracker_data", "held_symbols", "listcomp")]),
+    ("KoreaStockRealAccountNode", "held_symbols", [(RealAccountNodeExecutor, "_get_korea_stock_tracker_data", "held_symbols", "listcomp")]),
+    ("OverseasFuturesRealAccountNode", "held_symbols", [(RealAccountNodeExecutor, "_get_overseas_futures_tracker_data", "held_symbols", "listcomp")]),
+
+    # ── 실시간 시세: ohlcv_data / data 는 **같은 객체**(별칭) — 봉(bar) 한 줄의 키를 검사한다 ──
+    ("OverseasStockRealMarketDataNode", "ohlcv_data", [(RealMarketDataNodeExecutor, "_execute_stock", "ohlcv_bars", "subscript")]),
+    ("OverseasStockRealMarketDataNode", "data", [(RealMarketDataNodeExecutor, "_execute_stock", "ohlcv_bars", "subscript")]),
+    ("OverseasFuturesRealMarketDataNode", "ohlcv_data", [(RealMarketDataNodeExecutor, "_execute_futures", "ohlcv_bars", "subscript")]),
+    ("OverseasFuturesRealMarketDataNode", "data", [(RealMarketDataNodeExecutor, "_execute_futures", "ohlcv_bars", "subscript")]),
+    ("KoreaStockRealMarketDataNode", "ohlcv_data", [(RealMarketDataNodeExecutor, "_execute_korea_stock", "ohlcv_bars", "subscript")]),
+    ("KoreaStockRealMarketDataNode", "data", [(RealMarketDataNodeExecutor, "_execute_korea_stock", "ohlcv_bars", "subscript")]),
 ]
 
 
-@pytest.mark.parametrize("node_type,method,port", CASES)
-def test_declared_fields_match_runtime(node_type, method, port):
-    runtime = _runtime_keys(MarketDataNodeExecutor, method)
-    assert runtime, f"{method} 에서 런타임 키를 못 뽑았다 (테스트가 낡았다)"
+@pytest.mark.parametrize(
+    "node_type,port,producers",
+    CASES,
+    ids=[f"{n}.{p}" for n, p, _ in CASES],
+)
+def test_producers_of_one_port_agree(node_type, port, producers):
+    """한 포트를 만드는 갈래가 여럿이면 **키 집합이 같아야** 한다.
+
+    실측(2026-07-14): 실시간 계좌의 tracker 갈래는 `qty`/`market_code` 를, REST 스냅샷 갈래는
+    `exchange`/`quantity`/`price` 를 내보냈다. 같은 포트인데 **시점마다 모양이 달랐다** —
+    주문 노드는 `exchange`/`quantity` 를 읽으므로 실시간 틱이 오는 순간 조용히 깨진다.
+    """
+    by_branch = _port_runtime_keys(producers)
+    if len(by_branch) < 2:
+        pytest.skip("갈래가 하나뿐 — 대조할 상대가 없다")
+
+    branches = list(by_branch.items())
+    base_name, base_keys = branches[0]
+    for other_name, other_keys in branches[1:]:
+        assert base_keys == other_keys, (
+            f"{node_type}.{port}: 갈래마다 키가 다르다 — "
+            f"{base_name} 에만 {sorted(base_keys - other_keys)}, "
+            f"{other_name} 에만 {sorted(other_keys - base_keys)}"
+        )
+
+
+@pytest.mark.parametrize(
+    "node_type,port,producers",
+    CASES,
+    ids=[f"{n}.{p}" for n, p, _ in CASES],
+)
+def test_declared_fields_match_runtime(node_type, port, producers):
+    by_branch = _port_runtime_keys(producers)
+    runtime: Set[str] = set()
+    for keys in by_branch.values():
+        runtime |= keys
+    assert runtime, (
+        f"{node_type}.{port}: 런타임 키를 못 뽑았다 — executor 가 바뀌었고 "
+        f"이 테스트가 낡았다 (producers={[(c.__name__, m) for c, m, _, _ in producers]})"
+    )
 
     declared = _declared_fields(node_type, port)
 
@@ -92,15 +256,97 @@ def test_declared_fields_match_runtime(node_type, method, port):
     )
 
 
+MARKET_DATA_NODES = [
+    "OverseasStockMarketDataNode",
+    "OverseasFuturesMarketDataNode",
+    "KoreaStockMarketDataNode",
+]
+
+
 def test_price_and_change_names_are_consistent_across_markets():
     """같은 개념을 시장마다 다른 이름으로 부르면 챗봇이 반드시 헷갈린다."""
-    names = {}
-    for node_type, method, port in CASES:
-        declared = _declared_fields(node_type, port)
-        names[node_type] = declared
+    names = {nt: _declared_fields(nt, "value") for nt in MARKET_DATA_NODES}
 
     for node_type, declared in names.items():
         assert "price" in declared, f"{node_type}: 현재가는 'price' 로 통일한다 (실측 런타임 이름)"
         assert "change_pct" in declared, f"{node_type}: 등락률은 'change_pct' 로 통일한다"
         assert "current_price" not in declared, f"{node_type}: 'current_price' 는 런타임에 없다"
         assert "change_percent" not in declared, f"{node_type}: 'change_percent' 는 런타임에 없다"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 선언한 포트를 런타임이 **실제로 반환하는가**
+#
+# 위의 계약 검사는 dict 의 *모양*만 본다. 그런데 2026-07-14 실측에서 드러난 최대 결함은
+# 모양이 아니라 **반환 자체가 없는 것**이었다:
+#   계좌 노드 6종이 전부 `held_symbols` 출력 포트를 선언했는데, executor 는 그 값을 계산만
+#   하고 **반환 dict 에 싣지 않았다**(죽은 지역변수). 그래서 바인딩하면 정적 검증은 통과하고
+#   런타임엔 늘 비어 있었다 — "내가 보유한 종목을 실시간 감시" 워크플로우가 조용히 아무것도
+#   구독하지 않았다.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def _returned_keys(cls, method_name: str) -> Set[str]:
+    """메서드가 반환하는 dict 의 키를 모은다.
+
+    ``return {...}`` 직접 리터럴과 ``result = {...}`` → ``return result`` 두 형태를 모두 읽는다.
+    """
+    src = inspect.getsource(getattr(cls, method_name))
+    tree = ast.parse(_dedent(src))
+
+    # 이름 → dict 리터럴 키 (result: Dict[str, Any] = {...} 형태 포함)
+    assigned: Dict[str, Set[str]] = {}
+    for node in ast.walk(tree):
+        target = value = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            target, value = node.target, node.value
+        if isinstance(target, ast.Name) and isinstance(value, ast.Dict):
+            assigned.setdefault(target.id, set()).update(
+                k.value for k in value.keys if isinstance(k, ast.Constant)
+            )
+
+    keys: Set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Return):
+            continue
+        if isinstance(node.value, ast.Dict):
+            keys |= {k.value for k in node.value.keys if isinstance(k, ast.Constant)}
+        elif isinstance(node.value, ast.Name):
+            keys |= assigned.get(node.value.id, set())
+    return keys
+
+
+# (executor, 노드 출력 dict 을 반환하는 메서드, 반드시 실려야 하는 키)
+RETURN_CASES = [
+    (AccountNodeExecutor, "_ls_overseas_stock", {"held_symbols", "positions", "balance"}),
+    (AccountNodeExecutor, "_ls_korea_stock", {"held_symbols", "positions", "balance"}),
+    (AccountNodeExecutor, "_ls_overseas_futureoption", {"held_symbols", "positions", "balance"}),
+    (AccountNodeExecutor, "_empty_result", {"held_symbols", "positions", "balance"}),
+    (RealAccountNodeExecutor, "_get_overseas_stock_tracker_data", {"held_symbols", "positions", "balance", "open_orders"}),
+    (RealAccountNodeExecutor, "_get_overseas_futures_tracker_data", {"held_symbols", "positions", "balance", "open_orders"}),
+    (RealAccountNodeExecutor, "_get_korea_stock_tracker_data", {"held_symbols", "positions", "balance", "open_orders"}),
+    (RealAccountNodeExecutor, "_empty_result", {"held_symbols", "positions", "balance"}),
+    (ScreenerNodeExecutor, "execute", {"symbols", "count"}),
+    (SymbolQueryNodeExecutor, "_execute_stock_master", {"symbols", "count"}),
+    (SymbolQueryNodeExecutor, "_execute_korea_stock_master", {"symbols", "count"}),
+    (SymbolQueryNodeExecutor, "_execute_futures_master", {"symbols", "count"}),
+    (RealMarketDataNodeExecutor, "_execute_stock", {"symbols", "ohlcv_data", "data"}),
+    (RealMarketDataNodeExecutor, "_execute_futures", {"symbols", "ohlcv_data", "data"}),
+    (RealMarketDataNodeExecutor, "_execute_korea_stock", {"symbols", "ohlcv_data", "data"}),
+]
+
+
+@pytest.mark.parametrize(
+    "cls,method,required",
+    RETURN_CASES,
+    ids=[f"{c.__name__}.{m}" for c, m, _ in RETURN_CASES],
+)
+def test_declared_ports_are_actually_returned(cls, method, required):
+    returned = _returned_keys(cls, method)
+    missing = required - returned
+    assert not missing, (
+        f"{cls.__name__}.{method}: 선언된 출력 포트 {sorted(missing)} 를 **반환하지 않는다**. "
+        f"바인딩하면 정적 검증은 통과하고 런타임엔 값이 없다(조용한 실패). "
+        f"실제 반환 키: {sorted(returned)}"
+    )

--- a/src/programgarden/tests/test_output_schema_contract.py
+++ b/src/programgarden/tests/test_output_schema_contract.py
@@ -1,0 +1,106 @@
+"""출력 스키마 계약 — 노드가 **선언한 필드**와 **런타임이 실제로 내보내는 키**가 같아야 한다.
+
+왜 필요한가 (2026-07-13 라이브에서 확진):
+resolver 는 선언된 `fields` 로 **필드 존재를 정적 검증**한다. 그래서 선언이 런타임과 어긋나면
+검증이 **양방향으로 다 틀린다**:
+
+    실제 있는 필드를 바인딩  → INVALID_EXPRESSION_REF 로 **거부**   (동작하는 워크플로우를 막음)
+    실제 없는 필드를 바인딩  → **통과** 시킨 뒤 런타임에 조용히 None (표에 '-' 만 찍힘)
+
+실측: 시세 노드 선언이 `current_price` / `change_percent` 였는데 런타임은 `price` / `change_pct`.
+챗봇은 선언(카탈로그)을 보고 저작하므로, 라이브러리가 **틀린 이름을 쓰도록 강제**하고 있었다.
+
+이 테스트는 executor 의 런타임 dict 리터럴을 AST 로 뽑아 선언과 대조한다.
+런타임을 바꾸면서 선언을 안 고치면(또는 그 반대) 여기서 깨진다.
+"""
+import ast
+import inspect
+from typing import Dict, Set
+
+import pytest
+
+from programgarden.executor import MarketDataNodeExecutor
+
+
+def _runtime_keys(cls, method_name: str) -> Set[str]:
+    """executor 메서드 안의 ``values.append({...})`` dict 리터럴 키를 뽑는다."""
+    src = inspect.getsource(getattr(cls, method_name))
+    tree = ast.parse(inspect.cleandoc(src) if not src.startswith("    ") else _dedent(src))
+
+    keys: Set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Attribute) and func.attr == "append"):
+            continue
+        if not (isinstance(func.value, ast.Name) and func.value.id == "values"):
+            continue
+        for arg in node.args:
+            if isinstance(arg, ast.Dict):
+                keys |= {k.value for k in arg.keys if isinstance(k, ast.Constant)}
+    return keys
+
+
+def _dedent(src: str) -> str:
+    import textwrap
+    return textwrap.dedent(src)
+
+
+def _declared_fields(node_type: str, port: str) -> Set[str]:
+    from programgarden_core import NodeTypeRegistry
+
+    schema = NodeTypeRegistry().get_schema(node_type)
+    assert schema is not None, f"{node_type} 스키마를 레지스트리에서 못 찾았다"
+    for out in schema.outputs or []:
+        name = out.get("name") if isinstance(out, dict) else getattr(out, "name", None)
+        if name != port:
+            continue
+        fields = out.get("fields") if isinstance(out, dict) else getattr(out, "fields", None)
+        return {
+            (f.get("name") if isinstance(f, dict) else getattr(f, "name", None))
+            for f in (fields or [])
+        } - {None}
+    pytest.fail(f"{node_type} 에 '{port}' 출력 포트 선언이 없다")
+
+
+# (노드 타입, executor 메서드, 검사할 출력 포트)
+CASES = [
+    ("OverseasStockMarketDataNode", "_fetch_overseas_stock", "value"),
+    ("OverseasFuturesMarketDataNode", "_fetch_overseas_futures", "value"),
+    ("KoreaStockMarketDataNode", "_fetch_korea_stock", "value"),
+]
+
+
+@pytest.mark.parametrize("node_type,method,port", CASES)
+def test_declared_fields_match_runtime(node_type, method, port):
+    runtime = _runtime_keys(MarketDataNodeExecutor, method)
+    assert runtime, f"{method} 에서 런타임 키를 못 뽑았다 (테스트가 낡았다)"
+
+    declared = _declared_fields(node_type, port)
+
+    only_declared = declared - runtime   # 선언만 있고 런타임엔 없음 → 검증 통과 후 조용히 None
+    only_runtime = runtime - declared    # 런타임엔 있는데 선언에 없음 → 바인딩하면 부당하게 거부
+
+    assert not only_declared, (
+        f"{node_type}: 선언에만 있는 필드 {sorted(only_declared)} — "
+        f"바인딩하면 정적검증은 통과하고 런타임엔 None 이 된다(조용한 실패)."
+    )
+    assert not only_runtime, (
+        f"{node_type}: 런타임에만 있는 필드 {sorted(only_runtime)} — "
+        f"바인딩하면 INVALID_EXPRESSION_REF 로 부당하게 거부된다."
+    )
+
+
+def test_price_and_change_names_are_consistent_across_markets():
+    """같은 개념을 시장마다 다른 이름으로 부르면 챗봇이 반드시 헷갈린다."""
+    names = {}
+    for node_type, method, port in CASES:
+        declared = _declared_fields(node_type, port)
+        names[node_type] = declared
+
+    for node_type, declared in names.items():
+        assert "price" in declared, f"{node_type}: 현재가는 'price' 로 통일한다 (실측 런타임 이름)"
+        assert "change_pct" in declared, f"{node_type}: 등락률은 'change_pct' 로 통일한다"
+        assert "current_price" not in declared, f"{node_type}: 'current_price' 는 런타임에 없다"
+        assert "change_percent" not in declared, f"{node_type}: 'change_percent' 는 런타임에 없다"

--- a/src/programgarden/tests/test_output_secret_redaction.py
+++ b/src/programgarden/tests/test_output_secret_redaction.py
@@ -1,0 +1,140 @@
+"""브로커 자격증명이 노드 출력으로 새지 않는지 검증.
+
+근본 수정(2026-07-13): BrokerNode 는 자격증명을 **시크릿 저장소에만** 둔다.
+예전엔 `connection` **출력**에 평문 appkey/appsecret 을 실었고, 노드 출력은
+리스너(SSE→대시보드) · `get_state()` · 체크포인트로 외부에 나간다.
+(실측: pg-test-9 LIVE 에서 broker 노드 output 에 실 앱키 평문 노출.)
+
+하류는 `_resolve_broker_credentials(connection, context)` 로 저장소에서 꺼낸다.
+저장소 슬롯은 **product 별**이다 — 단일 슬롯이면 브로커가 둘 이상인 워크플로우
+(해외주식 + 국내주식)에서 뒤 브로커가 앞 자격증명을 덮어써 하류가 **다른 계좌 앱키**로
+로그인한다.
+
+마스킹(`_sanitize_outputs`)은 심층방어로 남긴다 — 다른 노드가 실수로 시크릿을 출력에
+실어도 외부 경계에서 걸린다.
+"""
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import _resolve_broker_credentials, broker_credential_key
+
+
+@pytest.fixture
+def ctx():
+    return ExecutionContext(job_id="test-cred", workflow_id="wf-cred")
+
+
+OVERSEAS = {"appkey": "OVERSEAS-KEY", "appsecret": "OVERSEAS-SECRET", "paper_trading": False}
+KOREA = {"appkey": "KOREA-KEY", "appsecret": "KOREA-SECRET", "paper_trading": True}
+
+
+class TestCredentialsResolveFromSecretStore:
+    def test_resolves_by_product(self, ctx):
+        ctx.set_secret(broker_credential_key("overseas_stock"), OVERSEAS)
+        conn = {"provider": "ls-sec.co.kr", "product": "overseas_stock", "paper_trading": False}
+
+        appkey, appsecret, paper = _resolve_broker_credentials(conn, ctx)
+        assert (appkey, appsecret, paper) == ("OVERSEAS-KEY", "OVERSEAS-SECRET", False)
+
+    def test_two_brokers_do_not_collide(self, ctx):
+        """단일 슬롯이면 국내가 해외를 덮어써 하류가 남의 계좌로 로그인한다."""
+        ctx.set_secret(broker_credential_key("overseas_stock"), OVERSEAS)
+        ctx.set_secret(broker_credential_key("korea_stock"), KOREA)
+
+        ov = _resolve_broker_credentials({"product": "overseas_stock"}, ctx)
+        kr = _resolve_broker_credentials({"product": "korea_stock"}, ctx)
+
+        assert ov[0] == "OVERSEAS-KEY"
+        assert kr[0] == "KOREA-KEY"
+        assert kr[2] is True  # paper_trading 도 브로커별로 따라와야 한다
+
+    def test_falls_back_to_legacy_single_slot(self, ctx):
+        """product 슬롯이 없으면(구 저장 경로) 레거시 단일 슬롯으로 내려간다."""
+        ctx.set_secret("credential_id", OVERSEAS)
+
+        appkey, _, _ = _resolve_broker_credentials({"product": "overseas_stock"}, ctx)
+        assert appkey == "OVERSEAS-KEY"
+
+    def test_falls_back_to_plaintext_connection(self, ctx):
+        """레거시 워크플로우·deep_validate 픽스처는 아직 connection 에 키를 싣는다."""
+        conn = {"product": "overseas_stock", "appkey": "LEGACY", "appsecret": "LEGACY-S"}
+
+        appkey, appsecret, _ = _resolve_broker_credentials(conn, ctx)
+        assert (appkey, appsecret) == ("LEGACY", "LEGACY-S")
+
+    def test_missing_everything_is_empty_not_crash(self, ctx):
+        assert _resolve_broker_credentials(None, ctx) == ("", "", False)
+
+
+class TestBrokerOutputCarriesNoSecrets:
+    def test_connection_shape_has_no_credentials(self):
+        """BrokerNodeExecutor 가 반환하는 `connection` dict 에 자격증명 키가 없어야 한다.
+
+        (시크릿 저장소에 넣는 payload 에는 당연히 appkey 가 있으므로, 소스 전체 문자열
+        검색이 아니라 **반환 dict 리터럴만** AST 로 집어서 본다.)
+        """
+        import ast
+        import inspect
+        import textwrap
+
+        from programgarden.executor import BrokerNodeExecutor
+
+        tree = ast.parse(textwrap.dedent(inspect.getsource(BrokerNodeExecutor)))
+
+        checked = 0
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Return) and isinstance(node.value, ast.Dict)):
+                continue
+            keys = [k.value for k in node.value.keys if isinstance(k, ast.Constant)]
+            if "connection" not in keys:
+                continue
+            conn_node = node.value.values[keys.index("connection")]
+            if not isinstance(conn_node, ast.Dict):
+                continue
+            conn_keys = {k.value for k in conn_node.keys if isinstance(k, ast.Constant)}
+            checked += 1
+            assert "appkey" not in conn_keys, f"connection 출력에 appkey 가 다시 실렸다: {conn_keys}"
+            assert "appsecret" not in conn_keys, f"connection 출력에 appsecret 이 다시 실렸다: {conn_keys}"
+            assert "product" in conn_keys, "하류가 자격증명을 찾으려면 product 가 필요하다"
+
+        assert checked, "BrokerNodeExecutor 에서 connection 반환 dict 를 찾지 못했다"
+
+
+class TestSanitizerDefenseInDepth:
+    """근본 수정과 별개로, 출력 경계 마스킹은 남겨 둔다."""
+
+    def test_masks_credentials_in_outputs(self, ctx):
+        ctx.set_output("broker", "connection", {"provider": "ls", "appkey": "LEAK", "appsecret": "LEAK2"})
+
+        safe = ctx.get_all_outputs_sanitized("broker")
+        assert safe["connection"]["appkey"] == "[REDACTED]"
+        assert safe["connection"]["appsecret"] == "[REDACTED]"
+        assert safe["connection"]["provider"] == "ls"
+
+    def test_internal_store_is_not_mutated(self, ctx):
+        ctx.set_output("broker", "connection", {"appkey": "REAL"})
+
+        ctx.get_all_outputs_sanitized("broker")
+        assert ctx.get_all_outputs("broker")["connection"]["appkey"] == "REAL"
+
+    def test_secrets_inside_a_list_are_masked(self, ctx):
+        """기존 sanitizer 는 dict 만 재귀해 리스트 안의 dict 를 통과시켰다."""
+        ctx.set_output("n", "credentials", [{"credential_id": "c1", "appkey": "LEAK"}])
+
+        safe = ctx.get_all_outputs_sanitized("n")
+        assert "LEAK" not in repr(safe)
+        assert safe["credentials"][0]["credential_id"] == "c1"
+
+    @pytest.mark.parametrize(
+        "key", ["appkey", "appsecret", "api_key", "apikey", "token",
+                "access_token", "password", "secret", "private_key"],
+    )
+    def test_each_sensitive_key_is_masked(self, ctx, key):
+        ctx.set_output("n", "data", {key: "LEAK"})
+
+        assert ctx.get_all_outputs_sanitized("n")["data"][key] == "[REDACTED]"
+
+    def test_ordinary_keys_untouched(self, ctx):
+        ctx.set_output("n", "data", {"symbol": "NVDA", "price": 209.0})
+
+        assert ctx.get_all_outputs_sanitized("n")["data"] == {"symbol": "NVDA", "price": 209.0}


### PR DESCRIPTION
## 무엇을 고쳤나

라이브 E2E(`/pg-test-9-workflow`, 실 LS 키·read-only)가 잡은 결함 3건 + **선언 드리프트 후속**.

관통 불변식: **노드가 선언한 출력 포트는 런타임이 실제로, 어느 갈래에서든 같은 키로 내보낸다.**

resolver 는 이 선언으로 필드 존재를 **정적 검증**한다. 그래서 선언이 런타임과 어긋나면 검증이 양방향으로 다 틀린다 — **있는 필드는 부당 거부**하고, **없는 필드는 통과**시킨 뒤 런타임에 조용히 None 이 된다. 챗봇은 카탈로그(=선언)를 보고 저작하므로, 라이브러리가 **틀린 이름을 쓰도록 강제**하고 있었다.

| # | 결함 | 사용자에게 어떻게 보였나 |
|---|---|---|
| 1 | 해외주식 전일대비 부호 유실 | 하락장인데 등락폭이 **항상 양수** (g3101 `diff`=절댓값, 부호는 `sign` 에 별도 — 실 TR 16종목 실측) |
| 2 | 브로커 자격증명 평문 유출 | `connection` 출력에 appkey/appsecret → SSE·`get_state` 로 **외부 노출** |
| 3 | 시세 노드 선언 ↔ 런타임 | "엔비디아 현재가 보여줘" 표의 현재가 칸이 `-` 인데 워크플로우는 `completed / errors=0` |
| 4 | **`held_symbols` 를 아무도 안 내보냈다** | 계좌 노드 6종이 전부 이 포트를 선언하는데 executor 는 계산만 하고 **반환 dict 에 안 실었다**(죽은 지역변수). "내가 보유한 종목 실시간 감시"가 **아무것도 구독하지 않고** 성공으로 보고 |
| 5 | 실시간 계좌 `positions` 가 시점마다 다른 모양 | REST 스냅샷 갈래는 `exchange`/`quantity`, WebSocket tracker 갈래는 `qty`/`market_code`. 주문 노드는 `exchange`/`quantity` 를 읽으므로 **실시간 틱이 오는 순간 조용히 깨짐** |

부수: 실시간 `data` 포트가 약속하던 `bid_price`/`ask_price` 를 만드는 코드(`_build_full_data`)는 **아무도 호출하지 않는 죽은 코드**였다(제거). ScreenerNode 가 상류의 종목명(`name`)을 버리고 있었다(통과시킴).

## 어떻게 재발을 막나

공유 상수(`SYMBOL_LIST_FIELDS` 11파일 20포트 / `POSITION_FIELDS` 6노드)를 **노드별 상수로 분리**했다. 상수를 공유하면 한 노드를 맞추는 순간 다른 노드가 반대로 거짓말한다 — Screener 를 맞추려 `price` 를 넣으면 Watchlist 가 **안 내보내는 필드를 선언**하게 된다.

`tests/test_output_schema_contract.py` (**47 passed**) — executor 의 런타임 dict 리터럴을 **AST 로 뽑아** 선언과 대조한다. 한쪽만 바꾸면 여기서 깨진다.
- `test_declared_ports_are_actually_returned` — 선언한 포트를 **반환에 싣는지** (위 #4 를 잡는다)
- `test_producers_of_one_port_agree` — 한 포트를 만드는 갈래가 여럿이면 키 집합이 같아야 한다 (위 #5)

돌연변이 테스트로 역증명: `held_symbols` 반환을 지우면, `pnl` 선언을 되살리면 → **실패한다.**

## Validation

- **정적 검증 역전 해소** (동봉 예제 22 로 실측): `pnl_amount`/`name`/`eval_amount` → ✅ 통과 (수정 전 🔴 거부) · `pnl`/`pnl_percent` → 🔴 거부 (수정 전 ✅ 통과)
- **오탐 0** — 동봉 예제 100개: 베이스라인 2 failed → 2 failed (같은 2건, 기존 결함). 가드가 새로 잡은 4건은 전부 **정탐**이었다(유령 컬럼 → 수정).
- **회귀 0** — programgarden 스위트: 실패/에러 **집합이 베이스라인과 이름까지 동일**(72건), passed 1465 → 1509.
- **core 1505 passed / 0 failed** (1.27.0 에서 노드 추가 후 갱신 안 된 노드 수 가드도 복구).
- resolver `VERIFIED_PORTS` 6 → 24 포트 (계약 검사로 증명된 것만).

## 버전

`programgarden` 1.27.0 → **1.28.0** · `programgarden-core` 1.19.0 → **1.20.0**
core 핀 lockstep(`^1.20.0`) — 핀을 안 올리면 1.28.0 이 **옛 선언과 설치**될 수 있고 가드가 다시 거꾸로 돈다.

머지 후: PyPI publish(core → programgarden) → requirements 핀 3종 bump → dev 배포 → pg-test-9 재검증 → prod.