### PR TITLE
fix(engine): 국내주식 실시간이 통째로 죽어 있던 것 — 이벤트 소스 목록 3곳 드리프트

### DIFF
--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -54,6 +54,28 @@ _RESERVED_ITERATION_ROOTS: frozenset = frozenset({"item", "row"})
 
 _INLINE_EXPR_PATTERN = re.compile(r"\{\{\s*(.+?)\s*\}\}")
 
+# Realtime (event-source) node types — the ONE list. Three separate lifecycle
+# decisions key off it: (1) whether the job enters the event loop (and so keeps
+# the WebSocket subscriptions alive instead of tearing them down in `finally`),
+# (2) whether the node auto-triggers its downstream chain on each event, and
+# (3) whether it is skipped on re-execution (it is already running).
+#
+# It used to be copy-pasted at all three sites, and the Korea family — added
+# later — was never added to any of them. Result: Korea realtime workflows had
+# no event source, so the job completed immediately, cleanup closed the socket,
+# and ticks never reached the table. Keep this the single source of truth;
+# `test_realtime_node_types_cover_declarations` fails if a node declares
+# `stay_connected` but is missing here.
+REALTIME_NODE_TYPES: frozenset = frozenset({
+    "RealAccountNode", "RealMarketDataNode", "RealOrderEventNode",
+    "OverseasStockRealAccountNode", "OverseasStockRealMarketDataNode",
+    "OverseasStockRealOrderEventNode",
+    "OverseasFuturesRealAccountNode", "OverseasFuturesRealMarketDataNode",
+    "OverseasFuturesRealOrderEventNode",
+    "KoreaStockRealAccountNode", "KoreaStockRealMarketDataNode",
+    "KoreaStockRealOrderEventNode",
+})
+
 
 def _free_root_names(text: str) -> Set[str]:
     """Return the set of free-variable root identifiers referenced (ctx=Load) by
@@ -17523,12 +17545,7 @@ class WorkflowJob:
         result = []
         for node_id, node in self.workflow.nodes.items():
             # 실시간 노드 (stay_connected 설정)
-            if node.node_type in (
-                "RealAccountNode", "RealMarketDataNode", "RealOrderEventNode",
-                "OverseasStockRealAccountNode", "OverseasFuturesRealAccountNode",
-                "OverseasStockRealMarketDataNode", "OverseasFuturesRealMarketDataNode",
-                "OverseasStockRealOrderEventNode", "OverseasFuturesRealOrderEventNode",
-            ):
+            if node.node_type in REALTIME_NODE_TYPES:
                 if node.config.get("stay_connected", True):
                     result.append(node_id)
             # 영속 노드 (백그라운드 태스크를 등록하는 노드)
@@ -18835,13 +18852,7 @@ class WorkflowJob:
         source_node = self.workflow.nodes.get(source_node_id)
         
         # 실시간 노드는 하위 노드를 자동 트리거
-        auto_trigger_types = {
-            "RealAccountNode", "RealMarketDataNode", "RealOrderEventNode",
-            "OverseasStockRealAccountNode", "OverseasFuturesRealAccountNode",
-            "OverseasStockRealMarketDataNode", "OverseasFuturesRealMarketDataNode",
-            "OverseasStockRealOrderEventNode", "OverseasFuturesRealOrderEventNode",
-        }
-        is_realtime_source = source_node and source_node.node_type in auto_trigger_types
+        is_realtime_source = source_node and source_node.node_type in REALTIME_NODE_TYPES
         
         for edge in self.workflow.edges:
             if edge.from_node_id == source_node_id:
@@ -19279,12 +19290,7 @@ class WorkflowJob:
                 continue
             
             # 실시간 노드는 이미 실행 중이므로 스킵 (무한 루프 방지)
-            if node.node_type in (
-                "RealAccountNode", "RealMarketDataNode", "RealOrderEventNode",
-                "OverseasStockRealAccountNode", "OverseasFuturesRealAccountNode",
-                "OverseasStockRealMarketDataNode", "OverseasFuturesRealMarketDataNode",
-                "OverseasStockRealOrderEventNode", "OverseasFuturesRealOrderEventNode",
-            ):
+            if node.node_type in REALTIME_NODE_TYPES:
                 continue
             
             # Re-execute the triggered node

--- a/src/programgarden/tests/test_realtime_node_types_contract.py
+++ b/src/programgarden/tests/test_realtime_node_types_contract.py
@@ -1,0 +1,113 @@
+"""REALTIME_NODE_TYPES must cover every node that declares `stay_connected`.
+
+Why this test exists
+--------------------
+Three separate lifecycle decisions key off the realtime node-type set:
+
+  1. `_find_stay_connected_nodes` — does the job enter the event loop? If not, the
+     job completes as soon as the main flow ends and the `finally` block calls
+     `cleanup_persistent_nodes()`, which sets the shutdown flag and CLOSES the
+     WebSocket. Ticks then never arrive.
+  2. `_get_trigger_nodes` — does the node auto-trigger its downstream chain on
+     each event?
+  3. re-execution — is the node skipped when already running (loop prevention)?
+
+That set was copy-pasted at all three sites. The Korea family
+(`KoreaStockReal*Node`), added later, was never added to any of them — so Korea
+realtime workflows had no event source at all: the job finished in ~2s, the
+socket was torn down, and zero ticks ever reached the table. The library itself
+was streaming ~1000 ticks/45s the whole time.
+
+The list is now a single constant, and this test makes the DECLARATIONS the
+source of truth: declare `stay_connected` on a node and you are in the set, or
+this test fails. A hand-maintained list drifts; a derived one cannot.
+"""
+import pytest
+
+from programgarden.executor import REALTIME_NODE_TYPES, WorkflowExecutor
+from programgarden_core.registry.node_registry import NodeTypeRegistry
+
+
+# Nodes that declare `stay_connected` but are deliberately NOT event sources.
+# MarketStatusNode holds a JIF subscription with its own lifecycle
+# (`_cleanup_jif_subscriptions`) and must not keep the job alive on its own.
+_NOT_EVENT_SOURCES = {"MarketStatusNode"}
+
+
+def _declares_stay_connected(cls) -> bool:
+    for attr in ("get_field_schema", "get_config_schema"):
+        fn = getattr(cls, attr, None)
+        if not callable(fn):
+            continue
+        try:
+            schema = fn()
+        except Exception:
+            continue
+        if isinstance(schema, dict):
+            if "stay_connected" in schema:
+                return True
+            props = schema.get("properties")
+            if isinstance(props, dict) and "stay_connected" in props:
+                return True
+        elif isinstance(schema, (list, tuple)):
+            for f in schema:
+                name = getattr(f, "name", None) or (
+                    f.get("name") if isinstance(f, dict) else None
+                )
+                if name == "stay_connected":
+                    return True
+    return False
+
+
+def _nodes_declaring_stay_connected():
+    reg = NodeTypeRegistry()
+    found = set()
+    for nt in reg.list_types():
+        try:
+            cls = reg.get(nt)
+        except Exception:
+            continue
+        if cls is not None and _declares_stay_connected(cls):
+            found.add(nt)
+    return found
+
+
+def test_realtime_node_types_cover_declarations():
+    """Every node declaring `stay_connected` is an event source (or explicitly exempt).
+
+    This is the guard that would have caught the dead Korea realtime family.
+    """
+    declared = _nodes_declaring_stay_connected()
+    assert declared, "no node declares stay_connected — registry introspection broke"
+
+    missing = declared - REALTIME_NODE_TYPES - _NOT_EVENT_SOURCES
+    assert not missing, (
+        f"{sorted(missing)} declare `stay_connected` but are absent from "
+        f"REALTIME_NODE_TYPES. Such a node never keeps the job alive, so its "
+        f"WebSocket is torn down when the main flow ends and it silently "
+        f"delivers zero events. Add it to REALTIME_NODE_TYPES (or to "
+        f"_NOT_EVENT_SOURCES with a reason)."
+    )
+
+
+def test_realtime_node_types_are_real_nodes():
+    """No stale entries: every listed type is something the engine can actually run.
+
+    Checked against the executor map as well as the declaration registry: the
+    generic `Real*Node` names are executable legacy aliases that the registry does
+    not declare, so registry membership alone would false-fail on them.
+    """
+    reg = NodeTypeRegistry()
+    known = set(reg.list_types()) | set(WorkflowExecutor()._executors)
+    stale = {nt for nt in REALTIME_NODE_TYPES if nt not in known}
+    assert not stale, f"REALTIME_NODE_TYPES lists unknown node types: {sorted(stale)}"
+
+
+@pytest.mark.parametrize(
+    "node_type",
+    ["KoreaStockRealMarketDataNode", "KoreaStockRealAccountNode",
+     "KoreaStockRealOrderEventNode"],
+)
+def test_korea_realtime_family_is_an_event_source(node_type):
+    """Regression: the Korea family was missing from all three lifecycle lists."""
+    assert node_type in REALTIME_NODE_TYPES


### PR DESCRIPTION
## Summary

**국내주식(KOSPI/KOSDAQ) 실시간이 통째로 동작하지 않고 있었습니다.** 시세도, 계좌도, 주문 체결 이벤트도.

원인은 한 줄로 말하면 **하드코딩된 노드 타입 목록의 드리프트**입니다. 엔진은 "실시간(이벤트 소스) 노드"
목록을 **세 곳에 복사해** 두고 있었는데, 나중에 추가된 국내 계열(`KoreaStockReal*Node`)은 **어느 곳에도
들어가지 않았습니다.**

세 목록은 각각 다른 생명주기를 결정합니다:

1. `_find_stay_connected_nodes` — job 이 **이벤트 루프에 진입**하는가. 아니면 메인 플로우가 끝나는 즉시
   job 이 `completed` 되고, `finally` 의 `cleanup_persistent_nodes()` 가 shutdown 플래그를 세우고
   **WebSocket 을 닫습니다.**
2. `_get_trigger_nodes` — 이벤트마다 **하류 체인을 자동 트리거**하는가.
3. 재실행 스킵 — 이미 돌고 있는 실시간 노드를 다시 실행하지 않는가(무한 루프 방지).

결과적으로 국내 실시간 워크플로우는 **이벤트 소스가 0** → job 이 약 2초 만에 종료 → 소켓 철거 →
**틱이 단 한 건도 하류에 도달하지 못했습니다.** 그 시간 내내 라이브러리 자체는 초당 수십 틱을 받고 있었습니다.

**수정**: 세 목록을 단일 상수 `REALTIME_NODE_TYPES` 로 통합하고 국내 계열 3종을 포함시켰습니다.

## Validation

**실 LS 계좌 라이브 (KRX 장중, 삼성전자 005930)** — 같은 워크플로우, 수정 전/후:

| | 수정 전 | 수정 후 |
|---|---|---|
| 구독 | 성립 (`Subscribed to S3_/K3_: ['005930']`) | 성립 |
| `job.status` | **1.9초만에 `completed`** (소켓 철거) | **`running` 유지** |
| real_market emission | **0건** | **765건** (실 OHLCV 764건) |

수정 후 실측 바: `{"005930": [{"open":255000, "high":270000, "low":247000, "close":263250, "volume":30511582}]}`
대조군(라이브러리 직결): 45초에 틱 1,052건 — **수정 전에는 엔진만 0 이었습니다.**

- **회귀 없음**: 변경 전/후 테스트 결과가 **완전히 동일**합니다 (1567 passed / 13 failed / 60 errors — 실패·에러는
  전부 기존이며 실시간과 무관). 계약 테스트 5종 99 passed.
- **드리프트 방지 테스트 신설** (`test_realtime_node_types_contract.py`): `stay_connected` 를 **선언한** 노드는
  반드시 `REALTIME_NODE_TYPES` 에 있어야 합니다. **선언을 진실의 원천으로 삼습니다** — 손으로 관리하는 목록은
  드리프트하지만 파생된 목록은 드리프트할 수 없습니다. 이 테스트가 있었다면 이 결함은 국내 계열이 추가된 날 잡혔습니다.

## Follow-up

- 틱이 **노드까지는** 오지만 `Split → Throttle → Aggregate → Table` 배선에서는 **표가 아직 안 찹니다.**
  틱 트리거가 하류(throttle)만 재실행하고 **split 분기를 다시 돌리지 않아** Aggregate 가 분기 결과를
  수집하지 못합니다. 별건으로 진단이 필요합니다.
- 제네릭 `Real{Account,MarketData,OrderEvent}Node` 는 실행기 맵엔 있는데 노드 레지스트리엔 선언이 없습니다
  (또 다른 선언↔런타임 드리프트).

> base 를 #22 로 두어 이 PR 의 diff 에는 본 수정만 보입니다. #22 가 main 에 머지되면 자동으로 base 가 main 으로 바뀝니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ozaHLK9CkXGJAf4ZqiVTX
