### PR TITLE
fix(engine): 실시간 시세 표가 영원히 안 차던 것 — Split 분기 미재구동 + Throttle 상류 수집 死 + 종목 미분리

### DIFF
--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -758,8 +758,14 @@ class ThrottleNodeExecutor(NodeExecutorBase):
         interval_sec = config.get("interval_sec", 5.0)
         pass_first = config.get("pass_first", True)
 
-        # State key for this node
+        # State key for this node.
+        # Split 분기 안에서는 종목마다 별도 스코프를 쓴다. 노드 하나를 분기 아이템들이
+        # 공유하므로, 스코프가 없으면 쿨다운까지 공유돼 한 사이클에 한 종목만 통과하고
+        # 나머지 종목은 매번 버려진다(표에 종목당 1행이 안 나온다).
         state_key = "_throttle_state"
+        branch_scope = config.get("_branch_scope")
+        if branch_scope:
+            state_key = f"{state_key}:{branch_scope}"
         throttle_state = context.get_node_state(node_id, state_key) or {
             "last_passed_at": None,
             "skipped_count": 0,
@@ -952,7 +958,18 @@ class ThrottleNodeExecutor(NodeExecutorBase):
                             for key, value in all_outputs.items():
                                 if not key.startswith("_"):
                                     input_data[key] = value
-        
+
+        # 상류 출력은 모든 실행 경로(메인 플로우/Split 분기/실시간 재실행)가 이미
+        # `_input_<node_id>` 의사 노드에 모아둔다. 위의 `context._workflow_edges` 워크는
+        # **프로덕션에서 그 속성을 아무도 설정하지 않아** 통째로 죽어 있었다(테스트만 주입).
+        # 그래서 ThrottleNode 는 실시간 핸들러가 `_realtime_data` 를 직접 꽂아주는 경로에서만
+        # 동작했고, Split 분기 안에서는 상류에 실시간 시세가 흘러도 영원히 빈 입력을 봤다
+        # → 영원히 cooldown → 분기 결과가 전부 버려져 Aggregate 표가 안 찼다.
+        upstream = context.get_all_outputs(f"_input_{node_id}") or {}
+        for key, value in upstream.items():
+            if not key.startswith("_"):
+                input_data.setdefault(key, value)
+
         return input_data
 
 
@@ -1009,6 +1026,71 @@ def _public_outputs(outputs: Dict[str, Any]) -> Dict[str, Any]:
         k: v for k, v in outputs.items()
         if not (isinstance(k, str) and k.startswith("_"))
     }
+
+
+# ── Split 분기 × 실시간 시세: 종목별 분리 (2026-07-14) ────────────────────────
+# 실시간 시세 노드는 **노드 하나에 구독 종목이 전부 합쳐진** symbol-keyed 출력을 낸다
+# (`ohlcv_data = {"005930": [bar], "000660": [bar]}` — on_tick 이 종목별 bar 를 한 dict 에
+# 누적). 그런데 Split 분기의 아이템 하나는 자기 종목만 봐야 한다. 자르지 않으면 모든
+# 분기가 같은 덩어리를 보고 같은 값을 수집해 "종목당 1행" 표가 나오지 않는다.
+_SYMBOL_ITEM_KEYS = ("symbol", "shcode", "code")
+
+# Split 분기가 수집할 값을 고를 때 payload 로 인정하는 포트(선언 순). 예전엔 공개 포트
+# 중 **아무거나 첫 번째**(dict 순서 의존)를 집어서, 시세 노드가 `symbols` 를 먼저 쓰면
+# 가격 대신 종목코드 목록이 표에 실렸다(비결정 + 잘못된 데이터).
+_BRANCH_PAYLOAD_PORTS = ("result", "value", "data", "ohlcv_data")
+
+
+def _item_symbol(item: Any) -> Optional[str]:
+    """Split 아이템에서 종목코드를 뽑는다 ('005930' 또는 {'symbol': '005930'})."""
+    if isinstance(item, str):
+        return item or None
+    if isinstance(item, dict):
+        for key in _SYMBOL_ITEM_KEYS:
+            value = item.get(key)
+            if isinstance(value, str) and value:
+                return value
+    return None
+
+
+def _slice_realtime_outputs(outputs: Dict[str, Any], symbol: str) -> Dict[str, Any]:
+    """실시간 시세 노드의 합쳐진 출력을 한 종목 몫으로 자른다."""
+    sliced: Dict[str, Any] = {}
+    for port, value in outputs.items():
+        if port == "symbol":
+            sliced[port] = symbol
+        elif isinstance(value, dict) and symbol in value:
+            # symbol-keyed dict (ohlcv_data / data) → 이 종목의 값만
+            sliced[port] = value[symbol]
+        elif port == "symbols" and isinstance(value, list):
+            kept = [s for s in value if _item_symbol(s) == symbol]
+            sliced[port] = kept or value
+        else:
+            sliced[port] = value
+    return sliced
+
+
+def _realtime_branch_row(public: Dict[str, Any], symbol: Optional[str]) -> Optional[Dict[str, Any]]:
+    """실시간 분기 아이템이 표에 기여할 **평평한 한 행**을 만든다.
+
+    슬라이스된 payload 는 이 종목의 bar 리스트(`[{date, open, high, low, close, volume}]`)
+    이므로, 최신 bar 에 종목코드를 붙여 `{symbol, date, open, ..., volume}` 한 행으로 낸다.
+    TableDisplayNode 는 평평한 dict 의 리스트를 기대한다(첫 행의 키가 곧 표의 열).
+    """
+    for port in ("data", "ohlcv_data"):
+        value = public.get(port)
+        bar = None
+        if isinstance(value, list) and value and isinstance(value[-1], dict):
+            bar = value[-1]
+        elif isinstance(value, dict) and value and not isinstance(next(iter(value.values()), None), (dict, list)):
+            bar = value
+        if bar is None:
+            continue
+        row = dict(bar)
+        if symbol:
+            row.setdefault("symbol", symbol)
+        return row
+    return None
 
 
 # ── 해외주식 거래소 표기 정규화 (2026-07-14 결함3) ────────────────────────────
@@ -18626,7 +18708,7 @@ class WorkflowJob:
             return
 
         total = len(input_array)
-        collected_results: List[Any] = []
+        results_by_index: Dict[int, Any] = {}
         errors: List[str] = []
 
         print(f"    📦 SplitNode: {total} items, parallel={parallel}, delay_ms={delay_ms}")
@@ -18635,7 +18717,7 @@ class WorkflowJob:
         if parallel:
             # Parallel execution
             async def execute_item(idx: int, item: Any) -> Any:
-                return await self._execute_branch_for_item(
+                return idx, await self._execute_branch_for_item(
                     split_id=split_id,
                     branch_order=branch_order,
                     item=item,
@@ -18646,38 +18728,62 @@ class WorkflowJob:
             tasks = [execute_item(i, item) for i, item in enumerate(input_array)]
             for coro in asyncio.as_completed(tasks):
                 try:
-                    result = await coro
-                    if result is not _SKIP_BRANCH_ITEM:
-                        collected_results.append(result)
+                    idx, result = await coro
+                    results_by_index[idx] = result
                 except Exception as e:
                     if continue_on_error:
                         errors.append(str(e))
-                        collected_results.append(None)
                     else:
                         raise
         else:
             # Sequential execution
             for idx, item in enumerate(input_array):
                 try:
-                    result = await self._execute_branch_for_item(
+                    results_by_index[idx] = await self._execute_branch_for_item(
                         split_id=split_id,
                         branch_order=branch_order,
                         item=item,
                         index=idx,
                         total=total,
                     )
-                    if result is not _SKIP_BRANCH_ITEM:
-                        collected_results.append(result)
                 except Exception as e:
                     if continue_on_error:
                         errors.append(str(e))
-                        collected_results.append(None)
+                        results_by_index[idx] = None
                     else:
                         raise
 
                 # Apply delay between items (except last)
                 if delay_ms > 0 and idx < total - 1:
                     await asyncio.sleep(delay_ms / 1000)
+
+        # === Collect, holding the last known row per item (realtime branches) ===
+        # 실시간 분기는 틱마다 재구동되고 ThrottleNode 는 종목별 쿨다운으로 대부분의
+        # 사이클을 막는다. 통과하지 못한 종목을 그냥 버리면 수집 배열이 사이클마다
+        # 통째로 비어 **표가 깜빡인다**(찼다 → 빈 표 → 찼다). 이번 사이클에 새 값이 없으면
+        # 그 종목의 **직전 행을 유지**한다. 실시간이 아닌 분기는 기존대로 버린다
+        # (아직 실데이터가 없는 아이템을 표에 끼우지 않기 위함 — 2026-07-14 결함2).
+        realtime_branch = any(
+            (self.workflow.nodes.get(n).node_type in REALTIME_NODE_TYPES)
+            for n in branch_order
+            if self.workflow.nodes.get(n)
+        )
+        held_key = "_last_branch_rows"
+        held: Dict[str, Any] = dict(self.context.get_node_state(aggregate_id, held_key) or {})
+
+        collected_results: List[Any] = []
+        for idx in range(total):
+            result = results_by_index.get(idx, _SKIP_BRANCH_ITEM)
+            if result is _SKIP_BRANCH_ITEM:
+                if realtime_branch and str(idx) in held:
+                    collected_results.append(held[str(idx)])
+                continue
+            collected_results.append(result)
+            if realtime_branch and result is not None:
+                held[str(idx)] = result
+
+        if realtime_branch:
+            self.context.set_node_state(aggregate_id, held_key, held)
 
         # === Store results for AggregateNode ===
         self.context.set_node_state(aggregate_id, "_collected_items", collected_results)
@@ -18733,21 +18839,50 @@ class WorkflowJob:
         result = item
         last_had_public = None  # None = branch 노드 없음 / True|False = 마지막 노드 결과
 
+        # 이 분기가 실시간 시세를 다루는가 + 이 아이템의 종목은 무엇인가.
+        # (실시간 분기에서만 종목별 슬라이싱/행 생성을 적용해 파장을 그 경우로 가둔다.)
+        symbol = _item_symbol(item)
+        realtime_branch = any(
+            (self.workflow.nodes.get(n).node_type in REALTIME_NODE_TYPES)
+            for n in branch_order
+            if self.workflow.nodes.get(n)
+        )
+        # 분기 아이템마다 독립된 상태 스코프. ThrottleNode 의 쿨다운은 노드별 상태라
+        # 종목들이 한 노드를 공유하면 대기시간까지 공유돼 한 번에 한 종목만 통과한다.
+        branch_scope = f"{split_id}#{index}"
+
         # Execute each branch node
         for node_id in branch_order:
             node = self.workflow.nodes.get(node_id)
             if not node:
                 continue
 
+            # 이미 구독을 건 실시간 노드는 분기 재구동 때 다시 실행하지 않는다.
+            # 재실행하면 틱마다 재구독이 걸려 소켓이 폭주한다. 최신 시세는 틱 콜백이
+            # 이 노드의 context 출력에 계속 갱신해 두므로, 하류는 그걸 그대로 읽으면 된다.
+            # (최초 실행 때는 출력이 없으므로 정상적으로 실행돼 구독이 걸린다.)
+            if node.node_type in REALTIME_NODE_TYPES and self.context.get_all_outputs(node_id):
+                continue
+
             # Prepare config
             config = dict(node.config)
             config = self._resolve_config_expressions(config, node_id)
             config = self._auto_inject_connection(node_id, node, config)
+            config["_branch_scope"] = branch_scope
 
             # Connect inputs from upstream
             for edge in self.workflow.edges:
                 if edge.to_node_id == node_id:
                     all_outputs = self.context.get_all_outputs(edge.from_node_id)
+                    source = self.workflow.nodes.get(edge.from_node_id)
+                    if (
+                        all_outputs
+                        and symbol
+                        and source
+                        and source.node_type in REALTIME_NODE_TYPES
+                    ):
+                        # 합쳐진 시세를 이 아이템의 종목 몫으로 자른다
+                        all_outputs = _slice_realtime_outputs(all_outputs, symbol)
                     for port_name, port_value in all_outputs.items():
                         self.context.set_output(f"_input_{node_id}", port_name, port_value)
 
@@ -18772,7 +18907,14 @@ class WorkflowJob:
             public = _public_outputs(outputs) if outputs else {}
             last_had_public = bool(public)
             if public:
-                result = public.get("result") or public.get("value") or next(iter(public.values()), item)
+                row = _realtime_branch_row(public, symbol) if realtime_branch else None
+                if row is not None:
+                    result = row
+                else:
+                    result = next(
+                        (public[p] for p in _BRANCH_PAYLOAD_PORTS if public.get(p) is not None),
+                        next(iter(public.values()), item),
+                    )
 
         # 마지막 branch 노드가 공개 출력을 전혀 못 냈으면(예: ThrottleNode 가 이번 사이클
         # 을 throttling 중이라 내부 메타만 반환) 이 아이템은 기여할 실데이터가 없다 →
@@ -19280,19 +19422,42 @@ class WorkflowJob:
         # 🆕 트리거된 노드들 + 하위 노드들을 모두 찾아서 실행 순서대로 정렬
         nodes_to_execute = self._find_downstream_nodes(trigger_nodes)
         print(f"  → 실행할 노드 체인: {nodes_to_execute}")
-        
+
+        # Split→Aggregate 분기는 노드를 하나씩 재실행해서는 절대 채워지지 않는다.
+        # AggregateNode 의 유일한 입력인 node_state["_collected_items"] 를 쓰는 곳은
+        # _execute_split_branch 한 곳뿐이라, 틱이 하류만 일반 재실행하면 수집 배열이
+        # 최초 실행 시점 값(대개 [])에 영구히 얼어붙는다 → 표가 영원히 빈 채로 남는다.
+        # 체인이 분기에 닿으면 그 Split 분기를 통째로 재구동해 수집을 다시 채운다.
+        split_pairs = self._find_split_aggregate_pairs()
+        chain = set(nodes_to_execute)
+        branch_driven: Set[str] = set()
+        for split_id, aggregate_id in split_pairs.items():
+            branch = self._get_branch_nodes(split_id, aggregate_id)
+            if not (chain & branch) and aggregate_id not in chain:
+                continue
+            split_node = self.workflow.nodes.get(split_id)
+            if not split_node:
+                continue
+            print(f"    🔀 Re-driving split branch: {split_id} → {aggregate_id}")
+            await self._execute_split_branch(split_id, split_node, split_pairs, branch)
+            branch_driven |= branch | {split_id, aggregate_id}
+
         for node_id in nodes_to_execute:
             if not self.context.is_running:
                 break
-            
+
             node = self.workflow.nodes.get(node_id)
             if not node:
                 continue
-            
+
             # 실시간 노드는 이미 실행 중이므로 스킵 (무한 루프 방지)
             if node.node_type in REALTIME_NODE_TYPES:
                 continue
-            
+
+            # 분기 재구동이 이미 실행한 노드는 중복 실행하지 않는다
+            if node_id in branch_driven:
+                continue
+
             # Re-execute the triggered node
             try:
                 print(f"    ▶ Re-executing: {node_id} ({node.node_type})")

--- a/src/programgarden/tests/test_item_based_execution.py
+++ b/src/programgarden/tests/test_item_based_execution.py
@@ -549,3 +549,235 @@ class TestRealtimePendingProducesNoRow:
             {"mode": "latest", "interval_sec": 5.0, "pass_first": True}, ctx,
         )
         assert "ohlcv_data" in _public_outputs(out)
+
+
+class TestThrottleReadsUpstreamWithoutRealtimeEvent:
+    """ThrottleNode 는 실시간 이벤트가 config 로 데이터를 꽂아주지 않아도 상류를 읽어야 한다.
+
+    회귀 방지: 예전엔 상류 수집이 `context._workflow_edges` 만 봤는데, 그 속성은
+    **프로덕션 실행 경로에서 아무도 설정하지 않았다**(테스트만 주입). 그래서 Split 분기
+    안의 ThrottleNode 는 상류에 실시간 시세가 흘러도 영원히 빈 입력을 보고 통과하지
+    못했고, Aggregate 표가 절대 차지 않았다. 실행 경로가 채우는 `_input_<node_id>` 를
+    읽어야 한다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reads_input_pseudo_node(self):
+        from programgarden.context import ExecutionContext
+        from programgarden.executor import ThrottleNodeExecutor, _public_outputs
+
+        ctx = ExecutionContext(job_id="j", workflow_id="w")
+
+        async def _noop(**k):
+            return None
+
+        ctx.notify_node_state = _noop
+        # 실행 경로가 상류 출력을 모아두는 자리 (_workflow_edges 도, _realtime_data 도 없음)
+        ctx.set_output("_input_throttle", "ohlcv_data", [{"close": 263500.0}])
+
+        out = await ThrottleNodeExecutor().execute(
+            "throttle", "ThrottleNode",
+            {"mode": "latest", "interval_sec": 5.0, "pass_first": True}, ctx,
+        )
+        assert _public_outputs(out).get("ohlcv_data") == [{"close": 263500.0}]
+
+
+class TestBranchScopedThrottleCooldown:
+    """분기 아이템(종목)마다 쿨다운이 독립이어야 한다.
+
+    노드 하나를 분기 아이템들이 공유하므로 스코프가 없으면 쿨다운까지 공유돼
+    한 사이클에 한 종목만 통과하고 나머지 종목 행은 매번 사라진다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_two_items_both_pass_on_first_cycle(self):
+        from programgarden.context import ExecutionContext
+        from programgarden.executor import ThrottleNodeExecutor, _public_outputs
+
+        ctx = ExecutionContext(job_id="j", workflow_id="w")
+
+        async def _noop(**k):
+            return None
+
+        ctx.notify_node_state = _noop
+        executor = ThrottleNodeExecutor()
+        passed = []
+
+        for idx, symbol in enumerate(["005930", "000660"]):
+            ctx.set_output("_input_throttle", "ohlcv_data", [{"symbol": symbol}])
+            out = await executor.execute(
+                "throttle", "ThrottleNode",
+                {
+                    "mode": "latest", "interval_sec": 5.0, "pass_first": True,
+                    "_branch_scope": f"split#{idx}",
+                },
+                ctx,
+            )
+            if _public_outputs(out):
+                passed.append(symbol)
+
+        # 스코프가 없으면 두 번째 종목이 첫 종목의 쿨다운에 걸려 버려진다
+        assert passed == ["005930", "000660"]
+
+
+class TestRealtimeBranchRowShape:
+    """실시간 분기가 수집하는 값은 표가 렌더할 수 있는 **평평한 행**이어야 한다.
+
+    회귀 방지: 예전엔 공개 포트 중 dict 순서상 첫 번째를 집어서, 시세 노드가 `symbols`
+    를 먼저 쓰면 가격 대신 종목코드 목록이 표에 실렸다(비결정 + 잘못된 데이터).
+    """
+
+    def test_item_symbol_extraction(self):
+        from programgarden.executor import _item_symbol
+
+        assert _item_symbol({"symbol": "005930"}) == "005930"
+        assert _item_symbol("005930") == "005930"
+        assert _item_symbol({"qty": 3}) is None
+
+    def test_slice_merged_realtime_outputs_per_symbol(self):
+        from programgarden.executor import _slice_realtime_outputs
+
+        bar_a = {"date": "20260714", "close": 263500, "volume": 33325135}
+        bar_b = {"date": "20260714", "close": 1901000, "volume": 9114265}
+        merged = {
+            "symbols": [{"symbol": "005930"}, {"symbol": "000660"}],
+            "ohlcv_data": {"005930": [bar_a], "000660": [bar_b]},
+            "data": {"005930": [bar_a], "000660": [bar_b]},
+        }
+
+        sliced = _slice_realtime_outputs(merged, "005930")
+
+        assert sliced["ohlcv_data"] == [bar_a]
+        assert sliced["data"] == [bar_a]
+        assert sliced["symbols"] == [{"symbol": "005930"}]
+
+    def test_row_carries_price_not_symbol_list(self):
+        from programgarden.executor import _realtime_branch_row
+
+        bar = {"date": "20260714", "close": 263500, "volume": 33325135}
+        public = {
+            "symbols": [{"symbol": "005930"}],  # dict 순서상 첫 포트 — 예전엔 이게 행이 됐다
+            "ohlcv_data": [bar],
+            "data": [bar],
+        }
+
+        row = _realtime_branch_row(public, "005930")
+
+        assert row == {"symbol": "005930", **bar}
+        assert row["close"] == 263500
+
+    def test_no_row_when_no_payload(self):
+        from programgarden.executor import _realtime_branch_row
+
+        assert _realtime_branch_row({"symbols": [{"symbol": "005930"}]}, "005930") is None
+
+
+class TestRealtimeSplitBranchFillsTablePerSymbol:
+    """Split → 실시간시세 → Throttle → Aggregate 가 **종목당 1행**을 채운다 (통합).
+
+    실제 `_execute_split_branch` / `_execute_branch_for_item` / ThrottleNodeExecutor 를 그대로
+    돌린다. 시세 노드는 이미 구독된 상태(출력 있음)로 심어 두므로 재실행되지 않는다 —
+    라이브 소켓 없이 틱 사이클을 재현할 수 있다.
+
+    회귀 방지 대상(2026-07-14 라이브 실측으로 확인된 것):
+      · 틱 경로가 분기를 재구동하지 않아 수집 배열이 t=0 의 []에 얼어붙던 것
+      · 종목들이 시세·쿨다운을 공유해 가격 없는 한 행만 실리던 것
+      · 쿨다운 사이클마다 수집이 비어 표가 깜빡이던 것
+    """
+
+    BAR_A = {"date": "20260714", "open": 255000, "close": 263500, "volume": 33325135}
+    BAR_B = {"date": "20260714", "open": 1825000, "close": 1901000, "volume": 9114265}
+
+    @classmethod
+    def _mk_job(cls):
+        from programgarden.executor import WorkflowJob, ThrottleNodeExecutor
+        from programgarden.context import ExecutionContext
+
+        ctx = ExecutionContext(job_id="j", workflow_id="w")
+        ctx.notify_node_state = AsyncMock()
+
+        # 이미 구독 중인 실시간 시세 노드: 두 종목이 한 덩어리로 합쳐진 출력
+        merged = {"005930": [cls.BAR_A], "000660": [cls.BAR_B]}
+        ctx.set_output("rm", "_pending", True)
+        ctx.set_output("rm", "symbols", [{"symbol": "005930"}, {"symbol": "000660"}])
+        ctx.set_output("rm", "ohlcv_data", merged)
+        ctx.set_output("rm", "data", merged)
+
+        class _Edge:
+            def __init__(self, f, t):
+                self.from_node_id, self.to_node_id = f, t
+
+        class _Node:
+            def __init__(self, node_type, config=None):
+                self.node_type = node_type
+                self.config = config or {}
+                self.plugin = None
+                self.fields = None
+
+        job = MagicMock(spec=WorkflowJob)
+        job.context = ctx
+        job._execute_split_branch = WorkflowJob._execute_split_branch.__get__(job)
+        job._execute_branch_for_item = WorkflowJob._execute_branch_for_item.__get__(job)
+        job._get_branch_nodes = MagicMock(return_value={"rm", "throttle"})
+        job._resolve_config_expressions = lambda cfg, node_id: cfg
+        job._auto_inject_connection = lambda node_id, node, cfg: cfg
+        job._execute_aggregate_node = AsyncMock()
+
+        wf = MagicMock()
+        wf.edges = [_Edge("split", "rm"), _Edge("rm", "throttle"), _Edge("throttle", "agg")]
+        wf.execution_order = ["split", "rm", "throttle", "agg"]
+        wf.nodes = {
+            "split": _Node("SplitNode"),
+            "rm": _Node("KoreaStockRealMarketDataNode"),
+            "throttle": _Node("ThrottleNode"),
+            "agg": _Node("AggregateNode"),
+        }
+        job.workflow = wf
+
+        throttle = ThrottleNodeExecutor()
+
+        async def _execute_node(node_id, node_type, config, context, **kwargs):
+            if node_type == "ThrottleNode":
+                return await throttle.execute(node_id, node_type, config, context)
+            raise AssertionError(f"unexpected node execution: {node_type}")
+
+        job.executor = MagicMock()
+        job.executor.execute_node = _execute_node
+
+        split_node = _Node("SplitNode", {
+            "array": [{"symbol": "005930"}, {"symbol": "000660"}],
+            "parallel": False,
+            "delay_ms": 0,
+            "continue_on_error": True,
+            "mode": "latest",
+        })
+        return job, ctx, split_node
+
+    @pytest.mark.asyncio
+    async def test_each_symbol_becomes_a_priced_row(self):
+        job, ctx, split_node = self._mk_job()
+
+        await job._execute_split_branch("split", split_node, {"split": "agg"}, {"rm", "throttle"})
+
+        rows = ctx.get_node_state("agg", "_collected_items")
+        assert [r["symbol"] for r in rows] == ["005930", "000660"]
+        assert rows[0]["close"] == 263500
+        assert rows[1]["close"] == 1901000
+
+    @pytest.mark.asyncio
+    async def test_table_does_not_blank_out_during_throttle_cooldown(self):
+        job, ctx, split_node = self._mk_job()
+
+        # 사이클 1: 두 종목 모두 통과
+        await job._execute_split_branch("split", split_node, {"split": "agg"}, {"rm", "throttle"})
+        first = ctx.get_node_state("agg", "_collected_items")
+        assert len(first) == 2
+
+        # 사이클 2: 곧바로 재구동 → 기본 쿨다운(5초)에 걸려 새 값 없음.
+        # 그래도 직전 행을 유지해야 한다(표가 빈 표로 깜빡이면 안 된다).
+        await job._execute_split_branch("split", split_node, {"split": "agg"}, {"rm", "throttle"})
+        second = ctx.get_node_state("agg", "_collected_items")
+
+        assert len(second) == 2, "쿨다운 사이클에서 수집이 비어 표가 깜빡인다"
+        assert [r["symbol"] for r in second] == ["005930", "000660"]
+        assert second[0]["close"] == 263500


### PR DESCRIPTION
## 무엇이 문제였나

`Split → 실시간시세 → Throttle → Aggregate → Table` 배선에서 **표가 어느 버전에서도 항상 비어 있었다.**
이 배선은 임의의 형태가 아니라 **실시간 시세 노드의 공식 예제(`_examples`)가 가르치는 형태**이고,
챗봇도 그대로 생성한다(`chatbot-generated-pg-test-9-s3_held_subscribe`). 즉 의도된 설계가 아니라 결함이다.

KRX 장중 라이브로 원인을 3겹으로 분리했다.

| # | 결함 | 라이브 실측 |
|---|---|---|
| 1 | 틱 경로가 **Split 분기를 재구동하지 않음** | `_collected_items` 쓰기 **1회**(t+5.9s, 값 `[]`) · aggregate 29회 재실행 · 수집 **29/29 전부 `[]`** |
| 2 | **Throttle 상류 수집이 프로덕션에서 죽은 코드** | 35초간 Throttle **301회 실행 / 통과 0회** |
| 3 | 분기 아이템(종목)들이 노드를 공유해 **한 덩어리로 섞임** | 수집된 행 = `[{"symbol": "005930"}]` — **가격 없음** |

시세 자체는 멀쩡했다: `real_market` emission **3,106건, 전부 실 OHLCV**(005930 close 263,500 / 000660 close 1,901,000).
표까지 못 갔을 뿐이다.

## 각 결함의 정체

**1. Aggregate 의 유일한 입력을 쓰는 곳이 하나뿐이다.**
`node_state["_collected_items"]` 를 쓰는 곳은 코드베이스 전체에서 `_execute_split_branch` 단 한 곳.
그런데 `_handle_realtime_update` 는 하류를 **일반 노드로만** 재실행한다(SplitNode 특별취급 없음).
→ 수집 배열이 최초 실행 시점 값에 **영구히 얼어붙는다.**

**2. `context._workflow_edges` 는 아무도 설정하지 않는다.**
`_collect_input_data` 의 상류 엣지 워크가 이 속성에 의존하는데, **실행 경로 어디서도 설정되지 않는다**
— 테스트만 주입한다(`test_item_based_execution.py`). 그래서 **테스트는 통과하는데 실제로는 死**.
Throttle 은 실시간 핸들러가 `_realtime_data` 를 직접 꽂아주는 경로에서만 동작했고,
Split 분기 안에서는 시세가 흘러도 영원히 빈 입력 → 영원히 cooldown.

**3. 실시간 노드 하나에 종목이 전부 합쳐진다.**
`ohlcv_data = {"005930": [bar], "000660": [bar]}` — 분기 아이템은 자기 종목만 봐야 하는데 자르지 않았다.
게다가 수집값을 고르는 코드가 공개 포트 중 **dict 순서상 첫 번째**를 집어(비결정) 가격 대신 `symbols` 가 실렸다.
Throttle 쿨다운도 노드별 상태라 종목들이 공유 → 한 사이클에 한 종목만 통과.

## 수정

- 틱 체인이 분기에 닿으면 **해당 Split 분기를 통째로 재구동**한다. 이미 구독을 건 실시간 노드는
  분기 재구동 때 재실행하지 않는다(틱마다 재구독 = 소켓 폭주 방지).
- `_collect_input_data` 가 실행 경로들이 이미 모아두는 **`_input_<node_id>`** 를 읽는다.
- 아이템의 **종목 몫으로 시세를 슬라이스**, payload 포트를 **선언 순서로 명시**,
  Throttle 상태를 **분기 스코프(`split#idx`)로 분리**, 쿨다운에 막힌 종목은 **직전 행을 유지**
  (그러지 않으면 사이클마다 수집이 비어 표가 깜빡인다).

## 검증

**라이브(KRX 장중, 005930/000660)** — 1·2번 수정 후:
- 분기 재구동 **0 → 147회**
- Throttle 통과 **0/301 → 15회**

**테스트**: `1,588 passed / 7 failed / 60 errors` — 실패·에러는 수정 전과 **동일**(회귀 0).
실패 7건은 기존 것(외부 HTTP dry-run flaky, position_sizing 등).

신규 계약·통합 테스트 **8건**:
- 종목별 슬라이스 / payload 포트 명시 / 분기 스코프 쿨다운 / `_input_` 상류 수집
- **통합**: 분기 2사이클을 실제 `_execute_split_branch` + 실제 ThrottleNode 로 구동 →
  **종목당 1행에 실가격**(263,500 / 1,901,000) + **쿨다운 사이클에도 표 유지**(깜빡임 없음)

## 남은 것

- **3번 수정의 라이브 재검증은 다음 KRX 장중(09:00~15:30)** 에 국내 프로브로 수행한다(오늘 장 마감 이후 구현분).
- `parallel=True` 분기는 노드 출력이 node_id 로 공유돼 아이템 간 경합이 남는다 — **기존 위험**이며 이 PR 범위 밖.
