### PR TITLE
release: programgarden 1.29.1 — 실시간 시세 수정(#23·#24)이 빠진 1.29.0 보정

### DIFF
--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.29.0"
+version = "1.29.1"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"


### PR DESCRIPTION
## 왜 필요한가

**PyPI 의 1.29.0 에는 실시간 수정이 들어있지 않다.**

| | 시각(UTC, 2026-07-14) |
|---|---|
| PyPI 1.29.0 업로드 | **04:53** |
| #23 (국내 실시간 死) main 머지 | 07:04 |
| #24 (실시간 표 미충전 3겹) main 머지 | 07:04 |

발행이 머지보다 **2시간 이상 빨랐다.** 따라서 PyPI 1.29.0 은 #22(런타임 배선 3건)만 담고 있고,
아래는 빠져 있다:

- **#23** 국내주식 실시간이 통째로 死 — 이벤트 소스 목록 3곳 드리프트(국내 계열 누락)
- **#24** 실시간 시세 표 미충전 3겹 — Split 분기 미재구동 / Throttle 상류 수집 死코드 / 종목 미분리

PyPI 는 같은 버전 재발행이 불가하므로 **patch bump** 로 보정한다.

## 범위

- `programgarden` 1.29.0 → **1.29.1** (버전만 변경)
- `programgarden-core` 는 **변경 0** → 1.21.0 그대로 (재발행 불필요)

#22 머지 이후 바뀐 건 `src/programgarden/` 뿐이다(core/finance/community 0 files).