### PR TITLE
fix(engine): 실시간 분기 2번째 이후 종목 미구독 + 틱 없는 종목이 덩어리를 행으로 싣던 것 (release 1.29.2)

### DIFF
--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -1040,6 +1040,10 @@ _SYMBOL_ITEM_KEYS = ("symbol", "shcode", "code")
 # 가격 대신 종목코드 목록이 표에 실렸다(비결정 + 잘못된 데이터).
 _BRANCH_PAYLOAD_PORTS = ("result", "value", "data", "ohlcv_data")
 
+# 실시간 노드가 어떤 분기 스코프(종목)까지 구독을 걸었는지 기록하는 node_state 키.
+# 종목마다 최초 1회만 실행하고, 틱마다의 분기 재구동에선 건너뛴다(재구독 폭주 방지).
+_SUBSCRIBED_SCOPES_KEY = "_subscribed_branch_scopes"
+
 
 def _item_symbol(item: Any) -> Optional[str]:
     """Split 아이템에서 종목코드를 뽑는다 ('005930' 또는 {'symbol': '005930'})."""
@@ -1053,21 +1057,50 @@ def _item_symbol(item: Any) -> Optional[str]:
     return None
 
 
+def _is_symbol_keyed_payload(value: Any) -> bool:
+    """`{"005930": [bar], "000660": [bar]}` 처럼 종목코드로 키가 잡힌 시세 payload 인가."""
+    return (
+        isinstance(value, dict)
+        and bool(value)
+        and all(isinstance(v, list) for v in value.values())
+    )
+
+
 def _slice_realtime_outputs(outputs: Dict[str, Any], symbol: str) -> Dict[str, Any]:
-    """실시간 시세 노드의 합쳐진 출력을 한 종목 몫으로 자른다."""
-    sliced: Dict[str, Any] = {}
+    """실시간 시세 노드의 합쳐진 출력을 한 종목 몫으로 자른다.
+
+    **이 종목의 틱이 아직 없으면 공개 포트를 하나도 내지 않는다**(내부 `_` 포트만 남긴다).
+    빈 값이나 `symbols` 목록만 내보내면 Throttle 이 "흘릴 데이터가 있다"고 착각해 통과시키고,
+    표에 **가격 없는 행**이 낀다. 실제로 HKEX 라이브에서 아직 체결이 없던 2번째 종목이
+    합쳐진 덩어리를 그대로 행으로 실어 이 결함이 드러났다(2026-07-14).
+    """
+    meta = {
+        k: v for k, v in outputs.items()
+        if isinstance(k, str) and k.startswith("_")
+    }
+    payload: Dict[str, Any] = {}
+    has_payload = False
+
     for port, value in outputs.items():
+        if isinstance(port, str) and port.startswith("_"):
+            continue
+        if _is_symbol_keyed_payload(value):
+            if symbol in value:
+                payload[port] = value[symbol]
+                has_payload = True
+            # 이 종목 몫이 없으면 그 포트는 **아예 내지 않는다** (덩어리 통과 금지)
+            continue
         if port == "symbol":
-            sliced[port] = symbol
-        elif isinstance(value, dict) and symbol in value:
-            # symbol-keyed dict (ohlcv_data / data) → 이 종목의 값만
-            sliced[port] = value[symbol]
-        elif port == "symbols" and isinstance(value, list):
-            kept = [s for s in value if _item_symbol(s) == symbol]
-            sliced[port] = kept or value
-        else:
-            sliced[port] = value
-    return sliced
+            payload[port] = symbol
+            continue
+        if port == "symbols" and isinstance(value, list):
+            payload[port] = [s for s in value if _item_symbol(s) == symbol]
+            continue
+        payload[port] = value
+
+    if not has_payload:
+        return meta
+    return {**meta, **payload}
 
 
 def _realtime_branch_row(public: Dict[str, Any], symbol: Optional[str]) -> Optional[Dict[str, Any]]:
@@ -18857,12 +18890,22 @@ class WorkflowJob:
             if not node:
                 continue
 
-            # 이미 구독을 건 실시간 노드는 분기 재구동 때 다시 실행하지 않는다.
-            # 재실행하면 틱마다 재구독이 걸려 소켓이 폭주한다. 최신 시세는 틱 콜백이
-            # 이 노드의 context 출력에 계속 갱신해 두므로, 하류는 그걸 그대로 읽으면 된다.
-            # (최초 실행 때는 출력이 없으므로 정상적으로 실행돼 구독이 걸린다.)
-            if node.node_type in REALTIME_NODE_TYPES and self.context.get_all_outputs(node_id):
-                continue
+            is_realtime = node.node_type in REALTIME_NODE_TYPES
+            subscribed: List[str] = []
+            if is_realtime:
+                # 실시간 노드는 **분기 아이템(종목)마다 최초 1회는 반드시 실행**해야 한다
+                # — 그래야 그 종목의 구독이 걸린다. 그 뒤(틱마다의 분기 재구동)엔 실행하지
+                # 않는다: 재실행하면 틱마다 재구독이 걸려 소켓이 폭주한다. 최신 시세는 틱
+                # 콜백이 이 노드의 context 출력에 계속 갱신해 두므로 하류는 그걸 읽으면 된다.
+                #
+                # ⚠️ 예전엔 "출력이 있으면 스킵"으로 판단했는데, 첫 종목이 실행되며 출력을
+                # 남기는 순간 **2번째 이후 종목의 최초 구독까지 건너뛰어** 그 종목엔 시세가
+                # 영영 오지 않았다(HKEX 라이브에서 2번째 종목이 통째로 死, 2026-07-14).
+                subscribed = list(
+                    self.context.get_node_state(node_id, _SUBSCRIBED_SCOPES_KEY) or []
+                )
+                if branch_scope in subscribed:
+                    continue
 
             # Prepare config
             config = dict(node.config)
@@ -18901,15 +18944,26 @@ class WorkflowJob:
             for port_name, value in outputs.items():
                 self.context.set_output(node_id, port_name, value)
 
+            if is_realtime:
+                # 이 종목 구독 완료 — 다음 재구동부터는 이 노드를 건너뛴다
+                subscribed.append(branch_scope)
+                self.context.set_node_state(node_id, _SUBSCRIBED_SCOPES_KEY, subscribed)
+
             # Track last result — only from PUBLIC ports. Internal meta
             # (_throttle_stats 등)이 유일 출력일 때 그걸 결과로 집으면 Aggregate/Display
             # 가 내부 통계를 데이터로 렌더한다.
             public = _public_outputs(outputs) if outputs else {}
             last_had_public = bool(public)
             if public:
-                row = _realtime_branch_row(public, symbol) if realtime_branch else None
-                if row is not None:
-                    result = row
+                if realtime_branch:
+                    row = _realtime_branch_row(public, symbol)
+                    if row is None:
+                        # 실시간 분기인데 가격 payload 가 없다(예: symbols 목록만 남음)
+                        # → 이 아이템은 표에 기여할 실데이터가 없다 → skip.
+                        # 그러지 않으면 가격 없는 행이 '실시간 체결가' 표에 낀다.
+                        last_had_public = False
+                    else:
+                        result = row
                 else:
                     result = next(
                         (public[p] for p in _BRANCH_PAYLOAD_PORTS if public.get(p) is not None),

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.29.1"
+version = "1.29.2"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"

--- a/src/programgarden/tests/test_item_based_execution.py
+++ b/src/programgarden/tests/test_item_based_execution.py
@@ -671,6 +671,94 @@ class TestRealtimeBranchRowShape:
 
         assert _realtime_branch_row({"symbols": [{"symbol": "005930"}]}, "005930") is None
 
+    def test_symbol_without_tick_yet_yields_no_public_port(self):
+        """아직 틱이 없는 종목은 **공개 포트를 하나도 받으면 안 된다.**
+
+        회귀 방지 (2026-07-14 HKEX 라이브에서 발견): 예전엔 내 종목이 symbol-keyed dict 에
+        없으면 **합쳐진 덩어리를 그대로 통과**시켰고, 그게 표의 한 행이 됐다
+        (`{"HMHN26": [{...}]}` 가 HMCEN26 의 행으로 실림). 빈 값이나 symbols 목록만 내보내도
+        Throttle 이 '흘릴 데이터 있음'으로 착각해 통과시켜 가격 없는 행이 낀다.
+        """
+        from programgarden.executor import _slice_realtime_outputs, _public_outputs
+
+        bar = {"date": "20260714", "close": 24347.0, "volume": 113310}
+        outputs = {
+            "_pending": True,
+            "symbols": [{"symbol": "HMHN26"}, {"symbol": "HMCEN26"}],
+            "ohlcv_data": {"HMHN26": [bar]},   # HMCEN26 은 아직 체결 없음
+            "data": {"HMHN26": [bar]},
+        }
+
+        sliced = _slice_realtime_outputs(outputs, "HMCEN26")
+
+        assert _public_outputs(sliced) == {}, "틱 없는 종목에 공개 데이터가 새어나갔다"
+        assert sliced.get("_pending") is True  # 내부 신호는 유지
+
+        # 틱이 있는 종목은 정상적으로 자기 몫을 받는다
+        ok = _slice_realtime_outputs(outputs, "HMHN26")
+        assert ok["ohlcv_data"] == [bar]
+
+
+class TestRealtimeNodeSubscribesEveryBranchItem:
+    """실시간 노드는 **분기 아이템(종목)마다 최초 1회 실행**돼야 한다 — 그래야 구독이 걸린다.
+
+    회귀 방지 (2026-07-14 HKEX 라이브에서 발견): 재구독 폭주를 막는 가드를 "출력이 있으면
+    스킵"으로 걸었더니, 첫 종목이 실행되며 출력을 남기는 순간 **2번째 이후 종목의 최초 구독까지
+    건너뛰어** 그 종목엔 시세가 영영 오지 않았다. 스킵 판단은 **분기 스코프별**이어야 한다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_second_symbol_also_subscribes_then_redrive_skips(self):
+        from programgarden.executor import WorkflowJob, REALTIME_NODE_TYPES
+        from programgarden.context import ExecutionContext
+
+        ctx = ExecutionContext(job_id="j", workflow_id="w")
+        ctx.notify_node_state = AsyncMock()
+
+        class _Edge:
+            def __init__(self, f, t):
+                self.from_node_id, self.to_node_id = f, t
+
+        class _Node:
+            def __init__(self, node_type):
+                self.node_type = node_type
+                self.config = {}
+                self.plugin = None
+                self.fields = None
+
+        job = MagicMock(spec=WorkflowJob)
+        job.context = ctx
+        job._execute_branch_for_item = WorkflowJob._execute_branch_for_item.__get__(job)
+        job._resolve_config_expressions = lambda cfg, node_id: cfg
+        job._auto_inject_connection = lambda node_id, node, cfg: cfg
+
+        wf = MagicMock()
+        wf.edges = [_Edge("split", "rm")]
+        wf.nodes = {"split": _Node("SplitNode"), "rm": _Node("OverseasFuturesRealMarketDataNode")}
+        job.workflow = wf
+        assert "OverseasFuturesRealMarketDataNode" in REALTIME_NODE_TYPES
+
+        subscribed = []
+
+        async def _execute_node(node_id, node_type, config, context, **kwargs):
+            subscribed.append(config.get("_branch_scope"))
+            return {"_pending": True}
+
+        job.executor = MagicMock()
+        job.executor.execute_node = _execute_node
+
+        items = [{"symbol": "HMHN26"}, {"symbol": "HMCEN26"}]
+
+        # 최초 분기: 두 종목 **모두** 구독돼야 한다
+        for idx, item in enumerate(items):
+            await job._execute_branch_for_item("split", ["rm"], item, idx, len(items))
+        assert subscribed == ["split#0", "split#1"], "2번째 종목이 구독되지 않았다"
+
+        # 틱에 의한 분기 재구동: 이미 구독한 종목은 다시 실행하지 않는다 (재구독 폭주 방지)
+        for idx, item in enumerate(items):
+            await job._execute_branch_for_item("split", ["rm"], item, idx, len(items))
+        assert subscribed == ["split#0", "split#1"], "재구동에서 재구독이 일어났다"
+
 
 class TestRealtimeSplitBranchFillsTablePerSymbol:
     """Split → 실시간시세 → Throttle → Aggregate 가 **종목당 1행**을 채운다 (통합).
@@ -739,6 +827,10 @@ class TestRealtimeSplitBranchFillsTablePerSymbol:
         async def _execute_node(node_id, node_type, config, context, **kwargs):
             if node_type == "ThrottleNode":
                 return await throttle.execute(node_id, node_type, config, context)
+            if node_type == "KoreaStockRealMarketDataNode":
+                # 실제 시세 노드처럼: 종목마다 최초 1회 실행돼 구독을 걸고 _pending 만 낸다.
+                # (틱 데이터는 이미 context 에 심어둔 것 = 소켓이 채워준 상태)
+                return {"_pending": True}
             raise AssertionError(f"unexpected node execution: {node_type}")
 
         job.executor = MagicMock()


### PR DESCRIPTION
## 라이브가 잡아낸 결함 — 둘 다 #24 가 넣은 것

**HKEX 해외선물 모의투자 라이브 검증**(데이 세션, 챗봇과 동일한 Split 배선)에서 발견했다.

### 1. 분기 2번째 이후 종목이 **구독조차 되지 않았다**

재구독 폭주를 막는 가드를 `이 노드에 출력이 있으면 스킵` 으로 걸었는데, 첫 종목이 실행되며
`_pending` 출력을 남기는 순간 **2번째 이후 종목의 최초 구독까지 건너뛰었다** → 그 종목엔 시세가 영영 안 온다.

→ 스킵 판단을 **분기 스코프(`split#idx`)별**로. 종목마다 **최초 1회는 반드시 실행(=구독)**,
틱에 의한 재구동에서만 건너뛴다.

### 2. 틱이 아직 없는 종목이 **합쳐진 덩어리를 행으로** 실었다

슬라이서가 내 종목이 symbol-keyed dict 에 없으면 덩어리를 그대로 통과시켰다 →
`{"HMHN26": [{...}]}` 가 **HMCEN26 의 행**으로 표에 실림.

→ 그 종목 몫이 없으면 **공개 포트를 하나도 내지 않는다**(내부 `_` 신호만). 빈 값이나 symbols 목록만
내보내도 Throttle 이 '흘릴 데이터 있음'으로 착각해 통과시켜 **가격 없는 행**이 끼므로,
실시간 분기에서 payload 가 없으면 아이템을 skip 한다.

## 라이브 검증 (HKEX 선물 모의투자, 2026-07-14 데이 세션)

**수정 전** — 표 2행:
```
{date, open:24201, high:24442, low:23889, close:24347, volume:113310, symbol:"HMHN26"}   ← 정상
{"HMHN26": [{...}]}                                                                      ← 덩어리(HMCEN26 미구독)
```

**수정 후** — 표 2행, **종목당 1행 + 실가격**:
```
HMHN26   open 24,201  high 24,442  low 23,889  close 24,347  volume 113,310
HMCEN26  open  8,069  high  8,139  low  7,954  close  8,107  volume   8,644
```
① 종목당 1행 ✅  ② 실가격 ✅  ③ 쿨다운 중 깜빡임 없음 ✅  ④ job running 유지 ✅

## 테스트

1,588 passed — 실패·에러 **수정 전과 동일**(회귀 0; 차이는 기존 flaky HTTP dry-run 1건).
신규 회귀 테스트 2건: **분기 스코프별 구독**(2번째 종목도 구독 + 재구동 시 재구독 없음),
**틱 없는 종목은 공개 포트 0**(덩어리 유출 금지).

## ⚠️ 릴리스 1.29.2 — 같은 PR 에 포함

**PyPI 의 1.29.1 은 위 결함 2건을 그대로 담고 있다.** 다종목 실시간 표에서는 오히려 **잘못된 표**를 낸다.
릴리스를 별도 PR 로 분리하면 또 누락될 수 있어(1.29.0 이 실제로 그렇게 됐다) **수정과 같은 PR** 에 bump 를 넣었다.
`programgarden-core` 는 변경 0 → 1.21.0 그대로.