### PR TITLE
fix(executor): surface order failures + wire orders_placed/filled + confirm fills (DEF-21/26/27)

### DIFF
--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -112,6 +112,60 @@ def _order_failure_from_outputs(outputs: Any) -> Optional[str]:
     return f"{label}: {' — '.join(parts)}" if parts else str(label)
 
 
+def _orders_placed_from_outputs(outputs: Any) -> int:
+    """Return how many orders this node successfully *submitted* (accepted).
+
+    DEF-26: the job's ``orders_placed`` stat was initialised to 0 and never
+    incremented, so the dashboard/monitoring always reported "0 orders placed"
+    even after a real fill. This derives the submitted count from the node's
+    ``order_result``:
+
+    - single-order shape (``_order_result``): 1 when ``success is True`` (an
+      order number came back = accepted), else 0.
+    - batch shape (``success_count``): that count (defensive — currently unused
+      by the live single-order path).
+    - non-order nodes / failed orders / no_signal: 0.
+
+    "Submitted" means accepted by the broker (order number returned), NOT
+    filled — see :func:`_orders_filled_from_outputs` for fills (DEF-27).
+    """
+    if not isinstance(outputs, dict):
+        return 0
+    result = outputs.get("order_result")
+    if not isinstance(result, dict):
+        return 0
+    if "success_count" in result:
+        try:
+            return max(0, int(result.get("success_count") or 0))
+        except (TypeError, ValueError):
+            return 0
+    return 1 if result.get("success") is True else 0
+
+
+def _orders_filled_from_outputs(outputs: Any) -> int:
+    """Return how many orders this node confirmed as *fully filled*.
+
+    DEF-26/DEF-27: ``orders_filled`` was a dead counter, and the engine
+    reported a bare "submitted" (order accepted) as if the order had traded.
+    An order only counts here when a post-submission re-query confirmed a
+    complete fill (``order_result.status == "filled"``, set by
+    :meth:`NewOrderNodeExecutor._confirm_order_fill`). ``submitted`` / ``open``
+    / ``partially_filled`` deliberately do NOT count — an accepted-but-unfilled
+    order must never inflate the fill counter.
+    """
+    if not isinstance(outputs, dict):
+        return 0
+    result = outputs.get("order_result")
+    if not isinstance(result, dict):
+        return 0
+    if "filled_count" in result:
+        try:
+            return max(0, int(result.get("filled_count") or 0))
+        except (TypeError, ValueError):
+            return 0
+    return 1 if (result.get("status") == "filled" and result.get("success") is True) else 0
+
+
 def _free_root_names(text: str) -> Set[str]:
     """Return the set of free-variable root identifiers referenced (ctx=Load) by
     every ``{{ ... }}`` expression embedded in ``text``.
@@ -13562,6 +13616,20 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                 context.log("error", f"{node_type}: Unsupported product: {product}", node_id)
                 return self._error_result(f"Unsupported product: {product}")
 
+            # === 5.4. DEF-27: 접수(order number) ≠ 체결. 주문 TR 응답은 주문번호만
+            # 돌려주므로, 방금 접수된 주문의 체결 여부를 best-effort 로 재조회해
+            # order_result.status 를 submitted → filled / partially_filled / open
+            # 으로 승격하고 filled_quantity / filled_count 를 붙인다. 순수 관측용 —
+            # 재조회가 실패해도 접수 성공(success=True)은 절대 뒤집지 않는다. ===
+            if (
+                isinstance(order_result, dict)
+                and isinstance(order_result.get("order_result"), dict)
+                and order_result["order_result"].get("success") is True
+            ):
+                await self._confirm_order_fill(
+                    ls, product, order_type, order_result, config, context, node_id
+                )
+
             # === 5.5. A-4: 성공 주문 idempotency 레지스트리에 기록 ===
             context.record_order_submitted(
                 node_id=node_id,
@@ -14084,6 +14152,259 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                 
         except Exception as e:
             context.log("warning", f"Failed to sync fills after market order: {e}", node_id)
+
+    async def _confirm_order_fill(
+        self,
+        ls,
+        product: str,
+        order_type: str,
+        order_result: Dict[str, Any],
+        config: Dict[str, Any],
+        context: ExecutionContext,
+        node_id: str,
+    ) -> None:
+        """Best-effort post-submission fill confirmation (DEF-27).
+
+        A broker order TR returns the order number only (= accepted), never a
+        fill. This re-queries the order right after submission and upgrades
+        ``order_result['order_result']`` in place:
+
+        - ``status``: submitted → ``filled`` / ``partially_filled`` / ``open``
+        - adds ``filled_quantity`` / ``fill_price`` / ``filled_count``
+
+        Purely additive observability: it never raises and never flips
+        ``success``. If the re-query errors or the order is not found, the
+        order stays reported as accepted with ``status="open"`` (honest
+        "accepted, not confirmed filled").
+
+        Fills are recorded a few seconds after the accept ack, so every order is
+        polled over a short bounded window (fill_confirm_attempts ×
+        fill_confirm_delay_seconds), breaking as soon as the fill lands; an order
+        still unfilled at the end is reported "open". Per-product re-query TR:
+        korea_stock=t0425, overseas_stock=COSAQ00102, overseas_futures/option=CIDBQ02400.
+        """
+        try:
+            inner = order_result.get("order_result", {})
+            order_id = str(order_result.get("order_id") or inner.get("order_id") or "")
+            if not order_id:
+                return
+            if product not in (
+                "korea_stock", "overseas_stock", "overseas_futures", "overseas_futureoption",
+            ):
+                return  # unknown product: no fill re-query — leave as submitted
+
+            try:
+                ordered_qty = int(inner.get("quantity") or 0)
+            except (TypeError, ValueError):
+                ordered_qty = 0
+
+            # A fill is recorded to the day's order/fill query a few seconds AFTER
+            # the accept ack — even for a marketable order (live-observed on HKEX
+            # futures paper: an immediate re-query still shows unfilled). So poll a
+            # short bounded window for every order type, breaking as soon as the
+            # fill lands. A genuinely resting limit order simply exhausts the window
+            # and is reported "open" (honest). Both knobs are configurable; set
+            # fill_confirm_attempts=1 to disable polling for latency-sensitive flows.
+            try:
+                attempts = int(config.get("fill_confirm_attempts", 4))
+            except (TypeError, ValueError):
+                attempts = 4
+            try:
+                delay = float(config.get("fill_confirm_delay_seconds", 2.0))
+            except (TypeError, ValueError):
+                delay = 2.0
+            attempts = max(1, attempts)
+
+            symbol = inner.get("symbol", "")
+            filled_qty, fill_price = 0, 0.0
+            for i in range(attempts):
+                # Query immediately first (catches an already-recorded fill at no
+                # cost), then wait between retries for the lagged fill to land.
+                if i > 0:
+                    await asyncio.sleep(delay)
+                if product == "korea_stock":
+                    filled_qty, fill_price = await self._query_korea_fill(
+                        ls, order_id, symbol, context, node_id
+                    )
+                elif product == "overseas_stock":
+                    filled_qty, fill_price = await self._query_overseas_stock_fill(
+                        ls, order_id, context, node_id
+                    )
+                else:  # overseas_futures / overseas_futureoption
+                    filled_qty, fill_price = await self._query_overseas_futures_fill(
+                        ls, order_id, context, node_id
+                    )
+                if ordered_qty > 0 and filled_qty >= ordered_qty:
+                    break
+
+            if ordered_qty > 0 and filled_qty >= ordered_qty:
+                inner["status"] = "filled"
+                inner["filled_count"] = 1
+            elif filled_qty > 0:
+                inner["status"] = "partially_filled"
+                inner["filled_count"] = 0
+            else:
+                inner["status"] = "open"
+                inner["filled_count"] = 0
+            inner["filled_quantity"] = filled_qty
+            if fill_price > 0:
+                inner["fill_price"] = fill_price
+
+            context.log(
+                "info",
+                f"Fill confirm: order {order_id} → {inner['status']} "
+                f"({filled_qty}/{ordered_qty})",
+                node_id,
+            )
+        except Exception as e:
+            # Best-effort: a re-query failure must not disturb the (successful)
+            # order submission. Leave order_result untouched (status stays
+            # "submitted").
+            context.log("debug", f"Fill confirmation skipped (best-effort): {e}", node_id)
+
+    async def _query_korea_fill(
+        self,
+        ls,
+        order_id: str,
+        symbol: str,
+        context: ExecutionContext,
+        node_id: str,
+    ) -> tuple:
+        """Return ``(filled_qty, avg_fill_price)`` for a korea_stock order via
+        t0425 (당일 체결/미체결 조회). ``(0, 0.0)`` when not found or on error."""
+        try:
+            from programgarden_finance.ls.korea_stock.accno.t0425.blocks import T0425InBlock
+
+            # expcode 는 빈값(전체 종목)으로 둔다 — 주문번호(ordno)가 authoritative
+            # 매칭 키이고, 심볼 포맷 차이('005930' vs 'A005930' 등)로 내 주문을
+            # 놓치는 것을 피한다. symbol 인자는 로깅/시그니처 호환용으로만 유지.
+            _ = symbol
+            response = await ls.korea_stock().accno().t0425(
+                body=T0425InBlock(
+                    expcode="",           # 전체 종목 (ordno 로 매칭)
+                    chegb="0",            # 0: 전체(체결+미체결) — 상태 판정에 필요
+                    medosu="0",           # 0: 전체
+                    sortgb="1",           # 1: 주문번호 역순(방금 낸 주문이 앞쪽)
+                    cts_ordno="",
+                )
+            ).req_async()
+
+            if getattr(response, "error_msg", None):
+                context.log("debug", f"t0425 fill query error: {response.error_msg}", node_id)
+                return 0, 0.0
+
+            for item in getattr(response, "block", None) or []:
+                if str(getattr(item, "ordno", "")) == order_id:
+                    filled_qty = int(getattr(item, "cheqty", 0) or 0)
+                    fill_price = float(getattr(item, "cheprice", 0) or 0)
+                    return filled_qty, fill_price
+            return 0, 0.0
+        except Exception as e:
+            context.log("debug", f"t0425 fill query exception: {e}", node_id)
+            return 0, 0.0
+
+    async def _query_overseas_stock_fill(
+        self,
+        ls,
+        order_id: str,
+        context: ExecutionContext,
+        node_id: str,
+    ) -> tuple:
+        """Return ``(filled_qty, avg_fill_price)`` for an overseas_stock order
+        via COSAQ00102 (주문체결내역조회, 체결분만). ``(0, 0.0)`` when not found
+        or on error."""
+        try:
+            from programgarden_finance import COSAQ00102
+            from datetime import datetime as _dt
+
+            today = _dt.now().strftime("%Y%m%d")
+            response = ls.overseas_stock().accno().cosaq00102(
+                body=COSAQ00102.COSAQ00102InBlock1(
+                    RecCnt=1,
+                    QryTpCode="1",       # 계좌별
+                    BkseqTpCode="1",     # 역순
+                    OrdMktCode="00",     # 전체 시장
+                    BnsTpCode="0",       # 전체(매수/매도)
+                    IsuNo="",            # 전체 종목
+                    SrtOrdNo=999999999,  # 역순 시작
+                    OrdDt=today,
+                    ExecYn="1",          # 1: 체결만
+                    CrcyCode="000",      # 전체 통화
+                    ThdayBnsAppYn="0",
+                    LoanBalHldYn="0",
+                ),
+            )
+            result = await response.req_async()
+            if not result or not getattr(result, "block3", None):
+                return 0, 0.0
+
+            filled_qty = 0
+            amount = 0.0
+            for item in result.block3:
+                if str(getattr(item, "OrdNo", 0)) != order_id:
+                    continue
+                q = int(getattr(item, "ExecQty", 0) or 0)
+                p = float(
+                    getattr(item, "OvrsExecPrc", 0) or getattr(item, "OvrsOrdPrc", 0) or 0
+                )
+                filled_qty += q
+                amount += q * p
+            avg_price = (amount / filled_qty) if filled_qty > 0 else 0.0
+            return filled_qty, avg_price
+        except Exception as e:
+            context.log("debug", f"COSAQ00102 fill query exception: {e}", node_id)
+            return 0, 0.0
+
+    async def _query_overseas_futures_fill(
+        self,
+        ls,
+        order_id: str,
+        context: ExecutionContext,
+        node_id: str,
+    ) -> tuple:
+        """Return ``(filled_qty, avg_fill_price)`` for an overseas_futures/option
+        order via CIDBQ02400 (당일 주문체결내역, 전체). ``(0, 0.0)`` when not
+        found or on error. Also covers HKEX-futures paper accounts."""
+        try:
+            from programgarden_finance.ls.overseas_futureoption.accno.CIDBQ02400.blocks import (
+                CIDBQ02400InBlock1,
+            )
+            from datetime import datetime as _dt
+
+            today = _dt.now().strftime("%Y%m%d")
+            response = await ls.overseas_futureoption().accno().CIDBQ02400(
+                body=CIDBQ02400InBlock1(
+                    IsuCodeVal="",          # 전체 종목
+                    QrySrtDt=today,
+                    QryEndDt=today,
+                    ThdayTpCode="1",        # 1: 당일조회
+                    OrdStatCode="0",        # 0: 전체(체결+미체결) — 상태 판정에 필요
+                    BnsTpCode="0",          # 0: 전체
+                    QryTpCode="1",          # 1: 역순(방금 낸 주문이 앞쪽)
+                    OrdPtnCode="00",        # 00: 전체
+                    OvrsDrvtFnoTpCode="A",  # A: 전체(선물+옵션)
+                )
+            ).req_async()
+
+            if getattr(response, "error_msg", None):
+                context.log("debug", f"CIDBQ02400 fill query error: {response.error_msg}", node_id)
+                return 0, 0.0
+
+            # block2 = 주문/체결 상세 (한 주문에 다중 체결이면 행이 여럿 → ExecQty 합산)
+            filled_qty = 0
+            amount = 0.0
+            for item in getattr(response, "block2", None) or []:
+                if str(getattr(item, "OvrsFutsOrdNo", "")) != order_id:
+                    continue
+                q = int(getattr(item, "ExecQty", 0) or 0)
+                p = float(getattr(item, "AbrdFutsExecPrc", 0) or 0)
+                filled_qty += q
+                amount += q * p
+            avg_price = (amount / filled_qty) if filled_qty > 0 else 0.0
+            return filled_qty, avg_price
+        except Exception as e:
+            context.log("debug", f"CIDBQ02400 fill query exception: {e}", node_id)
+            return 0, 0.0
 
     async def _execute_overseas_futures(
         self,
@@ -18267,6 +18588,15 @@ class WorkflowJob:
                 # it: FAILED node state + job stats + an error log line. no_signal
                 # ("no trading signal today") is a normal no-op and is excluded.
                 order_failure = _order_failure_from_outputs(outputs)
+
+                # DEF-26/DEF-27: wire the previously-dead orders_placed /
+                # orders_filled counters. placed = orders this node actually
+                # submitted (accepted by the broker); filled = orders a
+                # post-submit re-query confirmed as fully traded. Both are 0 for
+                # non-order nodes and for failed orders, so this is safe to run
+                # unconditionally for every node.
+                self.stats["orders_placed"] += _orders_placed_from_outputs(outputs)
+                self.stats["orders_filled"] += _orders_filled_from_outputs(outputs)
 
                 # deep_validate: promote it to a blocking structured error so the
                 # chatbot learns its order wiring is broken at *build* time instead

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -77,6 +77,41 @@ REALTIME_NODE_TYPES: frozenset = frozenset({
 })
 
 
+def _order_failure_from_outputs(outputs: Any) -> Optional[str]:
+    """Return a human-readable reason if an order node *failed without raising*.
+
+    Order nodes never raise on failure — they return ``order_result.success=False``
+    with an :class:`EmptyOrderReason`. A node that returns normally is reported as
+    COMPLETED with ``errors_count=0`` and ``last_error=None``, so "the order never
+    went out" leaves **no trace on any observable surface**: the dashboard, the
+    monitoring page and the user all see a clean run. In automated trading that is
+    the single most dangerous failure mode.
+
+    ``no_signal`` ("no trading signal today") is a legitimate no-op and is NOT a
+    failure. Every other reason (``fetch_failed``, ``no_symbol``, or an explicit
+    ``error`` with no reason at all) means an order was supposed to go out and
+    didn't — surface it.
+
+    Returns None when there is nothing wrong.
+    """
+    if not isinstance(outputs, dict):
+        return None
+    result = outputs.get("order_result")
+    if not isinstance(result, dict) or result.get("success") is not False:
+        return None
+
+    reason = result.get("reason")
+    if reason == EmptyOrderReason.NO_SIGNAL.value:
+        return None
+
+    parts = [
+        str(p) for p in (result.get("message"), result.get("detail"), result.get("error"))
+        if p
+    ]
+    label = reason or "order_failed"
+    return f"{label}: {' — '.join(parts)}" if parts else str(label)
+
+
 def _free_root_names(text: str) -> Set[str]:
     """Return the set of free-variable root identifiers referenced (ctx=Load) by
     every ``{{ ... }}`` expression embedded in ``text``.
@@ -18225,6 +18260,44 @@ class WorkflowJob:
                         },
                     )
 
+                # An order node that failed did NOT raise — it returned
+                # order_result.success=False. Reporting that as COMPLETED leaves
+                # errors_count=0 / last_error=None, i.e. every observable surface
+                # says the run succeeded while no order actually went out. Surface
+                # it: FAILED node state + job stats + an error log line. no_signal
+                # ("no trading signal today") is a normal no-op and is excluded.
+                order_failure = _order_failure_from_outputs(outputs)
+
+                # deep_validate: promote it to a blocking structured error so the
+                # chatbot learns its order wiring is broken at *build* time instead
+                # of shipping a workflow whose order silently never fires.
+                if (
+                    order_failure
+                    and getattr(self.context, "is_deep_validate", False)
+                    and node_id not in self._node_error_infos
+                ):
+                    from programgarden_core import (
+                        ErrorCode,
+                        ErrorLocation,
+                        build_error,
+                    )
+                    self._node_error_infos[node_id] = build_error(
+                        ErrorCode.DEEP_VALIDATION_NODE_ERROR,
+                        f"Node '{node_id}' ({node.node_type}) placed no order: "
+                        f"{order_failure}",
+                        location=ErrorLocation(node_id=node_id, node_type=node.node_type),
+                        suggestion=(
+                            "주문 노드가 주문을 내지 못했습니다. 상류 노드의 출력이 이 노드의 "
+                            "주문 입력(order/orders)에 실제로 연결되어 있는지, 표현식이 "
+                            "해소되는지, 수량·종목이 채워지는지 확인하세요."
+                        ),
+                        details={
+                            "raw_message": order_failure,
+                            "deep_validate": True,
+                            "stage": "order_not_placed",
+                        },
+                    )
+
                 # Store outputs
                 for out_port_name, value in outputs.items():
                     self.context.set_output(node_id, out_port_name, value)
@@ -18233,16 +18306,39 @@ class WorkflowJob:
                 # stay_connected 노드는 RUNNING 상태 유지 (계속 실시간 업데이트)
                 duration_ms = (datetime.utcnow() - start_time).total_seconds() * 1000
                 is_stay_connected = node_id in self._stay_connected_nodes
-                
-                await self.context.notify_node_state(
-                    node_id=node_id,
-                    node_type=node.node_type,
-                    state=NodeState.RUNNING if is_stay_connected else NodeState.COMPLETED,
-                    outputs=outputs,
-                    duration_ms=duration_ms,
-                )
+
+                if order_failure:
+                    await self.context.notify_node_state(
+                        node_id=node_id,
+                        node_type=node.node_type,
+                        state=NodeState.FAILED,
+                        outputs=outputs,
+                        error=order_failure,
+                        duration_ms=duration_ms,
+                    )
+                    self.stats["errors_count"] += 1
+                    self.stats["last_error"] = f"{node_id}: {order_failure}"
+                    self.stats["last_error_detail"] = {
+                        "node_id": node_id,
+                        "node_type": node.node_type,
+                        "error": order_failure,
+                        "timestamp": datetime.utcnow().isoformat(),
+                    }
+                    self.context.log(
+                        "error", f"Order not placed by {node_id}: {order_failure}", node_id
+                    )
+                else:
+                    await self.context.notify_node_state(
+                        node_id=node_id,
+                        node_type=node.node_type,
+                        state=NodeState.RUNNING if is_stay_connected else NodeState.COMPLETED,
+                        outputs=outputs,
+                        duration_ms=duration_ms,
+                    )
 
                 # Checkpoint: 노드 완료 추적 + 일회성 워크플로우 노드 완료마다 저장
+                # (실패해도 흐름은 계속한다 — 스케줄 잡이 한 사이클의 주문 실패로
+                #  통째로 죽지 않도록. 관측 표면에는 위에서 이미 실패로 남았다.)
                 self._completed_node_ids.add(node_id)
                 if not self._stay_connected_nodes:
                     await self._save_checkpoint()

--- a/src/programgarden/tests/test_order_failure_observability.py
+++ b/src/programgarden/tests/test_order_failure_observability.py
@@ -26,10 +26,17 @@ fix 이후 계약 (이 테스트가 못 박는 것):
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 
 from programgarden_core import EmptyOrderReason
-from programgarden.executor import _order_failure_from_outputs
+from programgarden.executor import (
+    NewOrderNodeExecutor,
+    _order_failure_from_outputs,
+    _orders_filled_from_outputs,
+    _orders_placed_from_outputs,
+)
 
 
 class TestOrderFailureDetection:
@@ -111,3 +118,267 @@ class TestOrderFailureDetection:
     def test_non_order_nodes_are_untouched(self, outputs):
         """주문 노드가 아닌 출력은 절대 실패로 보지 않는다 (오탐 0)."""
         assert _order_failure_from_outputs(outputs) is None
+
+
+# ── DEF-26: orders_placed / orders_filled 死카운터 배선 ──
+
+
+class TestOrdersPlacedCounter:
+    """orders_placed = 이 노드가 실제로 접수(발주)한 주문 수 (DEF-26)."""
+
+    def test_successful_single_order_counts_one(self):
+        outputs = {
+            "order_result": {
+                "success": True,
+                "status": "submitted",
+                "symbol": "028670",
+                "quantity": 1,
+            },
+            "order_id": "9972",
+        }
+        assert _orders_placed_from_outputs(outputs) == 1
+
+    def test_filled_order_still_counts_as_placed(self):
+        """접수 후 체결로 승격돼도 '접수 1건'은 그대로."""
+        outputs = {
+            "order_result": {"success": True, "status": "filled", "quantity": 1},
+            "order_id": "9972",
+        }
+        assert _orders_placed_from_outputs(outputs) == 1
+
+    def test_failed_order_counts_zero(self):
+        outputs = {"order_result": {"success": False, "error": "rejected"}, "order_id": ""}
+        assert _orders_placed_from_outputs(outputs) == 0
+
+    def test_no_signal_counts_zero(self):
+        outputs = {"order_result": {"success": False, "reason": EmptyOrderReason.NO_SIGNAL.value}}
+        assert _orders_placed_from_outputs(outputs) == 0
+
+    def test_batch_shape_uses_success_count(self):
+        outputs = {"order_result": {"success": True, "success_count": 3, "total": 5}}
+        assert _orders_placed_from_outputs(outputs) == 3
+
+    @pytest.mark.parametrize(
+        "outputs",
+        [{}, None, "x", {"data": [1, 2]}, {"order_result": None}, {"order_result": "weird"}],
+    )
+    def test_non_order_nodes_count_zero(self, outputs):
+        assert _orders_placed_from_outputs(outputs) == 0
+
+
+class TestOrdersFilledCounter:
+    """orders_filled = 재조회로 '완전 체결'이 확인된 주문 수만 (DEF-26/DEF-27)."""
+
+    def test_filled_status_counts_one(self):
+        outputs = {"order_result": {"success": True, "status": "filled", "filled_count": 1}}
+        assert _orders_filled_from_outputs(outputs) == 1
+
+    def test_submitted_but_unconfirmed_counts_zero(self):
+        """DEF-27 핵심: 접수만 됐고 체결 미확인이면 filled 로 세면 안 된다."""
+        outputs = {"order_result": {"success": True, "status": "submitted"}}
+        assert _orders_filled_from_outputs(outputs) == 0
+
+    def test_open_counts_zero(self):
+        outputs = {"order_result": {"success": True, "status": "open", "filled_count": 0}}
+        assert _orders_filled_from_outputs(outputs) == 0
+
+    def test_partially_filled_counts_zero(self):
+        """부분체결은 '완전 체결'이 아니므로 filled 카운터에 넣지 않는다."""
+        outputs = {
+            "order_result": {
+                "success": True,
+                "status": "partially_filled",
+                "filled_count": 0,
+                "filled_quantity": 3,
+            }
+        }
+        assert _orders_filled_from_outputs(outputs) == 0
+
+    def test_failed_counts_zero(self):
+        outputs = {"order_result": {"success": False, "status": "failed"}}
+        assert _orders_filled_from_outputs(outputs) == 0
+
+    @pytest.mark.parametrize(
+        "outputs", [{}, None, "x", {"order_result": None}, {"data": [1]}]
+    )
+    def test_non_order_nodes_count_zero(self, outputs):
+        assert _orders_filled_from_outputs(outputs) == 0
+
+
+# ── DEF-27: 접수 후 체결 재조회 (submitted → filled/partially_filled/open) ──
+
+
+def _mock_ctx():
+    ctx = MagicMock()
+    ctx.log = MagicMock()
+    return ctx
+
+
+class TestConfirmOrderFill:
+    """_confirm_order_fill 이 order_result.status 를 체결 실측으로 승격하는지 +
+    어떤 경우에도 접수 성공(success)을 뒤집지 않는지 검증."""
+
+    def _executor(self):
+        return NewOrderNodeExecutor()
+
+    def _submitted(self, symbol="028670", qty=1, order_id="9972"):
+        return {
+            "order_result": {
+                "success": True,
+                "status": "submitted",
+                "symbol": symbol,
+                "quantity": qty,
+            },
+            "order_id": order_id,
+        }
+
+    @pytest.mark.asyncio
+    async def test_full_fill_upgrades_to_filled(self, monkeypatch):
+        ex = self._executor()
+
+        async def fake_query(ls, order_id, symbol, context, node_id):
+            return 1, 5270.0
+
+        monkeypatch.setattr(ex, "_query_korea_fill", fake_query)
+        order_result = self._submitted()
+        await ex._confirm_order_fill(
+            MagicMock(), "korea_stock", "market", order_result,
+            {"fill_confirm_delay_seconds": 0}, _mock_ctx(), "ord1",
+        )
+        inner = order_result["order_result"]
+        assert inner["status"] == "filled"
+        assert inner["filled_count"] == 1
+        assert inner["filled_quantity"] == 1
+        assert inner["fill_price"] == 5270.0
+        assert inner["success"] is True  # never flipped
+
+    @pytest.mark.asyncio
+    async def test_no_fill_marks_open(self, monkeypatch):
+        ex = self._executor()
+
+        async def fake_query(*a, **k):
+            return 0, 0.0
+
+        monkeypatch.setattr(ex, "_query_korea_fill", fake_query)
+        order_result = self._submitted()
+        await ex._confirm_order_fill(
+            MagicMock(), "korea_stock", "limit", order_result,
+            {"fill_confirm_delay_seconds": 0}, _mock_ctx(), "ord1",
+        )
+        inner = order_result["order_result"]
+        assert inner["status"] == "open"
+        assert inner["filled_count"] == 0
+        assert inner["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_partial_fill_marks_partially_filled(self, monkeypatch):
+        ex = self._executor()
+
+        async def fake_query(*a, **k):
+            return 3, 100.0
+
+        monkeypatch.setattr(ex, "_query_korea_fill", fake_query)
+        order_result = self._submitted(symbol="AAA", qty=10, order_id="1")
+        await ex._confirm_order_fill(
+            MagicMock(), "korea_stock", "limit", order_result,
+            {"fill_confirm_delay_seconds": 0, "fill_confirm_attempts": 1}, _mock_ctx(), "ord1",
+        )
+        inner = order_result["order_result"]
+        assert inner["status"] == "partially_filled"
+        assert inner["filled_quantity"] == 3
+        assert inner["filled_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_requery_exception_never_disturbs_submission(self, monkeypatch):
+        """재조회가 터져도 예외 전파 없이 접수 성공을 보존한다 (best-effort 계약)."""
+        ex = self._executor()
+
+        async def boom(*a, **k):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(ex, "_query_korea_fill", boom)
+        order_result = self._submitted()
+        await ex._confirm_order_fill(
+            MagicMock(), "korea_stock", "limit", order_result,
+            {"fill_confirm_delay_seconds": 0}, _mock_ctx(), "ord1",
+        )
+        inner = order_result["order_result"]
+        assert inner["success"] is True
+        assert inner["status"] == "submitted"  # 손대지 않음
+
+    @pytest.mark.asyncio
+    async def test_overseas_futures_full_fill_upgrades_to_filled(self, monkeypatch):
+        """해외선물(HKEX 모의 포함)도 CIDBQ02400 재조회로 체결 확정된다."""
+        ex = self._executor()
+
+        async def fake_query(ls, order_id, context, node_id):
+            return 1, 24680.0
+
+        monkeypatch.setattr(ex, "_query_overseas_futures_fill", fake_query)
+        order_result = self._submitted(symbol="HSIF26", order_id="F1")
+        await ex._confirm_order_fill(
+            MagicMock(), "overseas_futures", "market", order_result,
+            {"fill_confirm_delay_seconds": 0}, _mock_ctx(), "ord1",
+        )
+        inner = order_result["order_result"]
+        assert inner["status"] == "filled"
+        assert inner["filled_count"] == 1
+        assert inner["fill_price"] == 24680.0
+
+    @pytest.mark.asyncio
+    async def test_unknown_product_stays_submitted(self):
+        """알 수 없는 상품은 재조회하지 않고 접수 상태 그대로."""
+        ex = self._executor()
+        order_result = self._submitted(symbol="???", order_id="Z1")
+        await ex._confirm_order_fill(
+            MagicMock(), "mystery_product", "market", order_result,
+            {"fill_confirm_delay_seconds": 0}, _mock_ctx(), "ord1",
+        )
+        assert order_result["order_result"]["status"] == "submitted"
+
+    @pytest.mark.asyncio
+    async def test_query_overseas_futures_fill_sums_execqty(self):
+        """CIDBQ02400 block2 에서 내 주문번호 행들의 ExecQty 를 합산한다(부분체결 다행)."""
+        ex = self._executor()
+        r1 = MagicMock(OvrsFutsOrdNo="F1", ExecQty=1, AbrdFutsExecPrc=24680.0)
+        r2 = MagicMock(OvrsFutsOrdNo="F1", ExecQty=2, AbrdFutsExecPrc=24690.0)
+        r_other = MagicMock(OvrsFutsOrdNo="F9", ExecQty=99, AbrdFutsExecPrc=1.0)
+        resp = MagicMock(error_msg=None, block2=[r1, r_other, r2])
+        req = MagicMock()
+        req.req_async = AsyncMock(return_value=resp)
+        ls = MagicMock()
+        ls.overseas_futureoption.return_value.accno.return_value.CIDBQ02400.return_value = req
+
+        filled, price = await ex._query_overseas_futures_fill(ls, "F1", _mock_ctx(), "ord1")
+        assert filled == 3  # 1 + 2, F9 제외
+        # 가중평균: (1*24680 + 2*24690) / 3
+        assert abs(price - (1 * 24680.0 + 2 * 24690.0) / 3) < 1e-6
+
+    @pytest.mark.asyncio
+    async def test_query_korea_fill_matches_order_in_t0425(self):
+        """t0425 응답에서 내 주문번호 행만 골라 체결수량/가격을 읽는다."""
+        ex = self._executor()
+        row_match = MagicMock(ordno=9972, cheqty=1, cheprice=5270)
+        row_other = MagicMock(ordno=1234, cheqty=99, cheprice=1)
+        resp = MagicMock(error_msg=None, block=[row_other, row_match])
+        req = MagicMock()
+        req.req_async = AsyncMock(return_value=resp)
+        ls = MagicMock()
+        ls.korea_stock.return_value.accno.return_value.t0425.return_value = req
+
+        filled, price = await ex._query_korea_fill(ls, "9972", "028670", _mock_ctx(), "ord1")
+        assert filled == 1
+        assert price == 5270.0
+
+    @pytest.mark.asyncio
+    async def test_query_korea_fill_returns_zero_when_order_absent(self):
+        ex = self._executor()
+        resp = MagicMock(error_msg=None, block=[MagicMock(ordno=1234, cheqty=5, cheprice=10)])
+        req = MagicMock()
+        req.req_async = AsyncMock(return_value=resp)
+        ls = MagicMock()
+        ls.korea_stock.return_value.accno.return_value.t0425.return_value = req
+
+        filled, price = await ex._query_korea_fill(ls, "9972", "028670", _mock_ctx(), "ord1")
+        assert filled == 0
+        assert price == 0.0

--- a/src/programgarden/tests/test_order_failure_observability.py
+++ b/src/programgarden/tests/test_order_failure_observability.py
@@ -1,0 +1,113 @@
+"""주문 실패가 관측 표면에 드러나는지 검증 (DEF-21).
+
+배경 (2026-07-14, S5 E2E — 해외선물 모의 즉시주문):
+    주문 배선이 해소되지 않아 주문이 발주되지 않았다. 엔진은 그 사실을 **정확히
+    알고 있었다** — ``order_result`` 에 사유(``reason: "fetch_failed"``)와 detail 까지
+    담았다. 그런데 관측 표면은 전부 성공을 말했다:
+
+        노드 상태     : completed  (failed 아님)
+        errors_count : 0
+        last_error   : null
+        job status   : completed
+
+    대시보드·모니터링·사용자 눈에는 "워크플로우 정상 완료" 로 보였고, 실제로는
+    매수 주문이 나가지 않았다. 자동매매에서 가장 위험한 실패 모드다.
+
+    원인: 노드는 **예외를 던져야만** FAILED / errors_count 로 잡힌다. 주문 노드는
+    실패를 예외가 아니라 ``order_result.success=False`` 로 *정상 반환*한다.
+
+fix 이후 계약 (이 테스트가 못 박는 것):
+    - ``order_result.success=False`` + reason != no_signal  → 노드 FAILED,
+      errors_count += 1, last_error 기록.
+    - ``reason == "no_signal"``("오늘 신호 없음")은 정상 no-op → completed 유지.
+    - 주문 노드가 아닌 노드(order_result 없음)는 영향 없음.
+    - 흐름은 중단하지 않는다 — 스케줄 잡이 한 사이클의 주문 실패로 죽지 않도록.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from programgarden_core import EmptyOrderReason
+from programgarden.executor import _order_failure_from_outputs
+
+
+class TestOrderFailureDetection:
+    def test_fetch_failed_is_surfaced(self):
+        """상류 파이프라인 고장 — S5 에서 실제로 나온 그 출력."""
+        outputs = {
+            "order_result": {
+                "success": False,
+                "error": "No order to submit",
+                "reason": EmptyOrderReason.FETCH_FAILED.value,
+                "message": "Upstream data fetch failed; no order placed (pipeline error).",
+                "detail": "Order binding was not resolved (unresolved expression: {{ item }})",
+            },
+            "order_id": "",
+        }
+        failure = _order_failure_from_outputs(outputs)
+        assert failure is not None, "주문이 안 나갔는데 실패로 잡히지 않았다"
+        assert "fetch_failed" in failure
+        assert "{{ item }}" in failure, "진단에 필요한 detail 이 사라졌다"
+
+    def test_no_signal_is_not_a_failure(self):
+        """'오늘 신호 없음' 은 정상 no-op — 실패로 오탐하면 안 된다."""
+        outputs = {
+            "order_result": {
+                "success": False,
+                "error": "No order to submit",
+                "reason": EmptyOrderReason.NO_SIGNAL.value,
+                "message": "No trading signal today; nothing to order.",
+                "detail": "",
+            },
+            "order_id": "",
+        }
+        assert _order_failure_from_outputs(outputs) is None
+
+    def test_no_symbol_is_surfaced(self):
+        """종목이 안 채워진 채 주문 노드에 도달 = 설정 오류 → 실패."""
+        outputs = {
+            "order_result": {
+                "success": False,
+                "error": "No order to submit",
+                "reason": EmptyOrderReason.NO_SYMBOL.value,
+                "message": "No symbol resolved; no order placed.",
+                "detail": "",
+            }
+        }
+        failure = _order_failure_from_outputs(outputs)
+        assert failure is not None
+        assert "no_symbol" in failure
+
+    def test_explicit_error_without_reason_is_surfaced(self):
+        """_error_result 경로 — reason 이 아예 없는 실패도 잡는다."""
+        outputs = {
+            "order_result": {"success": False, "error": "LS API rejected: 40510"},
+            "order_id": "",
+        }
+        failure = _order_failure_from_outputs(outputs)
+        assert failure is not None
+        assert "40510" in failure
+
+    def test_successful_order_is_not_a_failure(self):
+        outputs = {
+            "order_result": {"success": True, "order_id": "A0001"},
+            "order_id": "A0001",
+        }
+        assert _order_failure_from_outputs(outputs) is None
+
+    @pytest.mark.parametrize(
+        "outputs",
+        [
+            {},
+            {"data": [1, 2, 3]},
+            {"report": [{"symbol": "AAPL"}]},
+            None,
+            "not-a-dict",
+            {"order_result": None},
+            {"order_result": "weird"},
+        ],
+    )
+    def test_non_order_nodes_are_untouched(self, outputs):
+        """주문 노드가 아닌 출력은 절대 실패로 보지 않는다 (오탐 0)."""
+        assert _order_failure_from_outputs(outputs) is None


### PR DESCRIPTION
## 무엇을 / 왜

자동매매 실행 엔진의 **주문 관측(observability)** 결함 3종을 수정합니다. 세 결함 모두 "주문이 실제로 어떻게 됐는지를 시스템이 스스로 알지 못하거나, 실패/미체결을 성공으로 오보고"하는 문제입니다.

### DEF-21 — 주문 실패가 관측 표면에 안 드러남 (이미 라이브 검증, 국내주식 S3)
주문 노드는 실패 시 예외를 던지지 않고 `order_result.success=False` 를 *정상 반환*한다. 그러면 노드는 `completed`, `errors_count=0`, `last_error=null` 로 남아 **대시보드·모니터링·사용자 눈엔 정상 완료**로 보이지만 실제로는 매수가 안 나갔다(자동매매에서 가장 위험한 실패 모드). → 실패를 노드 `FAILED` + `errors_count` + `last_error` 로 표면화(`no_signal`="오늘 신호 없음"은 정상 no-op 로 제외).

### DEF-26 — `orders_placed` / `orders_filled` 死카운터
두 통계가 `WorkflowJob.stats` 에 초기화만 되고 **어디서도 증가되지 않아** 실제 체결 후에도 항상 `0` 으로 보고됐다. → 노드완료 루프에서 `order_result` 로부터 파생(`_orders_placed_from_outputs` / `_orders_filled_from_outputs`).

### DEF-27 — 접수(order number) ≠ 체결
주문 TR 응답은 **주문번호만**(=접수) 돌려주고, 실제 체결(SC 웹소켓)은 pnl 리스너가 있을 때만 조건부 구독된다(로컬 실행엔 없음). 그래서 "접수"가 "체결"로 오보고됐다. → 주문 노드가 접수 직후 **best-effort 로 체결을 재조회**해 `order_result.status` 를 `submitted → filled / partially_filled / open` 으로 승격하고 `filled_quantity` / `fill_price` 를 붙인다.

## 접근

- **순수 additive** — `executor.py` 삭제 0줄. 기존 동작을 바꾸지 않고 관측 표면만 정확하게.
- **best-effort** — 체결 재조회가 실패해도 접수 성공(`success=True`)은 절대 뒤집지 않는다. `orders_filled` 는 **완전 체결이 확인된 주문만** 센다(접수/미체결/부분체결은 미포함).
- **상품별 체결조회 TR**: `korea_stock`=t0425 · `overseas_stock`=COSAQ00102 · `overseas_futures/option`=CIDBQ02400.
- **체결 지연 대응** — 체결은 접수 ack 후 수 초 뒤 조회 API 에 반영된다(HKEX 선물 모의로 실측). 그래서 모든 주문 유형을 짧은 폴링 창(`fill_confirm_attempts=4` × `fill_confirm_delay_seconds=2.0`, 체결 즉시 종료)으로 확인한다. 창을 다 써도 미체결이면 `open`(정직). 두 값은 노드 config 로 조절 가능(`fill_confirm_attempts=1` 로 폴링 비활성).

## 검증

- **단위테스트**: `test_order_failure_observability.py` 에 29개 신규(카운터 헬퍼, 상품별 체결 분류, best-effort 안전망, t0425/CIDBQ02400 파싱). 전체 스위트의 기존 실패 3건은 이 변경 유무와 무관하게 동일(회귀 0).
- **라이브 검증(HKEX Mini-Hang-Seng 선물 모의계좌, 실제 돈 0)**: marketable-limit BUY+SELL 각각 → `order_result.status` `submitted→filled`, `filled_quantity=1`, `_orders_placed_from_outputs=1`, `_orders_filled_from_outputs=1`. CIDBQ02400 재조회가 실 체결을 정확히 반환. 검증 후 포지션 flat(잔여 없음).
- DEF-21 은 직전 세션에서 국내주식(팬오션 028670 1주 실체결)으로 라이브 검증 완료.

## 릴리스

PyPI 배포는 별도(게이트). 머지 후 릴리스 판단.
