### PR TITLE
fix(executor): A-4 주문 idempotency 死 복구 + Split 분기 주문 node_state 방출

### DIFF
--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -12,6 +12,7 @@ from typing import Optional, Dict, Any, List, Callable, Awaitable, Set, Tuple
 from datetime import datetime
 import asyncio
 import ast
+import copy
 import re
 import uuid
 import logging
@@ -13683,13 +13684,23 @@ class NewOrderNodeExecutor(NodeExecutorBase):
             item=normalized_order,
         )
         if existing_order is not None:
+            _inner = existing_order.get("order_result")
+            _inner = _inner if isinstance(_inner, dict) else {}
             context.log(
                 "info",
                 f"{node_type}: 중복 주문 차단 — idempotency 레지스트리에서 기존 결과 반환 "
-                f"(order_no={existing_order.get('order_no', '?')})",
+                f"(order_no={existing_order.get('order_id') or _inner.get('order_no') or '?'})",
                 node_id,
             )
-            return existing_order
+            # 리플레이 표식: 이 완료 이벤트는 새 주문이 아니라 저장된 결과의 재방출이다.
+            # 리스너(트레이 per-order durable 로그 등)가 이걸 신규 주문으로 재적재하면
+            # 같은 실주문이 로그에 2행 생긴다 — 깊은 복사에 표식을 달아 반환한다
+            # (레지스트리 원본은 불변 유지).
+            replayed = copy.deepcopy(existing_order)
+            if isinstance(replayed.get("order_result"), dict):
+                replayed["order_result"]["idempotent_replay"] = True
+            replayed["idempotent_replay"] = True
+            return replayed
 
         # === 4. LS 로그인 ===
         credential = context.get_credential()
@@ -19492,6 +19503,36 @@ class WorkflowJob:
             for port_name, value in outputs.items():
                 self.context.set_output(node_id, port_name, value)
 
+            # 분기 안 주문 실행 관측성 (2026-08-16): 분기 노드는 메인 루프가 건너뛰어
+            # (⏭ Skipping branch node) node_state 이벤트가 전혀 방출되지 않았다 —
+            # 실주문이 나가도 리스너(트레이 per-order durable 로그·SSE 화면)가 완료를
+            # 못 봤다. 전 노드 방출은 실시간 분기의 틱 재구동에서 이벤트 홍수가 되므로
+            # **주문 결과(order/modify/cancel_result)를 낸 실행에만** COMPLETED 를
+            # 방출한다("제출할 주문 없음" 빈 결과는 제외 — 틱마다 재발화 방지).
+            # 분기 전 노드의 일반 관측성은 SplitNode 시맨틱 개편에서 다룬다.
+            _order_payload = None
+            if isinstance(outputs, dict):
+                for _k in ("order_result", "modify_result", "cancel_result"):
+                    _r = outputs.get(_k)
+                    if isinstance(_r, dict):
+                        _order_payload = _r
+                        break
+            if _order_payload is not None and _order_payload.get("reason") not in (
+                "no_signal", "fetch_failed", "no_symbol"
+            ):
+                try:
+                    await self.context.notify_node_state(
+                        node_id=node_id,
+                        node_type=node.node_type,
+                        state=NodeState.COMPLETED,
+                        outputs=outputs,
+                    )
+                except Exception as _notify_err:
+                    # 관측 실패가 분기 실행(실주문 경로)을 막으면 안 된다.
+                    logger.warning(
+                        f"branch order node_state notify failed: {node_id}: {_notify_err}"
+                    )
+
             if is_realtime:
                 # 이 종목 구독 완료 — 다음 재구동부터는 이 노드를 건너뛴다
                 subscribed.append(branch_scope)
@@ -20637,8 +20678,17 @@ class WorkflowJob:
         """
         if not self._is_order_idempotency_enabled():
             return
-        # 실패한 주문은 기록하지 않음 (재시도 가능해야 함)
-        if not order_result.get('success'):
+        # 실패한 주문은 기록하지 않음 (재시도 가능해야 함).
+        # ⚠️ order_result 는 노드 outputs 통짜 {"order_result": {...}, "order_id": ...}
+        # (NewOrderNodeExecutor → context.record_order_submitted 경유). 예전 flat
+        # {"success": ...} 가정은 중첩 shape 에서 항상 None 이라 성공 주문이 한 번도
+        # 기록되지 않았다 — check 가 항상 미제출을 돌려줘 A-4 가드가 통째로 죽어
+        # 복구 재실행 시 실중복 주문이 나갈 수 있었다(2026-08-16). flat 이 오면
+        # 하위호환으로 그대로 본다.
+        inner = order_result.get("order_result")
+        if not isinstance(inner, dict):
+            inner = order_result
+        if not inner.get('success'):
             return
         try:
             key = self._build_order_idempotency_key(

--- a/src/programgarden/tests/test_a4_order_idempotency.py
+++ b/src/programgarden/tests/test_a4_order_idempotency.py
@@ -210,17 +210,27 @@ class TestA4DuplicateOrderProof:
         return []
 
     def _mock_order_result(self, log: list) -> dict:
-        """order_result 반환값 (성공)"""
+        """order_result 반환값 (성공) — **프로덕션 중첩 shape**.
+
+        실제 _execute_overseas_stock 은 self._order_result(...) 를 반환한다:
+        {"order_result": {...}, "order_id": "..."}. 예전 이 mock 은 flat
+        {"success": ...} 을 반환해, record_order_submitted 의 flat 가정 결함
+        (중첩에서 success 를 못 찾아 성공 주문을 영영 미기록)을 가렸다.
+        """
         log.append("order_submitted")
         return {
-            "success": True,
-            "order_no": "ORD-MOCK-001",
-            "symbol": "AAPL",
-            "exchange": "NASDAQ",
-            "side": "buy",
-            "quantity": 10,
-            "price": 150.0,
-            "status": "submitted",
+            "order_result": {
+                "success": True,
+                "symbol": "AAPL",
+                "exchange": "NASDAQ",
+                "side": "buy",
+                "quantity": 10,
+                "price": 150.0,
+                "status": "submitted",
+                "error": None,
+                "diagnostics": None,
+            },
+            "order_id": "ORD-MOCK-001",
         }
 
     @pytest.mark.asyncio
@@ -345,11 +355,30 @@ class TestA4DuplicateOrderProof:
         with tempfile.TemporaryDirectory() as tmpdir:
             executor = WorkflowExecutor()
 
+            # record 스파이 — 회귀 가드의 관측점. 예전 record_order_submitted 는
+            # flat {"success": ...} 가정이라 중첩 shape 에서 조기 return 해 이 스파이가
+            # 0회 캡처됐다(성공 주문 영영 미기록 = A-4 死). 지금은 1회 캡처돼야 한다.
+            recorded: list = []
+            orig_record = CheckpointManager.record_order_submission
+
+            def spy_record(self_mgr, job_id, idempotency_key, order_result):
+                recorded.append({
+                    "job_id": job_id,
+                    "key": idempotency_key,
+                    "order_result": order_result,
+                })
+                return orig_record(
+                    self_mgr, job_id=job_id,
+                    idempotency_key=idempotency_key, order_result=order_result,
+                )
+
             # 1단계: idempotency 활성화 실행
             with patch.object(
                 NewOrderNodeExecutor,
                 "_execute_overseas_stock",
                 new=fake_execute_overseas_stock,
+            ), patch.object(
+                CheckpointManager, "record_order_submission", new=spy_record,
             ), patch("programgarden.executor.ensure_ls_login") as login_mock:
                 login_mock.return_value = (MagicMock(), True, None)
                 job1 = await asyncio.wait_for(
@@ -380,14 +409,30 @@ class TestA4DuplicateOrderProof:
                 cycle=0,
                 item=normalized_order,
             )
-            existing = mgr.get_submitted_order(job_id=job1.job_id, idempotency_key=idem_key)
-            if existing is None:
-                # 첫 실행에서 기록됐어야 할 주문 — 없으면 수동 삽입 (테스트 환경 보완)
-                mgr.record_order_submission(
-                    job_id=job1.job_id,
-                    idempotency_key=idem_key,
-                    order_result={"success": True, "order_no": "ORD-MOCK-001"},
-                )
+            # 회귀 가드: 첫 실행이 프로덕션 중첩 shape 그대로 record 를 발화해야 한다.
+            # (예전엔 flat 가정 조기 return 으로 0회 → 테스트가 "수동 삽입 보완"으로
+            # 결함을 덮고 통과했다. 그 보완을 제거하고 발화 자체를 단언한다.)
+            assert len(recorded) == 1, (
+                f"성공 주문 record 발화 {len(recorded)}회 (기대 1) — "
+                "record_order_submitted 가 중첩 order_result shape 의 success 를 "
+                "읽지 못하는 회귀 (A-4 死 결함)"
+            )
+            assert recorded[0]["job_id"] == job1.job_id
+            assert recorded[0]["key"] == idem_key, (
+                f"record 키 불일치: {recorded[0]['key']} != {idem_key}"
+            )
+            _rec_inner = recorded[0]["order_result"].get("order_result")
+            assert isinstance(_rec_inner, dict) and _rec_inner.get("success") is True
+
+            # 잡이 **정상 완료**되면 checkpoint 정리가 레지스트리도 비운다(의도 —
+            # 완료 잡은 복구 대상이 아님). 여기 크래시 시뮬레이션은 "완료 전 종료"
+            # 상태를 만들므로, 크래시였다면 남아 있었을 기록을 **캡처한 실기록물
+            # 그대로** 복원한다(예전의 손으로 만든 flat 삽입과 달리 프로덕션 shape).
+            mgr.record_order_submission(
+                job_id=recorded[0]["job_id"],
+                idempotency_key=recorded[0]["key"],
+                order_result=recorded[0]["order_result"],
+            )
 
             # checkpoint를 order1 미완료 상태로 덮어씀
             mgr.save_checkpoint(
@@ -433,6 +478,15 @@ class TestA4DuplicateOrderProof:
                 f"\n  [A-4 FIX] idempotency 활성: "
                 f"dispatch {calls_after_recovery}회 (복구 전={calls_after_first_run}) — 중복 차단 확인"
             )
+
+            # 리플레이 표식: 차단 경로가 돌려준 결과에는 idempotent_replay 가 달려
+            # 리스너(트레이 per-order 로그)가 신규 주문으로 재적재하지 않는다.
+            replay_outputs = job2.context.get_all_outputs("order1")
+            assert replay_outputs.get("idempotent_replay") is True, (
+                f"리플레이 표식 누락 — outputs={replay_outputs}"
+            )
+            inner = replay_outputs.get("order_result")
+            assert isinstance(inner, dict) and inner.get("idempotent_replay") is True
 
 
 # ---------------------------------------------------------------------------

--- a/src/programgarden/tests/test_split_branch_order_events.py
+++ b/src/programgarden/tests/test_split_branch_order_events.py
@@ -1,0 +1,180 @@
+"""Split 분기 안 주문 노드의 node_state 관측성 (2026-08-16).
+
+결함: 분기 노드는 메인 루프가 건너뛰고(⏭ Skipping branch node) SplitNode 의
+_execute_branch_for_item 이 직접 실행하는데, 그 경로엔 notify_node_state 가 없어
+분기 안에서 실주문이 나가도 리스너(트레이 per-order durable 로그·SSE)가 완료
+이벤트를 전혀 받지 못했다 → order_fills 적재 0행.
+
+수정 계약:
+- 분기 노드 실행 결과에 주문 결과(order/modify/cancel_result)가 실려 있으면
+  아이템마다 COMPLETED node_state 를 방출한다 (outputs 동봉).
+- "제출할 주문 없음"(reason: no_signal/fetch_failed/no_symbol)은 방출하지 않는다
+  — 실시간 분기의 틱 재구동마다 재발화해 이벤트 홍수가 되는 것을 막는다.
+- 주문 결과가 없는 일반 분기 노드는 종전대로 미방출(전면 방출은 SplitNode
+  시맨틱 개편 몫).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _CaptureListener:
+    """on_node_state_change 만 캡처하고 나머지 훅은 전부 no-op (Protocol 덕타이핑)."""
+
+    def __init__(self) -> None:
+        self.node_events: List[Any] = []
+
+    async def on_node_state_change(self, event) -> None:
+        self.node_events.append(event)
+
+    def __getattr__(self, name: str):
+        async def _noop(*args, **kwargs) -> None:
+            return None
+        return _noop
+
+
+def _split_order_workflow(symbols: list[dict]) -> dict:
+    return {
+        "id": "wf-split-order-events",
+        "name": "Split Branch Order Events",
+        "version": "1.0.0",
+        "nodes": [
+            {"id": "start", "type": "StartNode"},
+            {"id": "broker", "type": "OverseasStockBrokerNode", "credential_id": "broker-cred"},
+            {"id": "wl", "type": "WatchlistNode", "symbols": symbols},
+            {"id": "split", "type": "SplitNode"},
+            {
+                "id": "order1",
+                "type": "OverseasStockNewOrderNode",
+                "side": "buy",
+                "order_type": "limit",
+                "order": {
+                    "symbol": "{{ nodes.split.item }}",
+                    "exchange": "NASDAQ",
+                    "quantity": 1,
+                    "price": 150.0,
+                },
+            },
+            {"id": "agg", "type": "AggregateNode", "mode": "collect"},
+        ],
+        "edges": [
+            {"from": "start", "to": "broker"},
+            {"from": "broker", "to": "wl"},
+            {"from": "wl", "to": "split"},
+            {"from": "split", "to": "order1"},
+            {"from": "order1", "to": "agg"},
+        ],
+        "credentials": [
+            {
+                "credential_id": "broker-cred",
+                "type": "broker_ls_overseas_stock",
+                "data": [
+                    {"key": "appkey", "value": "test-appkey"},
+                    {"key": "appsecret", "value": "test-appsecret"},
+                ],
+            }
+        ],
+    }
+
+
+def _order1_events(listener: _CaptureListener) -> list:
+    # 메인 루프는 분기 노드를 skip 하며 PENDING 을 방출한다(기존 동작) — 이 테스트의
+    # 관심사는 분기 실행이 새로 방출하는 **COMPLETED**(주문 결과 동봉)뿐이다.
+    return [
+        e for e in listener.node_events
+        if e.node_id == "order1" and e.state.value == "completed"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_branch_order_node_emits_completed_per_item():
+    """분기 안 주문 노드: 아이템(종목)마다 COMPLETED 1회 + outputs 에 order_result."""
+    from programgarden import WorkflowExecutor
+    from programgarden.executor import NewOrderNodeExecutor
+
+    async def fake_execute_overseas_stock(self_ex, ls, order, side, order_type, config, context, node_id):
+        symbol = (order or {}).get("symbol") or "?"
+        if isinstance(symbol, dict):  # split item(dict)이 그대로 온 경우
+            symbol = symbol.get("symbol") or "?"
+        return {
+            "order_result": {
+                "success": True,
+                "symbol": symbol,
+                "exchange": "NASDAQ",
+                "side": "buy",
+                "quantity": 1,
+                "price": 150.0,
+                "status": "submitted",
+                "error": None,
+                "diagnostics": None,
+            },
+            "order_id": f"ORD-{symbol}",
+        }
+
+    listener = _CaptureListener()
+    workflow = _split_order_workflow(
+        [{"symbol": "AAPL", "exchange": "NASDAQ"}, {"symbol": "MSFT", "exchange": "NASDAQ"}]
+    )
+
+    with patch.object(
+        NewOrderNodeExecutor, "_execute_overseas_stock", new=fake_execute_overseas_stock
+    ), patch("programgarden.executor.ensure_ls_login") as login_mock:
+        login_mock.return_value = (MagicMock(), True, None)
+        executor = WorkflowExecutor()
+        job = await asyncio.wait_for(
+            executor.execute(workflow, listeners=[listener]), timeout=15.0
+        )
+        await asyncio.wait_for(job._task, timeout=15.0)
+
+    events = _order1_events(listener)
+    assert len(events) == 2, (
+        f"분기 아이템 2개 → 주문 완료 이벤트 2회 기대, 실제 {len(events)} — "
+        "분기 실행 경로가 node_state 를 방출하지 않는 회귀(⏭ Skipping branch node)"
+    )
+    symbols = set()
+    for e in events:
+        assert e.state.value == "completed"
+        assert isinstance(e.outputs, dict)
+        result = e.outputs.get("order_result")
+        assert isinstance(result, dict) and result.get("success") is True
+        symbols.add(result.get("symbol"))
+    assert symbols == {"AAPL", "MSFT"}, f"아이템별 결과가 아님: {symbols}"
+
+
+@pytest.mark.asyncio
+async def test_branch_order_nonevent_and_plain_nodes_do_not_emit():
+    """no_signal 빈 결과는 미방출(틱 홍수 방지) + 주문 없는 분기 노드도 종전대로 미방출."""
+    from programgarden import WorkflowExecutor
+    from programgarden.executor import NewOrderNodeExecutor
+
+    async def fake_no_signal(self_ex, ls, order, side, order_type, config, context, node_id):
+        return {
+            "order_result": {
+                "success": False,
+                "error": "No order to submit",
+                "reason": "no_signal",
+                "message": "no signal",
+                "detail": "",
+            },
+            "order_id": "",
+        }
+
+    listener = _CaptureListener()
+    workflow = _split_order_workflow([{"symbol": "AAPL", "exchange": "NASDAQ"}])
+
+    with patch.object(
+        NewOrderNodeExecutor, "_execute_overseas_stock", new=fake_no_signal
+    ), patch("programgarden.executor.ensure_ls_login") as login_mock:
+        login_mock.return_value = (MagicMock(), True, None)
+        executor = WorkflowExecutor()
+        job = await asyncio.wait_for(
+            executor.execute(workflow, listeners=[listener]), timeout=15.0
+        )
+        await asyncio.wait_for(job._task, timeout=15.0)
+
+    assert _order1_events(listener) == [], "no_signal 빈 결과가 이벤트로 새어 나옴"


### PR DESCRIPTION
## 요약
per-order durable 로깅(server PR #296) 작업 중 실측 발견한 엔진 결함 2건 수정.

### 1. A-4 주문 idempotency 가 프로덕션에서 통째로 미작동 (실돈 리스크)
`record_order_submitted` 가 flat `{"success": ...}` 를 가정하는데 실제 호출부는 중첩 `{"order_result": {...}, "order_id": ...}` 를 넘긴다 → success 를 못 찾아 성공 주문이 **한 번도 기록되지 않음** → 복구 재실행 시 같은 실주문 중복 제출 가능. 예외 없이 조용히 지나가고, 기존 테스트는 flat mock + "수동 삽입 보완" 으로 결함을 가리고 있었다.
- 수정: 중첩 unwrap(+flat 하위호환) + 차단 로그 order_no 도출 교정
- 리플레이 표식 `idempotent_replay` 추가 — 차단 경로의 재방출을 리스너(트레이 per-order 로그, computer_app PR #57)가 신규 주문으로 재적재하지 않게 함

### 2. Split 분기 안 주문은 node_state 이벤트가 전혀 안 나옴 (로그 0행)
분기 노드는 메인 루프가 건너뛰고 `_execute_branch_for_item` 이 직접 실행 — notify 부재로 분기 안 실주문의 완료를 리스너가 못 봤다. **주문 결과를 낸 실행에만** COMPLETED 방출(no_signal 빈 결과 제외 — 실시간 분기 틱 재구동 이벤트 홍수 방지). 분기 전 노드 일반 관측성은 SplitNode 시맨틱 개편에서.

## 테스트
- A-4 테스트를 프로덕션 중첩 shape 로 교정 + record 발화 스파이 단언(수동 삽입 보완 제거) + 리플레이 표식 단언
- 신규 test_split_branch_order_events 2건 (아이템별 COMPLETED / no_signal 미방출)
- 전체 스위트: 실패/에러 집합이 main 기준선과 **완전 동일**(회귀 0 — env 의존 65건은 양쪽 공통)

## 배포 참고
PyPI 릴리스에 실려야 트레이앱에 도달(릴리스는 별도 게이트). 머지는 리뷰 후 진행해 주세요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)