### PR TITLE
fix: 소수점(fractional) 잔고 전면 대응 — COSOQ00201 근본 수정 + 소비 경로 전수 + 적대 리뷰 반영

### DIFF
--- a/src/core/programgarden_core/bases/listener.py
+++ b/src/core/programgarden_core/bases/listener.py
@@ -189,7 +189,7 @@ class PositionDetail:
     """
     symbol: str
     exchange: str
-    quantity: int
+    quantity: Union[Decimal, float, int]  # 소수점(fractional) 잔고 대응
     avg_price: Union[Decimal, float]
     current_price: Union[Decimal, float]
     pnl_amount: Union[Decimal, float]

--- a/src/core/programgarden_core/models/order_diagnostics.py
+++ b/src/core/programgarden_core/models/order_diagnostics.py
@@ -138,6 +138,15 @@ class EmptyOrderReason(str, Enum):
 # Each entry was produced by deliberately triggering the rejection and reading
 # the returned rsp_cd/rsp_msg — none of these are inferred from the LS spec.
 OVERSEAS_STOCK_REJECT_CODES: Dict[str, Dict[str, str]] = {
+    # Live-verified 2026-08-24: deliberately submitted OrdQty=0.1 (COSAT00301,
+    # limit buy far below market). The LS gateway rejected at its type-validation
+    # layer with HTTP 500 + rsp_cd IGW40011 "주문수량(OrdQty) data type을
+    # 확인하세요." — fractional order quantities are not accepted by this TR.
+    "IGW40011": {
+        "retry": RetryAdvice.RETRY_AFTER_FIX.value,
+        "cause": "The order quantity failed the LS gateway's data-type validation (non-integer quantity).",
+        "tip": "Order quantities must be integers; floor fractional quantities before ordering.",
+    },
     "02201": {
         "retry": RetryAdvice.RETRY_AFTER_FIX.value,
         "cause": "The account does not have enough cash to place this order.",

--- a/src/core/programgarden_core/models/order_diagnostics.py
+++ b/src/core/programgarden_core/models/order_diagnostics.py
@@ -117,6 +117,12 @@ class EmptyOrderReason(str, Enum):
     NO_SYMBOL = "no_symbol"
     """No symbol was specified (missing configuration)."""
 
+    FRACTIONAL_ONLY = "fractional_only"
+    """The position quantity is fractional-only (e.g. 0.847972 shares) and the
+    order pipeline submits integer quantities, so flooring left nothing to
+    order. Distinct from NO_SIGNAL so the holder learns why nothing happened
+    (fractional balances measured on a real LS account, prod 2026-08-24)."""
+
 
 # ---------------------------------------------------------------------------
 # Market-specific reject-code tables.

--- a/src/core/tests/test_order_diagnostics.py
+++ b/src/core/tests/test_order_diagnostics.py
@@ -30,7 +30,9 @@ from programgarden_core.models.order_diagnostics import (
 
 # Registered from a real LS overseas-stock account on 2026-08-19 by deliberately
 # triggering each rejection. Pinned here so a future guess-based addition fails.
-LIVE_VERIFIED_OVERSEAS_STOCK_CODES = {"02201", "02259", "03053", "03759"}
+# IGW40011 added 2026-08-24: OrdQty=0.1 deliberately submitted (COSAT00301) →
+# gateway type-validation rejection (fractional quantities not accepted).
+LIVE_VERIFIED_OVERSEAS_STOCK_CODES = {"02201", "02259", "03053", "03759", "IGW40011"}
 
 # Registered from a real LS Korea-stock account on 2026-08-19 the same way
 # (CSPAT00601 new order / CSPAT00801 cancel, each rejection deliberately

--- a/src/finance/programgarden_finance/ls/overseas_stock/accno/COSAQ00102/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/accno/COSAQ00102/blocks.py
@@ -334,8 +334,8 @@ class COSAQ00102OutBlock2(BaseModel):
         ),
         examples=["0", "1234.56"],
     )
-    SellExecQty: int = Field(
-        default=0,
+    SellExecQty: float = Field(
+        default=0.0,
         title="매도체결수량 (Sell-executed quantity)",
         description="Aggregated sell-executed share quantity.",
         examples=[0, 100],
@@ -350,8 +350,8 @@ class COSAQ00102OutBlock2(BaseModel):
         ),
         examples=["0", "1234.56"],
     )
-    BuyExecQty: int = Field(
-        default=0,
+    BuyExecQty: float = Field(
+        default=0.0,
         title="매수체결수량 (Buy-executed quantity)",
         description="Aggregated buy-executed share quantity.",
         examples=[0, 100],
@@ -435,14 +435,14 @@ class COSAQ00102OutBlock3(BaseModel):
         ),
         examples=[0, 1, 2],
     )
-    MrcAbleQty: int = Field(
-        default=0,
+    MrcAbleQty: float = Field(
+        default=0.0,
         title="정정취소가능수량 (Modify/cancel-able quantity)",
         description="Remaining quantity that can still be modified or cancelled.",
         examples=[0, 100],
     )
-    OrdQty: int = Field(
-        default=0,
+    OrdQty: float = Field(
+        default=0.0,
         title="주문수량 (Order quantity)",
         description="Total order quantity (shares).",
         examples=[0, 100],
@@ -456,8 +456,8 @@ class COSAQ00102OutBlock3(BaseModel):
         ),
         examples=[0.0, 150.25],
     )
-    ExecQty: int = Field(
-        default=0,
+    ExecQty: float = Field(
+        default=0.0,
         title="체결수량 (Executed quantity)",
         description="Quantity that has been executed so far for this order.",
         examples=[0, 100],
@@ -516,8 +516,8 @@ class COSAQ00102OutBlock3(BaseModel):
         description="Display name of the modify/cancel classification.",
         examples=["", "정정", "취소"],
     )
-    AllExecQty: int = Field(
-        default=0,
+    AllExecQty: float = Field(
+        default=0.0,
         title="전체체결수량 (Total executed quantity)",
         description="Total executed quantity across this order's lifecycle.",
         examples=[0, 100],
@@ -555,14 +555,14 @@ class COSAQ00102OutBlock3(BaseModel):
         description="Korean display name of the issue when applicable to Japan market.",
         examples=["", "도요타자동차"],
     )
-    UnercQty: int = Field(
-        default=0,
+    UnercQty: float = Field(
+        default=0.0,
         title="미체결수량 (Unexecuted quantity)",
         description="Remaining unexecuted quantity for this order.",
         examples=[0, 100],
     )
-    CnfQty: int = Field(
-        default=0,
+    CnfQty: float = Field(
+        default=0.0,
         title="확인수량 (Confirmed quantity)",
         description="Confirmed quantity. Exact semantics not declared in available source.",
         examples=[0, 100],

--- a/src/finance/programgarden_finance/ls/overseas_stock/accno/COSAQ01400/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/accno/COSAQ01400/blocks.py
@@ -271,8 +271,8 @@ class COSAQ01400OutBlock2(BaseModel):
         description="Korean display name of the issue when applicable to Japan market.",
         examples=["", "도요타자동차"],
     )
-    OrdQty: int = Field(
-        default=0,
+    OrdQty: float = Field(
+        default=0.0,
         title="주문수량 (Order quantity)",
         description="Reservation order quantity (shares).",
         examples=[0, 100],
@@ -298,20 +298,20 @@ class COSAQ01400OutBlock2(BaseModel):
         description="Display name of the buy/sell side (e.g., '매도', '매수').",
         examples=["매도", "매수"],
     )
-    ExecQty: int = Field(
-        default=0,
+    ExecQty: float = Field(
+        default=0.0,
         title="체결수량 (Executed quantity)",
         description="Quantity that has been executed for this reservation.",
         examples=[0, 100],
     )
-    UnercQty: int = Field(
-        default=0,
+    UnercQty: float = Field(
+        default=0.0,
         title="미체결수량 (Unexecuted quantity)",
         description="Remaining unexecuted quantity for this reservation.",
         examples=[0, 100],
     )
-    TotExecQty: int = Field(
-        default=0,
+    TotExecQty: float = Field(
+        default=0.0,
         title="총체결수량 (Total executed quantity)",
         description="Total executed quantity across this reservation's lifecycle.",
         examples=[0, 100],

--- a/src/finance/programgarden_finance/ls/overseas_stock/accno/COSOQ00201/__init__.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/accno/COSOQ00201/__init__.py
@@ -103,8 +103,9 @@ class TrCOSOQ00201(TRAccnoAbstract):
             logger.error(f"COSOQ00201 request failed with status: {error_msg}")
         else:
             # A block that had data but lost every row is a real failure; a few
-            # skipped rows among survivors stays a logged warning (error_msg on a
-            # partially parsed response would make consumers treat it as total).
+            # skipped rows among survivors stays a warning carried on
+            # ``parse_warnings`` (error_msg on a partially parsed response would
+            # make consumers treat it as total failure).
             for block_name, raw_rows, parsed_rows in (
                 ("OutBlock3", block3_data, parsed_block3),
                 ("OutBlock4", block4_data, parsed_block4),
@@ -116,6 +117,15 @@ class TrCOSOQ00201(TRAccnoAbstract):
                     )
                     logger.error(f"COSOQ00201 {error_msg}")
                     break
+            # OutBlock2(잔고 요약)가 있었는데 통째로 잃었으면 진짜 실패다 — 무음
+            # 처리하면 예수금/평가금이 0 원으로 조용히 나간다(적대 리뷰 #2).
+            # OutBlock1 은 입력 에코라 소실돼도 로그로 충분하다.
+            if error_msg is None and block2_data is not None and parsed_block2 is None:
+                error_msg = (
+                    "response parse error: OutBlock2 (balance summary) failed to "
+                    f"parse — {parse_failures[0] if parse_failures else 'unknown'}"
+                )
+                logger.error(f"COSOQ00201 {error_msg}")
 
         result = COSOQ00201Response(
             header=header,
@@ -127,6 +137,7 @@ class TrCOSOQ00201(TRAccnoAbstract):
             rsp_msg=resp_json.get("rsp_msg", ""),
             status_code=status,
             error_msg=error_msg,
+            parse_warnings=parse_failures,
         )
         if resp is not None:
             result.raw_data = resp

--- a/src/finance/programgarden_finance/ls/overseas_stock/accno/COSOQ00201/__init__.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/accno/COSOQ00201/__init__.py
@@ -60,13 +60,37 @@ class TrCOSOQ00201(TRAccnoAbstract):
         parsed_block2 = None
         parsed_block3: list[COSOQ00201OutBlock3] = []
         parsed_block4: list[COSOQ00201OutBlock4] = []
+        parse_failures: list[str] = []
+
+        def _parse_rows(model, rows, block_name):
+            # One malformed row must not wipe out the whole balance response
+            # (prod 2026-08-24: a single fractional row killed every position).
+            parsed = []
+            for idx, item in enumerate(rows or []):
+                try:
+                    parsed.append(model.model_validate(item))
+                except Exception as row_exc:
+                    parse_failures.append(f"{block_name}[{idx}]: {row_exc}")
+                    logger.error(
+                        f"COSOQ00201 {block_name} row {idx} parse failed — skipping row: {row_exc}; raw={item}"
+                    )
+            return parsed
+
         if exc is None and not is_error_status:
             if block1_data is not None:
-                parsed_block1 = COSOQ00201OutBlock1.model_validate(block1_data)
+                try:
+                    parsed_block1 = COSOQ00201OutBlock1.model_validate(block1_data)
+                except Exception as blk_exc:
+                    parse_failures.append(f"OutBlock1: {blk_exc}")
+                    logger.error(f"COSOQ00201 OutBlock1 parse failed — dropping block: {blk_exc}")
             if block2_data is not None:
-                parsed_block2 = COSOQ00201OutBlock2.model_validate(block2_data)
-            parsed_block3 = [COSOQ00201OutBlock3.model_validate(item) for item in block3_data]
-            parsed_block4 = [COSOQ00201OutBlock4.model_validate(item) for item in block4_data]
+                try:
+                    parsed_block2 = COSOQ00201OutBlock2.model_validate(block2_data)
+                except Exception as blk_exc:
+                    parse_failures.append(f"OutBlock2: {blk_exc}")
+                    logger.error(f"COSOQ00201 OutBlock2 parse failed — dropping block: {blk_exc}")
+            parsed_block3 = _parse_rows(COSOQ00201OutBlock3, block3_data, "OutBlock3")
+            parsed_block4 = _parse_rows(COSOQ00201OutBlock4, block4_data, "OutBlock4")
 
         error_msg: Optional[str] = None
         if exc is not None:
@@ -77,6 +101,21 @@ class TrCOSOQ00201(TRAccnoAbstract):
             if resp_json.get("rsp_msg"):
                 error_msg = f"{error_msg}: {resp_json['rsp_msg']}"
             logger.error(f"COSOQ00201 request failed with status: {error_msg}")
+        else:
+            # A block that had data but lost every row is a real failure; a few
+            # skipped rows among survivors stays a logged warning (error_msg on a
+            # partially parsed response would make consumers treat it as total).
+            for block_name, raw_rows, parsed_rows in (
+                ("OutBlock3", block3_data, parsed_block3),
+                ("OutBlock4", block4_data, parsed_block4),
+            ):
+                if raw_rows and not parsed_rows:
+                    error_msg = (
+                        f"response parse error: every {block_name} row failed to parse "
+                        f"({len(raw_rows)} rows) — first: {parse_failures[0] if parse_failures else 'unknown'}"
+                    )
+                    logger.error(f"COSOQ00201 {error_msg}")
+                    break
 
         result = COSOQ00201Response(
             header=header,

--- a/src/finance/programgarden_finance/ls/overseas_stock/accno/COSOQ00201/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/accno/COSOQ00201/blocks.py
@@ -369,23 +369,27 @@ class COSOQ00201OutBlock4(BaseModel):
         description="Display name of the balance type.",
         examples=["일반", "소수점"],
     )
-    AstkBalQty: int = Field(
-        default=0,
+    AstkBalQty: float = Field(
+        default=0.0,
         title="해외증권잔고수량 (Overseas-stock balance quantity)",
         description=(
-            "Holdings quantity. Integer typed in the SDK — fractional positions "
-            "(``AstkBalTpCode='20'``) may be truncated by Pydantic int coercion."
+            "Holdings quantity. Float typed — fractional positions "
+            "(``AstkBalTpCode='20'``) arrive as decimal strings "
+            "(e.g. '0.847972', measured on prod 2026-08-24). The former int "
+            "typing did not truncate; it raised a Pydantic ValidationError and "
+            "killed the whole balance parse."
         ),
-        examples=[0, 100],
+        examples=[0.0, 100.0, 0.847972],
     )
-    AstkSellAbleQty: int = Field(
-        default=0,
+    AstkSellAbleQty: float = Field(
+        default=0.0,
         title="해외증권매도가능수량 (Overseas-stock sellable quantity)",
         description=(
-            "Quantity available to sell. Integer typed in the SDK — fractional "
-            "positions may be truncated by Pydantic int coercion."
+            "Quantity available to sell. Float typed — fractional positions "
+            "(``AstkBalTpCode='20'``) arrive as decimal strings; see "
+            "``AstkBalQty``."
         ),
-        examples=[0, 100],
+        examples=[0.0, 100.0, 0.847972],
     )
     FcstckUprc: float = Field(
         default=0.0,

--- a/src/finance/programgarden_finance/ls/overseas_stock/accno/COSOQ00201/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/accno/COSOQ00201/blocks.py
@@ -575,6 +575,17 @@ class COSOQ00201Response(BaseModel):
         title="오류 메시지 (Error message)",
         description="Error message when an exception or HTTP error occurred. None on success.",
     )
+    parse_warnings: List[str] = Field(
+        default_factory=list,
+        title="행 단위 파싱 경고 (Row-level parse warnings)",
+        description=(
+            "Rows/blocks skipped during row-level parsing (one entry per skipped "
+            "row). Empty on full success. A non-empty list with error_msg=None "
+            "means PARTIAL success — surviving rows are present but some rows "
+            "were lost; consumers that must not mistake a lost row for 'no "
+            "position' should treat this as a failure signal (2026-08-24)."
+        ),
+    )
     _raw_data: Optional[Response] = PrivateAttr(default=None)
 
     @property

--- a/src/finance/programgarden_finance/ls/overseas_stock/extension/calculator.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/extension/calculator.py
@@ -179,7 +179,7 @@ class StockPnLCalculator:
     def calculate_realtime_pnl(
         self,
         symbol: str,
-        quantity: int,
+        quantity: Decimal,
         buy_price: Decimal,
         current_price: Decimal,
         currency: str = "USD",

--- a/src/finance/programgarden_finance/ls/overseas_stock/extension/models.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/extension/models.py
@@ -40,8 +40,8 @@ class StockTradeInput(BaseModel):
     ticker: str = Field(..., description="종목코드")
     """종목코드"""
     
-    qty: int = Field(..., description="수량")
-    """수량"""
+    qty: Decimal = Field(..., description="수량 (소수점 잔고 포함 가능)")
+    """수량 — 소수점(fractional) 보유분 손익 계산을 위해 Decimal (int 입력도 허용)"""
     
     buy_price: Decimal = Field(..., description="매수단가 (외화)")
     """매수단가 (외화)"""
@@ -117,11 +117,11 @@ class StockPositionItem(BaseModel):
     currency_code: str = Field(default="USD", description="통화코드")
     """통화코드"""
     
-    quantity: int = Field(default=0, description="보유수량")
-    """보유수량"""
-    
-    sellable_quantity: int = Field(default=0, description="매도가능수량")
-    """매도가능수량"""
+    quantity: Decimal = Field(default=Decimal("0"), description="보유수량 (소수점 잔고 AstkBalTpCode='20' 포함)")
+    """보유수량 — 소수점(fractional) 잔고를 담을 수 있어 Decimal"""
+
+    sellable_quantity: Decimal = Field(default=Decimal("0"), description="매도가능수량 (소수점 잔고 포함)")
+    """매도가능수량 — 소수점(fractional) 잔고를 담을 수 있어 Decimal"""
     
     buy_price: Decimal = Field(default=Decimal("0"), description="매입단가")
     """매입단가"""

--- a/src/finance/programgarden_finance/ls/overseas_stock/extension/models.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/extension/models.py
@@ -201,17 +201,17 @@ class StockOpenOrder(BaseModel):
     order_type: str = Field(default="", description="주문유형 (01: 매도, 02: 매수)")
     """주문유형 (01: 매도, 02: 매수)"""
     
-    order_qty: int = Field(default=0, description="주문수량")
-    """주문수량"""
-    
+    order_qty: int | float = Field(default=0, description="주문수량 (소수점 가능)")
+    """주문수량 — 소수점(fractional) 행 대응 int|float (정수는 int 유지)"""
+
     order_price: Decimal = Field(default=Decimal("0"), description="주문가격")
     """주문가격"""
-    
-    executed_qty: int = Field(default=0, description="체결수량")
-    """체결수량"""
-    
-    remaining_qty: int = Field(default=0, description="미체결수량")
-    """미체결수량"""
+
+    executed_qty: int | float = Field(default=0, description="체결수량 (소수점 가능)")
+    """체결수량 — 소수점(fractional) 행 대응 int|float"""
+
+    remaining_qty: int | float = Field(default=0, description="미체결수량 (소수점 가능)")
+    """미체결수량 — 소수점(fractional) 행 대응 int|float"""
     
     order_time: str = Field(default="", description="주문시간")
     """주문시간"""

--- a/src/finance/programgarden_finance/ls/overseas_stock/extension/tracker.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/extension/tracker.py
@@ -197,6 +197,19 @@ class StockAccountTracker:
                 logger.error(f"[_fetch_positions] {error_msg}")
                 return
 
+            # 행 단위 파싱에서 스킵된 행이 있으면(부분실패) 기존 포지션을 갱신하지
+            # 않는다 — 유실 행의 종목이 '미보유' 로 둔갑해 이중 매수를 유발한다
+            # (적대 리뷰 #3). 낡은 스냅샷이 잘못된 빈 스냅샷보다 낫다.
+            parse_warnings = getattr(resp, 'parse_warnings', None) or []
+            if parse_warnings:
+                error_msg = (
+                    f"[포지션 조회 부분실패] {len(parse_warnings)}행 파싱 스킵 — "
+                    f"기존 포지션 유지: {parse_warnings[0]}"
+                )
+                self._last_errors["positions"] = error_msg
+                logger.error(f"[_fetch_positions] {error_msg}")
+                return
+
             # "데이터 없음" 응답 → 정상 케이스 (빈 데이터)
             if is_no_data_response(rsp_cd, rsp_msg):
                 logger.info(f"[_fetch_positions] 보유종목 없음 (rsp_cd={rsp_cd}, msg={rsp_msg})")
@@ -339,20 +352,25 @@ class StockAccountTracker:
             now = datetime.now()
             self._open_orders.clear()
             
-            if hasattr(resp, 'block1') and resp.block1:
-                for item in resp.block1:
+            # 🔴 미체결 행은 block3 다 — 종전 코드는 block1(입력 에코, 단일 모델)을
+            # 순회해 (필드명, 값) 튜플에 getattr 기본값만 얻었고, 그 결과
+            # order_no='' 인 가짜 1건만 만들어 미체결 추적이 한 번도 실데이터를
+            # 흐른 적이 없었다 (적대 리뷰 2026-08-24 #4). 필드명도 OutBlock3
+            # 실명(UnercQty 등)으로 정정.
+            if getattr(resp, 'block3', None):
+                for item in resp.block3:
                     order = StockOpenOrder(
-                        order_no=getattr(item, 'OrdNo', ''),
-                        symbol=getattr(item, 'IsuNo', ''),
-                        symbol_name=getattr(item, 'IsuNm', ''),
-                        order_type=getattr(item, 'OrdPtnCode', ''),
+                        order_no=str(getattr(item, 'OrdNo', '') or ''),
+                        symbol=getattr(item, 'ShtnIsuNo', '') or getattr(item, 'IsuNo', ''),
+                        symbol_name=getattr(item, 'JpnMktHanglIsuNm', ''),
+                        order_type=str(getattr(item, 'OrdPtnCode', '') or ''),
                         order_qty=getattr(item, 'OrdQty', 0),
-                        order_price=Decimal(str(getattr(item, 'OrdPrc', 0))),
+                        order_price=Decimal(str(getattr(item, 'OvrsOrdPrc', 0) or 0)),
                         executed_qty=getattr(item, 'ExecQty', 0),
-                        remaining_qty=getattr(item, 'UnexecQty', 0),
+                        remaining_qty=getattr(item, 'UnercQty', 0),
                         order_time=getattr(item, 'OrdTime', ''),
-                        order_status=getattr(item, 'OrdStatCode', ''),
-                        currency_code=getattr(item, 'CrcyCode', 'USD'),
+                        order_status=str(getattr(item, 'OrdTrxPtnCode', '') or ''),
+                        currency_code=getattr(item, 'CrcyCode', '') or 'USD',
                         last_updated=now
                     )
                     self._open_orders[order.order_no] = order

--- a/src/finance/programgarden_finance/ls/overseas_stock/extension/tracker.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/extension/tracker.py
@@ -185,7 +185,18 @@ class StockAccountTracker:
             # 응답 코드 확인
             rsp_cd = getattr(resp, 'rsp_cd', '')
             rsp_msg = getattr(resp, 'rsp_msg', '')
-            
+
+            # 전송/파싱 실패 → fail-closed: 기존 상태를 지우지 않고 에러로 남긴다.
+            # (GenericTR fallback 은 rsp_cd="" 인 빈 응답을 주므로, 이 가드가 없으면
+            #  아래 분기를 전부 통과해 "데이터 0건" 이라는 조용한 오답이 된다 —
+            #  prod 2026-08-24 소수점 잔고 파싱 실패에서 실측된 경로)
+            resp_error = getattr(resp, 'error_msg', None)
+            if resp_error:
+                error_msg = f"[포지션 조회 실패] error_msg={resp_error}"
+                self._last_errors["positions"] = error_msg
+                logger.error(f"[_fetch_positions] {error_msg}")
+                return
+
             # "데이터 없음" 응답 → 정상 케이스 (빈 데이터)
             if is_no_data_response(rsp_cd, rsp_msg):
                 logger.info(f"[_fetch_positions] 보유종목 없음 (rsp_cd={rsp_cd}, msg={rsp_msg})")
@@ -235,8 +246,8 @@ class StockAccountTracker:
                         symbol=symbol,
                         symbol_name=item.JpnMktHanglIsuNm or symbol,
                         currency_code=item.CrcyCode,
-                        quantity=item.AstkBalQty,
-                        sellable_quantity=item.AstkSellAbleQty,
+                        quantity=Decimal(str(item.AstkBalQty)),
+                        sellable_quantity=Decimal(str(item.AstkSellAbleQty)),
                         buy_price=Decimal(str(item.FcstckUprc)),
                         current_price=Decimal(str(item.OvrsScrtsCurpri)),
                         buy_amount=Decimal(str(item.FcurrBuyAmt)),
@@ -297,7 +308,18 @@ class StockAccountTracker:
             # 응답 코드 확인
             rsp_cd = getattr(resp, 'rsp_cd', '')
             rsp_msg = getattr(resp, 'rsp_msg', '')
-            
+
+            # 전송/파싱 실패 → fail-closed: 기존 상태를 지우지 않고 에러로 남긴다.
+            # (GenericTR fallback 은 rsp_cd="" 인 빈 응답을 주므로, 이 가드가 없으면
+            #  아래 분기를 전부 통과해 "데이터 0건" 이라는 조용한 오답이 된다 —
+            #  prod 2026-08-24 소수점 잔고 파싱 실패에서 실측된 경로)
+            resp_error = getattr(resp, 'error_msg', None)
+            if resp_error:
+                error_msg = f"[미체결 조회 실패] error_msg={resp_error}"
+                self._last_errors["open_orders"] = error_msg
+                logger.error(f"[_fetch_open_orders] {error_msg}")
+                return
+
             # "데이터 없음" 응답 → 정상 케이스 (빈 데이터)
             if is_no_data_response(rsp_cd, rsp_msg):
                 logger.info(f"[_fetch_open_orders] 미체결 주문 없음 (rsp_cd={rsp_cd}, msg={rsp_msg})")

--- a/src/finance/programgarden_finance/ls/overseas_stock/order/COSAT00301/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/order/COSAT00301/blocks.py
@@ -83,7 +83,12 @@ class COSAT00301InBlock1(BaseModel):
     OrdQty: int = Field(
         ...,
         title="주문수량 (Order quantity)",
-        description="Order quantity in shares.",
+        description=(
+            "Order quantity in shares. Integers only — the LS gateway rejects "
+            "fractional quantities at its type-validation layer (measured "
+            "2026-08-24: OrdQty=0.1 -> HTTP 500, rsp_cd IGW40011 '주문수량"
+            "(OrdQty) data type을 확인하세요.')."
+        ),
         examples=[1, 5],
     )
     OvrsOrdPrc: float = Field(

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS0/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS0/blocks.py
@@ -453,19 +453,19 @@ class AS0RealResponseBody(BaseModel):
         description="Parent order number for grouped orders; consume as returned by LS.",
         examples=["0"],
     )
-    sOrgOrdUnercQty: int = Field(
+    sOrgOrdUnercQty: float = Field(
         ...,
         title="원주문미체결수량 (Original-order unfilled quantity)",
         description="Unfilled quantity remaining on the original order.",
         examples=[0, 5],
     )
-    sOrgOrdMdfyQty: int = Field(
+    sOrgOrdMdfyQty: float = Field(
         ...,
         title="원주문정정수량 (Original-order modified quantity)",
         description="Quantity that has been modified on the original order.",
         examples=[0, 1],
     )
-    sOrgOrdCancQty: int = Field(
+    sOrgOrdCancQty: float = Field(
         ...,
         title="원주문취소수량 (Original-order cancelled quantity)",
         description="Quantity cancelled from the original order.",
@@ -508,13 +508,13 @@ class AS0RealResponseBody(BaseModel):
         description="Order-user (placing employee) ID.",
         examples=["USER01"],
     )
-    sSpotOrdQty: int = Field(
+    sSpotOrdQty: float = Field(
         ...,
         title="실물주문수량 (Spot-order quantity)",
         description="Spot-order quantity in shares.",
         examples=[0, 1],
     )
-    sRuseOrdQty: int = Field(
+    sRuseOrdQty: float = Field(
         ...,
         title="재사용주문수량 (Reuse-order quantity)",
         description="Reuse-order quantity in shares.",
@@ -544,43 +544,43 @@ class AS0RealResponseBody(BaseModel):
         description="Commission consumed by the order.",
         examples=[0.0, 0.99],
     )
-    sSecBalQty: int = Field(
+    sSecBalQty: float = Field(
         ...,
         title="잔고수량 (Holding quantity)",
         description="Position holding quantity for the symbol after the event.",
         examples=[0, 10],
     )
-    sSpotOrdAbleQty: int = Field(
+    sSpotOrdAbleQty: float = Field(
         ...,
         title="실물주문가능수량 (Spot-orderable quantity)",
         description="Quantity available for spot ordering.",
         examples=[0, 10],
     )
-    sOrdAbleRuseQty: int = Field(
+    sOrdAbleRuseQty: float = Field(
         ...,
         title="주문가능재사용수량 (Reuse-orderable quantity)",
         description="Reusable quantity available for ordering.",
         examples=[0],
     )
-    sFlctQty: int = Field(
+    sFlctQty: float = Field(
         ...,
         title="변동수량 (Change quantity)",
         description="Net change in quantity caused by this event.",
         examples=[0, 1, -1],
     )
-    sSecBalQtyD2: int = Field(
+    sSecBalQtyD2: float = Field(
         ...,
         title="잔고수량(D2) (D+2 holding quantity)",
         description="D+2 settled holding quantity for the symbol.",
         examples=[0, 10],
     )
-    sSellAbleQty: int = Field(
+    sSellAbleQty: float = Field(
         ...,
         title="매도주문가능수량 (Sell-orderable quantity)",
         description="Quantity currently available to sell.",
         examples=[0, 10],
     )
-    sUnercSellOrdQty: int = Field(
+    sUnercSellOrdQty: float = Field(
         ...,
         title="미체결매도주문수량 (Unfilled sell-order quantity)",
         description="Sell-side quantity currently unfilled.",

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS1/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS1/blocks.py
@@ -395,7 +395,7 @@ class AS1RealResponseBody(BaseModel):
         description="Overseas-side execution identifier.",
         examples=[""],
     )
-    sOrdQty: int = Field(
+    sOrdQty: float = Field(
         ...,
         title="주문수량 (Order quantity)",
         description="Order quantity in shares.",
@@ -410,7 +410,7 @@ class AS1RealResponseBody(BaseModel):
         ),
         examples=[0.0, 180.5],
     )
-    sExecQty: int = Field(
+    sExecQty: float = Field(
         ...,
         title="체결수량 (Execution quantity)",
         description="Quantity filled in this execution event.",
@@ -425,7 +425,7 @@ class AS1RealResponseBody(BaseModel):
         ),
         examples=[0.0, 180.55],
     )
-    sMdfyCnfQty: int = Field(
+    sMdfyCnfQty: float = Field(
         ...,
         title="정정확인수량 (Modify-confirm quantity)",
         description="Quantity confirmed for a modify event.",
@@ -437,13 +437,13 @@ class AS1RealResponseBody(BaseModel):
         description="Price confirmed for a modify event.",
         examples=[0.0, 181.0],
     )
-    sCancCnfQty: int = Field(
+    sCancCnfQty: float = Field(
         ...,
         title="취소확인수량 (Cancel-confirm quantity)",
         description="Quantity confirmed for a cancel event.",
         examples=[0, 1],
     )
-    sRjtQty: int = Field(
+    sRjtQty: float = Field(
         ...,
         title="거부수량 (Reject quantity)",
         description="Quantity rejected.",
@@ -491,25 +491,25 @@ class AS1RealResponseBody(BaseModel):
         description="Operation-directive number; consume as returned by LS.",
         examples=[""],
     )
-    sUnercQty: int = Field(
+    sUnercQty: float = Field(
         ...,
         title="미체결수량(주문) (Unfilled order quantity)",
         description="Quantity unfilled on this order after this event.",
         examples=[0, 5],
     )
-    sOrgOrdUnercQty: int = Field(
+    sOrgOrdUnercQty: float = Field(
         ...,
         title="원주문미체결수량 (Original-order unfilled quantity)",
         description="Unfilled quantity remaining on the original order.",
         examples=[0, 5],
     )
-    sOrgOrdMdfyQty: int = Field(
+    sOrgOrdMdfyQty: float = Field(
         ...,
         title="원주문정정수량 (Original-order modified quantity)",
         description="Quantity that has been modified on the original order.",
         examples=[0, 1],
     )
-    sOrgOrdCancQty: int = Field(
+    sOrgOrdCancQty: float = Field(
         ...,
         title="원주문취소수량 (Original-order cancelled quantity)",
         description="Quantity cancelled from the original order.",
@@ -605,13 +605,13 @@ class AS1RealResponseBody(BaseModel):
         description="Reuse-funds executed amount within current day.",
         examples=[0.0],
     )
-    sSpotExecQty: int = Field(
+    sSpotExecQty: float = Field(
         ...,
         title="실물체결수량 (Spot execution quantity)",
         description="Spot-execution quantity in shares.",
         examples=[0, 1],
     )
-    sStslExecQty: int = Field(
+    sStslExecQty: float = Field(
         ...,
         title="공매도체결수량 (Short-sale execution quantity)",
         description="Short-sale execution quantity in shares.",
@@ -659,43 +659,43 @@ class AS1RealResponseBody(BaseModel):
         description="Reject reason text / code; empty when not rejected.",
         examples=[""],
     )
-    sSecBalQty: int = Field(
+    sSecBalQty: float = Field(
         ...,
         title="잔고수량 (Holding quantity)",
         description="Position holding quantity for the symbol after the fill.",
         examples=[0, 10],
     )
-    sSpotOrdAbleQty: int = Field(
+    sSpotOrdAbleQty: float = Field(
         ...,
         title="실물주문가능수량 (Spot-orderable quantity)",
         description="Quantity available for spot ordering.",
         examples=[0, 10],
     )
-    sOrdAbleRuseQty: int = Field(
+    sOrdAbleRuseQty: float = Field(
         ...,
         title="주문가능재사용수량 (Reuse-orderable quantity)",
         description="Reusable quantity available for ordering.",
         examples=[0],
     )
-    sFlctQty: int = Field(
+    sFlctQty: float = Field(
         ...,
         title="변동수량 (Change quantity)",
         description="Net change in quantity caused by this fill.",
         examples=[0, 1, -1],
     )
-    sSecBalQtyD2: int = Field(
+    sSecBalQtyD2: float = Field(
         ...,
         title="잔고수량(D2) (D+2 holding quantity)",
         description="D+2 settled holding quantity for the symbol.",
         examples=[0, 10],
     )
-    sSellAbleQty: int = Field(
+    sSellAbleQty: float = Field(
         ...,
         title="매도주문가능수량 (Sell-orderable quantity)",
         description="Quantity currently available to sell.",
         examples=[0, 10],
     )
-    sUnercSellOrdQty: int = Field(
+    sUnercSellOrdQty: float = Field(
         ...,
         title="미체결매도주문수량 (Unfilled sell-order quantity)",
         description="Sell-side quantity currently unfilled.",

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS2/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS2/blocks.py
@@ -392,7 +392,7 @@ class AS2RealResponseBody(BaseModel):
         description="Overseas-side execution identifier.",
         examples=[""],
     )
-    sOrdQty: int = Field(
+    sOrdQty: float = Field(
         ...,
         title="주문수량 (Order quantity)",
         description="Order quantity in shares.",
@@ -407,7 +407,7 @@ class AS2RealResponseBody(BaseModel):
         ),
         examples=[0.0, 180.5],
     )
-    sExecQty: int = Field(
+    sExecQty: float = Field(
         ...,
         title="체결수량 (Execution quantity)",
         description="Quantity filled in this event (typically 0 for modify).",
@@ -419,7 +419,7 @@ class AS2RealResponseBody(BaseModel):
         description="Execution price (typically 0 for modify).",
         examples=[0.0],
     )
-    sMdfyCnfQty: int = Field(
+    sMdfyCnfQty: float = Field(
         ...,
         title="정정확인수량 (Modify-confirm quantity)",
         description="Quantity confirmed for the modify event.",
@@ -431,13 +431,13 @@ class AS2RealResponseBody(BaseModel):
         description="Price confirmed for the modify event.",
         examples=[0.0, 181.0],
     )
-    sCancCnfQty: int = Field(
+    sCancCnfQty: float = Field(
         ...,
         title="취소확인수량 (Cancel-confirm quantity)",
         description="Quantity confirmed for a cancel event (0 for modify).",
         examples=[0],
     )
-    sRjtQty: int = Field(
+    sRjtQty: float = Field(
         ...,
         title="거부수량 (Reject quantity)",
         description="Quantity rejected.",
@@ -485,25 +485,25 @@ class AS2RealResponseBody(BaseModel):
         description="Operation-directive number; consume as returned by LS.",
         examples=[""],
     )
-    sUnercQty: int = Field(
+    sUnercQty: float = Field(
         ...,
         title="미체결수량(주문) (Unfilled order quantity)",
         description="Quantity unfilled on this order after the modify.",
         examples=[0, 5],
     )
-    sOrgOrdUnercQty: int = Field(
+    sOrgOrdUnercQty: float = Field(
         ...,
         title="원주문미체결수량 (Original-order unfilled quantity)",
         description="Unfilled quantity remaining on the original order.",
         examples=[0, 5],
     )
-    sOrgOrdMdfyQty: int = Field(
+    sOrgOrdMdfyQty: float = Field(
         ...,
         title="원주문정정수량 (Original-order modified quantity)",
         description="Quantity that has been modified on the original order.",
         examples=[0, 1],
     )
-    sOrgOrdCancQty: int = Field(
+    sOrgOrdCancQty: float = Field(
         ...,
         title="원주문취소수량 (Original-order cancelled quantity)",
         description="Quantity cancelled from the original order.",
@@ -603,13 +603,13 @@ class AS2RealResponseBody(BaseModel):
         description="Reuse-funds executed amount within current day.",
         examples=[0.0],
     )
-    sSpotExecQty: int = Field(
+    sSpotExecQty: float = Field(
         ...,
         title="실물체결수량 (Spot execution quantity)",
         description="Spot-execution quantity in shares.",
         examples=[0],
     )
-    sStslExecQty: int = Field(
+    sStslExecQty: float = Field(
         ...,
         title="공매도체결수량 (Short-sale execution quantity)",
         description="Short-sale execution quantity in shares.",
@@ -657,43 +657,43 @@ class AS2RealResponseBody(BaseModel):
         description="Reject reason text / code; empty when not rejected.",
         examples=[""],
     )
-    sSecBalQty: int = Field(
+    sSecBalQty: float = Field(
         ...,
         title="잔고수량 (Holding quantity)",
         description="Position holding quantity for the symbol after the event.",
         examples=[0, 10],
     )
-    sSpotOrdAbleQty: int = Field(
+    sSpotOrdAbleQty: float = Field(
         ...,
         title="실물주문가능수량 (Spot-orderable quantity)",
         description="Quantity available for spot ordering.",
         examples=[0, 10],
     )
-    sOrdAbleRuseQty: int = Field(
+    sOrdAbleRuseQty: float = Field(
         ...,
         title="주문가능재사용수량 (Reuse-orderable quantity)",
         description="Reusable quantity available for ordering.",
         examples=[0],
     )
-    sFlctQty: int = Field(
+    sFlctQty: float = Field(
         ...,
         title="변동수량 (Change quantity)",
         description="Net change in quantity caused by this event.",
         examples=[0],
     )
-    sSecBalQtyD2: int = Field(
+    sSecBalQtyD2: float = Field(
         ...,
         title="잔고수량(D2) (D+2 holding quantity)",
         description="D+2 settled holding quantity for the symbol.",
         examples=[0, 10],
     )
-    sSellAbleQty: int = Field(
+    sSellAbleQty: float = Field(
         ...,
         title="매도주문가능수량 (Sell-orderable quantity)",
         description="Quantity currently available to sell.",
         examples=[0, 10],
     )
-    sUnercSellOrdQty: int = Field(
+    sUnercSellOrdQty: float = Field(
         ...,
         title="미체결매도주문수량 (Unfilled sell-order quantity)",
         description="Sell-side quantity currently unfilled.",

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS3/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS3/blocks.py
@@ -392,7 +392,7 @@ class AS3RealResponseBody(BaseModel):
         description="Overseas-side execution identifier.",
         examples=[""],
     )
-    sOrdQty: int = Field(
+    sOrdQty: float = Field(
         ...,
         title="주문수량 (Order quantity)",
         description="Order quantity in shares.",
@@ -407,7 +407,7 @@ class AS3RealResponseBody(BaseModel):
         ),
         examples=[0.0, 180.5],
     )
-    sExecQty: int = Field(
+    sExecQty: float = Field(
         ...,
         title="체결수량 (Execution quantity)",
         description="Quantity filled in this event (typically 0 for cancel).",
@@ -419,7 +419,7 @@ class AS3RealResponseBody(BaseModel):
         description="Execution price (typically 0 for cancel).",
         examples=[0.0],
     )
-    sMdfyCnfQty: int = Field(
+    sMdfyCnfQty: float = Field(
         ...,
         title="정정확인수량 (Modify-confirm quantity)",
         description="Quantity confirmed for a modify event (0 for cancel).",
@@ -431,13 +431,13 @@ class AS3RealResponseBody(BaseModel):
         description="Price confirmed for a modify event (0 for cancel).",
         examples=[0.0],
     )
-    sCancCnfQty: int = Field(
+    sCancCnfQty: float = Field(
         ...,
         title="취소확인수량 (Cancel-confirm quantity)",
         description="Quantity confirmed for the cancel event.",
         examples=[0, 1],
     )
-    sRjtQty: int = Field(
+    sRjtQty: float = Field(
         ...,
         title="거부수량 (Reject quantity)",
         description="Quantity rejected.",
@@ -485,25 +485,25 @@ class AS3RealResponseBody(BaseModel):
         description="Operation-directive number; consume as returned by LS.",
         examples=[""],
     )
-    sUnercQty: int = Field(
+    sUnercQty: float = Field(
         ...,
         title="미체결수량(주문) (Unfilled order quantity)",
         description="Quantity unfilled on this order after the cancel.",
         examples=[0],
     )
-    sOrgOrdUnercQty: int = Field(
+    sOrgOrdUnercQty: float = Field(
         ...,
         title="원주문미체결수량 (Original-order unfilled quantity)",
         description="Unfilled quantity remaining on the original order.",
         examples=[0],
     )
-    sOrgOrdMdfyQty: int = Field(
+    sOrgOrdMdfyQty: float = Field(
         ...,
         title="원주문정정수량 (Original-order modified quantity)",
         description="Quantity that has been modified on the original order.",
         examples=[0],
     )
-    sOrgOrdCancQty: int = Field(
+    sOrgOrdCancQty: float = Field(
         ...,
         title="원주문취소수량 (Original-order cancelled quantity)",
         description="Quantity cancelled from the original order.",
@@ -603,13 +603,13 @@ class AS3RealResponseBody(BaseModel):
         description="Reuse-funds executed amount within current day.",
         examples=[0.0],
     )
-    sSpotExecQty: int = Field(
+    sSpotExecQty: float = Field(
         ...,
         title="실물체결수량 (Spot execution quantity)",
         description="Spot-execution quantity in shares.",
         examples=[0],
     )
-    sStslExecQty: int = Field(
+    sStslExecQty: float = Field(
         ...,
         title="공매도체결수량 (Short-sale execution quantity)",
         description="Short-sale execution quantity in shares.",
@@ -657,43 +657,43 @@ class AS3RealResponseBody(BaseModel):
         description="Reject reason text / code; empty when not rejected.",
         examples=[""],
     )
-    sSecBalQty: int = Field(
+    sSecBalQty: float = Field(
         ...,
         title="잔고수량 (Holding quantity)",
         description="Position holding quantity for the symbol after the event.",
         examples=[0, 10],
     )
-    sSpotOrdAbleQty: int = Field(
+    sSpotOrdAbleQty: float = Field(
         ...,
         title="실물주문가능수량 (Spot-orderable quantity)",
         description="Quantity available for spot ordering.",
         examples=[0, 10],
     )
-    sOrdAbleRuseQty: int = Field(
+    sOrdAbleRuseQty: float = Field(
         ...,
         title="주문가능재사용수량 (Reuse-orderable quantity)",
         description="Reusable quantity available for ordering.",
         examples=[0],
     )
-    sFlctQty: int = Field(
+    sFlctQty: float = Field(
         ...,
         title="변동수량 (Change quantity)",
         description="Net change in quantity caused by this event.",
         examples=[0, -1],
     )
-    sSecBalQtyD2: int = Field(
+    sSecBalQtyD2: float = Field(
         ...,
         title="잔고수량(D2) (D+2 holding quantity)",
         description="D+2 settled holding quantity for the symbol.",
         examples=[0, 10],
     )
-    sSellAbleQty: int = Field(
+    sSellAbleQty: float = Field(
         ...,
         title="매도주문가능수량 (Sell-orderable quantity)",
         description="Quantity currently available to sell.",
         examples=[0, 10],
     )
-    sUnercSellOrdQty: int = Field(
+    sUnercSellOrdQty: float = Field(
         ...,
         title="미체결매도주문수량 (Unfilled sell-order quantity)",
         description="Sell-side quantity currently unfilled.",

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS4/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS4/blocks.py
@@ -397,7 +397,7 @@ class AS4RealResponseBody(BaseModel):
         description="Overseas-side execution identifier.",
         examples=[""],
     )
-    sOrdQty: int = Field(
+    sOrdQty: float = Field(
         ...,
         title="주문수량 (Order quantity)",
         description="Order quantity in shares.",
@@ -412,7 +412,7 @@ class AS4RealResponseBody(BaseModel):
         ),
         examples=[0.0, 180.5],
     )
-    sExecQty: int = Field(
+    sExecQty: float = Field(
         ...,
         title="체결수량 (Execution quantity)",
         description="Quantity filled (typically 0 for reject).",
@@ -424,7 +424,7 @@ class AS4RealResponseBody(BaseModel):
         description="Execution price (typically 0 for reject).",
         examples=[0.0],
     )
-    sMdfyCnfQty: int = Field(
+    sMdfyCnfQty: float = Field(
         ...,
         title="정정확인수량 (Modify-confirm quantity)",
         description="Quantity confirmed for a modify event (0 for reject).",
@@ -436,13 +436,13 @@ class AS4RealResponseBody(BaseModel):
         description="Price confirmed for a modify event (0 for reject).",
         examples=[0.0],
     )
-    sCancCnfQty: int = Field(
+    sCancCnfQty: float = Field(
         ...,
         title="취소확인수량 (Cancel-confirm quantity)",
         description="Quantity confirmed for a cancel event (0 for reject).",
         examples=[0],
     )
-    sRjtQty: int = Field(
+    sRjtQty: float = Field(
         ...,
         title="거부수량 (Reject quantity)",
         description="Quantity rejected.",
@@ -490,25 +490,25 @@ class AS4RealResponseBody(BaseModel):
         description="Operation-directive number; consume as returned by LS.",
         examples=[""],
     )
-    sUnercQty: int = Field(
+    sUnercQty: float = Field(
         ...,
         title="미체결수량(주문) (Unfilled order quantity)",
         description="Quantity unfilled on this order at the time of reject.",
         examples=[0, 5],
     )
-    sOrgOrdUnercQty: int = Field(
+    sOrgOrdUnercQty: float = Field(
         ...,
         title="원주문미체결수량 (Original-order unfilled quantity)",
         description="Unfilled quantity remaining on the original order.",
         examples=[0, 5],
     )
-    sOrgOrdMdfyQty: int = Field(
+    sOrgOrdMdfyQty: float = Field(
         ...,
         title="원주문정정수량 (Original-order modified quantity)",
         description="Quantity that has been modified on the original order.",
         examples=[0],
     )
-    sOrgOrdCancQty: int = Field(
+    sOrgOrdCancQty: float = Field(
         ...,
         title="원주문취소수량 (Original-order cancelled quantity)",
         description="Quantity cancelled from the original order.",
@@ -608,13 +608,13 @@ class AS4RealResponseBody(BaseModel):
         description="Reuse-funds executed amount within current day.",
         examples=[0.0],
     )
-    sSpotExecQty: int = Field(
+    sSpotExecQty: float = Field(
         ...,
         title="실물체결수량 (Spot execution quantity)",
         description="Spot-execution quantity in shares.",
         examples=[0],
     )
-    sStslExecQty: int = Field(
+    sStslExecQty: float = Field(
         ...,
         title="공매도체결수량 (Short-sale execution quantity)",
         description="Short-sale execution quantity in shares.",
@@ -665,43 +665,43 @@ class AS4RealResponseBody(BaseModel):
         ),
         examples=["INSUFFICIENT_FUNDS", ""],
     )
-    sSecBalQty: int = Field(
+    sSecBalQty: float = Field(
         ...,
         title="잔고수량 (Holding quantity)",
         description="Position holding quantity for the symbol after the event.",
         examples=[0, 10],
     )
-    sSpotOrdAbleQty: int = Field(
+    sSpotOrdAbleQty: float = Field(
         ...,
         title="실물주문가능수량 (Spot-orderable quantity)",
         description="Quantity available for spot ordering.",
         examples=[0, 10],
     )
-    sOrdAbleRuseQty: int = Field(
+    sOrdAbleRuseQty: float = Field(
         ...,
         title="주문가능재사용수량 (Reuse-orderable quantity)",
         description="Reusable quantity available for ordering.",
         examples=[0],
     )
-    sFlctQty: int = Field(
+    sFlctQty: float = Field(
         ...,
         title="변동수량 (Change quantity)",
         description="Net change in quantity caused by this event.",
         examples=[0],
     )
-    sSecBalQtyD2: int = Field(
+    sSecBalQtyD2: float = Field(
         ...,
         title="잔고수량(D2) (D+2 holding quantity)",
         description="D+2 settled holding quantity for the symbol.",
         examples=[0, 10],
     )
-    sSellAbleQty: int = Field(
+    sSellAbleQty: float = Field(
         ...,
         title="매도주문가능수량 (Sell-orderable quantity)",
         description="Quantity currently available to sell.",
         examples=[0, 10],
     )
-    sUnercSellOrdQty: int = Field(
+    sUnercSellOrdQty: float = Field(
         ...,
         title="미체결매도주문수량 (Unfilled sell-order quantity)",
         description="Sell-side quantity currently unfilled.",

--- a/src/finance/programgarden_finance/ls/tr_helpers.py
+++ b/src/finance/programgarden_finance/ls/tr_helpers.py
@@ -38,6 +38,16 @@ TOKEN_REISSUE_RETRY_MAX = 2  # 한 요청 안에서 허용하는 강제 재발�
 _MUTATING_URL_SUFFIX = "/order"
 
 
+class ResponseParseException(Exception):
+    """response_builder 가 이미 수신한 HTTP 응답 위에서 실패한 경우 — 파싱/검증
+    실패이지 전송 실패가 아니다. error_msg 에 'response parse error:' 접두어가
+    실려 하류에서 네트워크 장애와 구분된다 (전에는 둘이 똑같이 보였다)."""
+
+    def __init__(self, original: Exception):
+        self.original = original
+        super().__init__(f"response parse error: {original}")
+
+
 class GenericTR(TRAccnoAbstract, Generic[R]):
     """
     범용 TR 핸들러입니다. 공통적인 동기/비동기 요청 처리, 예외 처리, 재시도 로직을 제공합니다.
@@ -254,15 +264,26 @@ class GenericTR(TRAccnoAbstract, Generic[R]):
         except TokenNotFoundException:
             pass
 
+    def _build_result(self, resp, resp_json, resp_headers) -> R:
+        """수신 완료한 응답을 파싱한다 — 여기서 나는 예외는 전송 실패가 아니라
+        파싱 실패이므로 ResponseParseException 으로 감싸 구분한다."""
+        try:
+            result: R = self._response_builder(resp, resp_json, resp_headers, None)
+        except Exception as e:
+            raise ResponseParseException(e) from e
+        if hasattr(result, "raw_data"):
+            result.raw_data = resp
+        return result
+
     async def req_async(self) -> R:
         try:
             async with aiohttp.ClientSession() as session:
                 resp, resp_json, resp_headers = await self._execute_async_with_retry(session)
-                result: R = self._response_builder(resp, resp_json, resp_headers, None)
-                if hasattr(result, "raw_data"):
-                    result.raw_data = resp
-                return result
+                return self._build_result(resp, resp_json, resp_headers)
 
+        except ResponseParseException as e:
+            logger.error(f"GenericTR 응답 파싱 중 예외: {e.original}")
+            return self._response_builder(None, None, None, e)
         except Exception as e:
             logger.error(f"GenericTR 비동기 요청 중 예외: {e}")
             return self._response_builder(None, None, None, e)
@@ -275,11 +296,11 @@ class GenericTR(TRAccnoAbstract, Generic[R]):
         """
         try:
             resp, resp_json, resp_headers = await self._execute_async_with_retry(session)
-            result: R = self._response_builder(resp, resp_json, resp_headers, None)
-            if hasattr(result, "raw_data"):
-                result.raw_data = resp
-            return result
+            return self._build_result(resp, resp_json, resp_headers)
 
+        except ResponseParseException as e:
+            logger.error(f"GenericTR._req_async_with_session 응답 파싱 중 예외: {e.original}")
+            return self._response_builder(None, None, None, e)
         except Exception as e:
             logger.error(f"GenericTR._req_async_with_session 비동기 요청 중 예외: {e}")
             return self._response_builder(None, None, None, e)
@@ -287,11 +308,11 @@ class GenericTR(TRAccnoAbstract, Generic[R]):
     def req(self) -> R:
         try:
             resp, resp_json, resp_headers = self._execute_sync_with_retry()
-            result: R = self._response_builder(resp, resp_json, resp_headers, None)
-            if hasattr(result, "raw_data"):
-                result.raw_data = resp
-            return result
+            return self._build_result(resp, resp_json, resp_headers)
 
+        except ResponseParseException as e:
+            logger.error(f"GenericTR 응답 파싱 중 예외: {e.original}")
+            return self._response_builder(None, None, None, e)
         except Exception as e:
             logger.error(f"GenericTR 동기 요청 중 예외: {e}")
             return self._response_builder(None, None, None, e)

--- a/src/finance/tests/test_cosoq00201_fractional.py
+++ b/src/finance/tests/test_cosoq00201_fractional.py
@@ -1,0 +1,151 @@
+"""COSOQ00201 소수점(fractional) 잔고 회귀 테스트.
+
+prod 2026-08-24 실측 재현: LS 가 소수점 잔고(AstkBalTpCode='20')를
+'0.847972' 같은 소수 문자열로 반환하면, 종전 int 타입은 pydantic
+ValidationError 를 던져 정상 종목까지 포함한 잔고 응답 전체를 유실시켰다.
+
+기존 test_account_balance.py 는 MagicMock 으로 block 을 만들어 pydantic
+검증을 한 번도 타지 않았다 — 여기서는 실제 모델/실제 파서를 태운다.
+"""
+import types
+
+import pytest
+
+from programgarden_finance.ls.overseas_stock.accno.COSOQ00201 import TrCOSOQ00201
+from programgarden_finance.ls.overseas_stock.accno.COSOQ00201.blocks import (
+    COSOQ00201OutBlock4,
+)
+from programgarden_finance.ls.tr_helpers import ResponseParseException
+from programgarden_finance.ls.overseas_stock.extension.tracker import (
+    StockAccountTracker,
+)
+
+
+def _fractional_row(symbol: str = "IBM", qty: str = "0.847972") -> dict:
+    """prod 실측 모양의 소수점 잔고 행 (수량이 소수 문자열로 온다)."""
+    return {
+        "ShtnIsuNo": symbol,
+        "AstkBalTpCode": "20",
+        "AstkBalQty": qty,
+        "AstkSellAbleQty": qty,
+    }
+
+
+def _integer_row(symbol: str = "SOXL", qty: int = 16) -> dict:
+    return {
+        "ShtnIsuNo": symbol,
+        "AstkBalTpCode": "10",
+        "AstkBalQty": qty,
+        "AstkSellAbleQty": qty,
+    }
+
+
+def _build(resp_json: dict, exc: Exception = None):
+    """_build_response 는 self 를 쓰지 않는다 — 인스턴스 없이 직접 호출."""
+    return TrCOSOQ00201._build_response(None, None, resp_json, None, exc)
+
+
+class TestFractionalBalanceParsing:
+    def test_fractional_string_parses_as_float(self):
+        block = COSOQ00201OutBlock4.model_validate(_fractional_row())
+        assert block.AstkBalQty == pytest.approx(0.847972)
+        assert block.AstkSellAbleQty == pytest.approx(0.847972)
+
+    def test_prod_regression_mixed_rows_all_survive(self):
+        """신고 재현: IBM 0.847972주(무관 종목) + SOXL 16주 — 전체가 살아야 한다."""
+        resp = _build({
+            "rsp_cd": "00000",
+            "rsp_msg": "정상",
+            "COSOQ00201OutBlock4": [_integer_row(), _fractional_row()],
+        })
+        assert resp.error_msg is None
+        assert len(resp.block4) == 2
+        by_symbol = {b.ShtnIsuNo: b for b in resp.block4}
+        assert by_symbol["SOXL"].AstkBalQty == 16
+        assert by_symbol["IBM"].AstkBalQty == pytest.approx(0.847972)
+
+    def test_bad_row_skipped_survivors_kept(self):
+        """불량 행 1개가 나머지를 죽이지 않는다 (행 단위 파싱)."""
+        resp = _build({
+            "rsp_cd": "00000",
+            "COSOQ00201OutBlock4": [
+                _integer_row(),
+                {"ShtnIsuNo": "BAD", "AstkBalQty": "not-a-number"},
+            ],
+        })
+        assert resp.error_msg is None
+        assert len(resp.block4) == 1
+        assert resp.block4[0].ShtnIsuNo == "SOXL"
+
+    def test_all_rows_bad_sets_error(self):
+        """블록 전멸은 빈 잔고가 아니라 에러다 (조용한 오답 금지)."""
+        resp = _build({
+            "rsp_cd": "00000",
+            "COSOQ00201OutBlock4": [
+                {"ShtnIsuNo": "BAD1", "AstkBalQty": "x"},
+                {"ShtnIsuNo": "BAD2", "AstkBalQty": "y"},
+            ],
+        })
+        assert resp.error_msg is not None
+        assert "response parse error" in resp.error_msg
+        assert resp.block4 == []
+
+    def test_parse_exception_prefix_distinguishes_from_transport(self):
+        exc = ResponseParseException(ValueError("boom"))
+        assert str(exc).startswith("response parse error:")
+        resp = _build({}, exc=exc)
+        assert resp.error_msg.startswith("response parse error:")
+
+
+class _StubTR:
+    def __init__(self, resp):
+        self._resp = resp
+
+    async def req_async(self):
+        return self._resp
+
+
+class _StubAccnoClient:
+    def __init__(self, resp):
+        self._resp = resp
+
+    def cosoq00201(self, body=None):
+        return _StubTR(self._resp)
+
+
+def _make_tracker(resp) -> StockAccountTracker:
+    return StockAccountTracker(accno_client=_StubAccnoClient(resp), real_client=None)
+
+
+class TestTrackerFailClosed:
+    @pytest.mark.asyncio
+    async def test_parse_failure_does_not_clear_positions(self):
+        """GenericTR fallback(빈 응답 + error_msg)이 '보유종목 0개' 로 둔갑하면 안 된다."""
+        failure = types.SimpleNamespace(
+            rsp_cd="", rsp_msg="", error_msg="response parse error: ...",
+            block3=[], block4=[],
+        )
+        tracker = _make_tracker(failure)
+        sentinel = object()
+        tracker._positions["SOXL"] = sentinel
+
+        await tracker._fetch_positions()
+
+        assert tracker._positions.get("SOXL") is sentinel, "기존 포지션이 지워지면 안 된다"
+        assert "positions" in tracker._last_errors
+        assert "response parse error" in tracker._last_errors["positions"]
+
+    @pytest.mark.asyncio
+    async def test_no_data_response_still_clears(self):
+        """정상 '데이터 없음' 응답은 종전대로 빈 잔고 처리."""
+        no_data = types.SimpleNamespace(
+            rsp_cd="00123", rsp_msg="조회내역이 없습니다", error_msg=None,
+            block3=[], block4=[],
+        )
+        tracker = _make_tracker(no_data)
+        tracker._positions["SOXL"] = object()
+
+        await tracker._fetch_positions()
+
+        assert tracker._positions == {}
+        assert "positions" not in tracker._last_errors

--- a/src/finance/tests/test_cosoq00201_fractional.py
+++ b/src/finance/tests/test_cosoq00201_fractional.py
@@ -149,3 +149,100 @@ class TestTrackerFailClosed:
 
         assert tracker._positions == {}
         assert "positions" not in tracker._last_errors
+
+
+class TestPartialFailureSignal:
+    """적대 리뷰 #2·#3·#15 — 부분실패가 응답 계약에 드러난다."""
+
+    def test_partial_rows_populate_parse_warnings_without_error(self):
+        resp = _build({
+            "rsp_cd": "00000",
+            "COSOQ00201OutBlock4": [
+                _integer_row(),
+                {"ShtnIsuNo": "BAD", "AstkBalQty": "not-a-number"},
+            ],
+        })
+        assert resp.error_msg is None
+        assert len(resp.parse_warnings) == 1
+        assert "OutBlock4[1]" in resp.parse_warnings[0]
+
+    def test_full_success_has_empty_warnings(self):
+        resp = _build({
+            "rsp_cd": "00000",
+            "COSOQ00201OutBlock4": [_integer_row(), _fractional_row()],
+        })
+        assert resp.parse_warnings == []
+
+    def test_block2_loss_is_loud(self):
+        """잔고 요약(OutBlock2) 전손은 무음 0원이 아니라 에러다 (적대 리뷰 #2)."""
+        resp = _build({
+            "rsp_cd": "00000",
+            "COSOQ00201OutBlock2": {"WonDpsBalAmt": "not-a-number"},
+            "COSOQ00201OutBlock4": [_integer_row()],
+        })
+        assert resp.error_msg is not None
+        assert "OutBlock2" in resp.error_msg
+
+    @pytest.mark.asyncio
+    async def test_tracker_partial_rows_fail_closed(self):
+        """스킵된 행이 있으면 기존 포지션을 갱신하지 않는다 (적대 리뷰 #3)."""
+        partial = types.SimpleNamespace(
+            rsp_cd="00000", rsp_msg="정상", error_msg=None,
+            parse_warnings=["OutBlock4[1]: boom"],
+            block3=[], block4=[],
+        )
+        tracker = _make_tracker(partial)
+        sentinel = object()
+        tracker._positions["IBM"] = sentinel
+
+        await tracker._fetch_positions()
+
+        assert tracker._positions.get("IBM") is sentinel
+        assert "부분실패" in tracker._last_errors["positions"]
+
+
+class TestOpenOrdersReadsBlock3:
+    """적대 리뷰 #4 — 미체결 조회가 입력 에코(block1)가 아닌 block3 을 읽는다."""
+
+    @pytest.mark.asyncio
+    async def test_real_rows_flow_into_open_orders(self):
+        row = types.SimpleNamespace(
+            OrdNo=12345, OrgOrdNo=0, ShtnIsuNo="SOXL", IsuNo="SOXL",
+            JpnMktHanglIsuNm="SOXL", OrdPtnCode="02", OrdQty=16,
+            OvrsOrdPrc=10.5, ExecQty=0, UnercQty=16, OrdTime="120000",
+            OrdTrxPtnCode=1, CrcyCode="USD",
+        )
+        resp = types.SimpleNamespace(
+            rsp_cd="00000", rsp_msg="정상", error_msg=None,
+            block1=object(), block3=[row],
+        )
+        tracker = StockAccountTracker(
+            accno_client=types.SimpleNamespace(cosaq00102=lambda body: _StubTR(resp)),
+            real_client=None,
+        )
+        await tracker._fetch_open_orders()
+        assert "12345" in tracker._open_orders
+        order = tracker._open_orders["12345"]
+        assert order.symbol == "SOXL"
+        assert order.order_qty == 16
+        assert order.remaining_qty == 16
+
+    @pytest.mark.asyncio
+    async def test_fractional_open_order_row_does_not_raise(self):
+        row = types.SimpleNamespace(
+            OrdNo=777, ShtnIsuNo="IBM", IsuNo="IBM", JpnMktHanglIsuNm="IBM",
+            OrdPtnCode="01", OrdQty=0.847972, OvrsOrdPrc=100.0,
+            ExecQty=0.5, UnercQty=0.347972, OrdTime="120000",
+            OrdTrxPtnCode=1, CrcyCode="USD",
+        )
+        resp = types.SimpleNamespace(
+            rsp_cd="00000", rsp_msg="정상", error_msg=None,
+            block1=object(), block3=[row],
+        )
+        tracker = StockAccountTracker(
+            accno_client=types.SimpleNamespace(cosaq00102=lambda body: _StubTR(resp)),
+            real_client=None,
+        )
+        await tracker._fetch_open_orders()
+        assert tracker._open_orders["777"].order_qty == pytest.approx(0.847972)
+        assert "open_orders" not in tracker._last_errors

--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -44,7 +44,7 @@ class PositionInfo:
     """포지션 정보"""
     symbol: str
     exchange: str
-    quantity: int
+    quantity: Decimal  # 소수점(fractional) 잔고 대응 — 가격류와의 Decimal 혼합 산술 안전
     avg_price: Decimal
     classification: str  # "workflow" | "manual" | "unknown_api"
 
@@ -570,18 +570,21 @@ class WorkflowPositionTracker:
             positions: Dict[str, PositionInfo] = {}
             
             for symbol, exchange, buy_price, remaining_qty, classification in cursor.fetchall():
+                # SQLite 가 소수점 체결 lot 을 REAL 로 돌려줄 수 있어 Decimal 로
+                # 통일한다 (Decimal * float 는 TypeError).
+                lot_qty = Decimal(str(remaining_qty))
                 if symbol in positions:
                     # 같은 종목: 평균단가 재계산
                     pos = positions[symbol]
-                    total_qty = pos.quantity + remaining_qty
-                    total_cost = (pos.avg_price * pos.quantity) + (Decimal(str(buy_price)) * remaining_qty)
+                    total_qty = pos.quantity + lot_qty
+                    total_cost = (pos.avg_price * pos.quantity) + (Decimal(str(buy_price)) * lot_qty)
                     pos.quantity = total_qty
                     pos.avg_price = total_cost / total_qty
                 else:
                     positions[symbol] = PositionInfo(
                         symbol=symbol,
                         exchange=exchange or "",
-                        quantity=remaining_qty,
+                        quantity=lot_qty,
                         avg_price=Decimal(str(buy_price)),
                         classification=classification,
                     )
@@ -605,11 +608,11 @@ class WorkflowPositionTracker:
         other_positions: Dict[str, PositionInfo] = {}
         
         for symbol, pos_data in all_positions.items():
-            total_qty = pos_data.get("quantity", 0) or pos_data.get("qty", 0)
+            total_qty = Decimal(str(pos_data.get("quantity", 0) or pos_data.get("qty", 0) or 0))
             avg_price = pos_data.get("avg_price", 0) or pos_data.get("buy_price", 0)
             exchange = pos_data.get("exchange", "")
-            
-            workflow_qty = workflow_positions.get(symbol, PositionInfo(symbol, "", 0, Decimal(0), "")).quantity
+
+            workflow_qty = workflow_positions.get(symbol, PositionInfo(symbol, "", Decimal(0), Decimal(0), "")).quantity
             other_qty = total_qty - workflow_qty
             
             if other_qty > 0:

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -4602,7 +4602,7 @@ class BrokerNodeExecutor(NodeExecutorBase):
             for item in result.block3:
                 order_no = str(getattr(item, 'OrdNo', 0))
                 fill_price = float(getattr(item, 'OvrsExecPrc', 0))
-                fill_qty = int(getattr(item, 'ExecQty', 0))
+                fill_qty = _qty_num(getattr(item, 'ExecQty', 0))
                 symbol = str(getattr(item, 'ShtnIsuNo', getattr(item, 'IsuNo', '')))
                 market_code = str(getattr(item, 'OrdMktCode', '82'))
                 side_code = str(getattr(item, 'BnsTpCode', ''))  # 1=매도, 2=매수
@@ -5186,6 +5186,22 @@ class AccountNodeExecutor(NodeExecutorBase):
             balance_info["_failure_codes"] = ["COSOQ02701"]
             balance_info["_failure_reason"] = cosoq02701_failure_reason or "COSOQ02701 fetch failed"
 
+        # COSOQ00201 행 단위 파싱에서 스킵된 행이 있으면 부분실패로 표시 —
+        # 유실 행의 종목을 '보유 없음' 으로 소비하면 이중 매수 같은 조용한
+        # 오답이 된다(적대 리뷰 #3·#15). balance dict 의 _partial_failure
+        # 프로토콜은 주문 노드 _diagnose_empty_reason 이 이미 소비한다.
+        cosoq00201_warnings = list(getattr(response, "parse_warnings", None) or [])
+        if cosoq00201_warnings:
+            balance_info["_partial_failure"] = True
+            balance_info.setdefault("_failure_codes", []).append("COSOQ00201_ROWS")
+            prior = balance_info.get("_failure_reason")
+            row_reason = (
+                f"COSOQ00201 skipped {len(cosoq00201_warnings)} unparseable row(s): "
+                f"{cosoq00201_warnings[0]}"
+            )
+            balance_info["_failure_reason"] = f"{prior}; {row_reason}" if prior else row_reason
+            context.log("warning", f"AccountNode: {row_reason}", node_id)
+
         context.log("info", f"AccountNode: {len(positions)} positions fetched", node_id)
         return {
             "held_symbols": held_symbols,
@@ -5701,9 +5717,9 @@ class OpenOrdersNodeExecutor(NodeExecutorBase):
                 "name": item.JpnMktHanglIsuNm.strip() if item.JpnMktHanglIsuNm else "",
                 "side": side,
                 "order_type": "limit",  # 해외주식은 대부분 지정가
-                "quantity": int(item.OrdQty) if item.OrdQty else 0,
-                "filled_quantity": int(item.ExecQty) if item.ExecQty else 0,
-                "remaining_quantity": int(item.UnercQty) if item.UnercQty else 0,
+                "quantity": _qty_num(item.OrdQty) if item.OrdQty else 0,
+                "filled_quantity": _qty_num(item.ExecQty) if item.ExecQty else 0,
+                "remaining_quantity": _qty_num(item.UnercQty) if item.UnercQty else 0,
                 "price": float(item.OvrsOrdPrc) if item.OvrsOrdPrc else 0.0,
                 "order_time": item.OrdTime if item.OrdTime else "",
             })
@@ -5751,9 +5767,9 @@ class OpenOrdersNodeExecutor(NodeExecutorBase):
             # BnsTpCode: 1=매도, 2=매수
             side = "buy" if item.BnsTpCode == "2" else "sell"
 
-            order_qty = int(item.OrdQty) if hasattr(item, 'OrdQty') and item.OrdQty else 0
-            exec_qty = int(item.ExecQty) if hasattr(item, 'ExecQty') and item.ExecQty else 0
-            unerc_qty = int(item.UnercQty) if hasattr(item, 'UnercQty') and item.UnercQty else 0
+            order_qty = _qty_num(item.OrdQty) if hasattr(item, 'OrdQty') and item.OrdQty else 0
+            exec_qty = _qty_num(item.ExecQty) if hasattr(item, 'ExecQty') and item.ExecQty else 0
+            unerc_qty = _qty_num(item.UnercQty) if hasattr(item, 'UnercQty') and item.UnercQty else 0
 
             open_orders.append({
                 "order_id": order_id,
@@ -13930,6 +13946,23 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                 context.log("error", f"{node_type}: Unsupported product: {product}", node_id)
                 return self._error_result(f"Unsupported product: {product}")
 
+            # === 5.2. 소수점 잔량 관측성 (숨은 절단 금지 — 적대 리뷰 #6) ===
+            # _normalize_order 가 정수부만 주문하고 남긴 소수점 잔량을 워크플로우
+            # 로그와 order_result 에 명시한다 — 이것이 없으면 16.847972주 전량매도가
+            # "16주 성공" 으로만 보여 사용자가 잔량의 존재를 알 수 없다.
+            fractional_remainder = normalized_order.get("fractional_remainder")
+            if fractional_remainder and isinstance(order_result, dict):
+                context.log(
+                    "warning",
+                    f"{node_type}: {normalized_order['symbol']} 소수점 잔량 "
+                    f"{fractional_remainder}주는 정수 주문만 가능해 이번 주문에서 "
+                    f"제외되었습니다 (주문 수량 {normalized_order['quantity']}주)",
+                    node_id,
+                )
+                inner = order_result.get("order_result")
+                if isinstance(inner, dict):
+                    inner["fractional_remainder"] = fractional_remainder
+
             # === 5.4. DEF-27: 접수(order number) ≠ 체결. 주문 TR 응답은 주문번호만
             # 돌려주므로, 방금 접수된 주문의 체결 여부를 best-effort 로 재조회해
             # order_result.status 를 submitted → filled / partially_filled / open
@@ -14469,7 +14502,7 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                 
                 order_info = order_info_map[order_no]
                 fill_price = float(getattr(item, 'OvrsExecPrc', 0) or getattr(item, 'OvrsOrdPrc', 0))
-                fill_qty = int(getattr(item, 'ExecQty', 0))
+                fill_qty = _qty_num(getattr(item, 'ExecQty', 0))
                 symbol = order_info.get("symbol", "")
                 exchange = order_info.get("exchange", "NASDAQ")
                 side = order_info.get("side", "buy")
@@ -14691,7 +14724,7 @@ class NewOrderNodeExecutor(NodeExecutorBase):
             for item in result.block3:
                 if str(getattr(item, "OrdNo", 0)) != order_id:
                     continue
-                q = int(getattr(item, "ExecQty", 0) or 0)
+                q = _qty_num(getattr(item, "ExecQty", 0) or 0)
                 p = float(
                     getattr(item, "OvrsExecPrc", 0) or getattr(item, "OvrsOrdPrc", 0) or 0
                 )
@@ -14744,7 +14777,7 @@ class NewOrderNodeExecutor(NodeExecutorBase):
             for item in getattr(response, "block2", None) or []:
                 if str(getattr(item, "OvrsFutsOrdNo", "")) != order_id:
                     continue
-                q = int(getattr(item, "ExecQty", 0) or 0)
+                q = _qty_num(getattr(item, "ExecQty", 0) or 0)
                 p = float(getattr(item, "AbrdFutsExecPrc", 0) or 0)
                 filled_qty += q
                 amount += q * p
@@ -19880,7 +19913,7 @@ class WorkflowJob:
                         _order_payload = _r
                         break
             if _order_payload is not None and _order_payload.get("reason") not in (
-                "no_signal", "fetch_failed", "no_symbol"
+                "no_signal", "fetch_failed", "no_symbol", "fractional_only"
             ):
                 try:
                     await self.context.notify_node_state(
@@ -20967,6 +21000,12 @@ class WorkflowJob:
             "{workflow_id}:{node_id}:{cycle}:{item_hash8}" 형식의 키
         """
         import hashlib, json
+        # fractional_remainder 는 관측용 부가 키다 — 해시에 넣으면 같은 주문 의도가
+        # 엔진 버전 경계(구 엔진 기록 ↔ 신 엔진 재계산)에서 다른 키가 되어
+        # 체크포인트 복구 재실행 시 실중복 주문이 가능하다(적대 리뷰 #7).
+        # 주문 정체성은 symbol/exchange/quantity/price 만으로 결정한다.
+        if isinstance(item, dict) and "fractional_remainder" in item:
+            item = {k: v for k, v in item.items() if k != "fractional_remainder"}
         item_str = json.dumps(item, sort_keys=True, default=str) if item else "{}"
         item_hash = hashlib.sha256(item_str.encode()).hexdigest()[:8]
         return f"{workflow_id}:{node_id}:{cycle}:{item_hash}"

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -68,6 +68,19 @@ OVERSEAS_STOCK_MARKET_CODES = {
 }
 
 
+def _qty_num(value: Any, default: int = 0):
+    """수량 필드 정규화 — 정수 값이면 int, 소수점(fractional)이면 값 보존 float.
+
+    소수점 잔고/체결(AstkBalTpCode='20', prod 2026-08-24 IBM 0.847972주 실측)을
+    ``int()`` 로 자르면 0 이 되어 체결 이벤트·포지션이 조용히 사라진다. 정수
+    응답은 종전과 동일하게 int 로 유지해 직렬화 모양이 바뀌지 않게 한다."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return default
+    return int(f) if f.is_integer() else f
+
+
 def _safe_print(*args: Any, **kwargs: Any) -> None:
     """Emit console output without ever letting it abort the caller.
 
@@ -4122,9 +4135,9 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 order_date = getattr(body, 'sOrdDt', datetime.now().strftime('%Y%m%d'))
                 
                 if ord_type_code == '12':  # 정정완료
-                    quantity = int(getattr(body, 'sOrdQty', 0))
+                    quantity = _qty_num(getattr(body, 'sOrdQty', 0))
                     price = float(getattr(body, 'sOrdPrc', 0))
-                    new_qty = int(getattr(body, 'sOrgOrdMdfyQty', 0)) or quantity
+                    new_qty = _qty_num(getattr(body, 'sOrgOrdMdfyQty', 0)) or quantity
                     new_price = price
                     asyncio.run_coroutine_threadsafe(
                         context.modify_workflow_order(
@@ -4157,8 +4170,9 @@ class BrokerNodeExecutor(NodeExecutorBase):
                     return
                 body = getattr(resp, 'body', resp)
                 
-                # AS1 체결 전용 필드
-                exec_qty = int(getattr(body, 'sExecQty', 0))
+                # AS1 체결 전용 필드 — 소수점 체결이 int() 절단으로 0 이 되면
+                # 체결 이벤트 자체가 조용히 사라진다 (_qty_num 은 정수는 int 유지)
+                exec_qty = _qty_num(getattr(body, 'sExecQty', 0))
                 exec_price = float(getattr(body, 'sExecPrc', 0))
                 
                 if exec_qty <= 0:
@@ -4741,7 +4755,7 @@ class BrokerNodeExecutor(NodeExecutorBase):
                     # 전체 포지션 정보도 전달
                     account_positions[symbol] = {
                         "symbol": symbol,
-                        "quantity": int(pos_item.quantity) if hasattr(pos_item, 'quantity') else 0,
+                        "quantity": _qty_num(pos_item.quantity) if hasattr(pos_item, 'quantity') else 0,
                         "buy_price": float(pos_item.buy_price) if hasattr(pos_item, 'buy_price') else 0,
                         "current_price": float(pos_item.current_price) if hasattr(pos_item, 'current_price') else 0,
                         "pnl_rate": float(pos_item.pnl_rate) if hasattr(pos_item, 'pnl_rate') else 0,
@@ -4804,7 +4818,7 @@ class BrokerNodeExecutor(NodeExecutorBase):
                         current_prices[symbol] = float(pos_item.current_price)
                     account_positions[symbol] = {
                         "symbol": symbol,
-                        "quantity": int(pos_item.quantity) if hasattr(pos_item, 'quantity') else 0,
+                        "quantity": _qty_num(pos_item.quantity) if hasattr(pos_item, 'quantity') else 0,
                         "buy_price": float(pos_item.entry_price) if hasattr(pos_item, 'entry_price') else 0,
                         "current_price": float(pos_item.current_price) if hasattr(pos_item, 'current_price') else 0,
                         "pnl_rate": float(pos_item.pnl_rate) if hasattr(pos_item, 'pnl_rate') else 0,
@@ -5351,7 +5365,7 @@ class AccountNodeExecutor(NodeExecutorBase):
                 is_long = item.BnsTpCode == "2"
                 position_side = "long" if is_long else "short"
                 close_side = "sell" if is_long else "buy"
-                quantity = int(item.BalQty) if item.BalQty else 0
+                quantity = _qty_num(item.BalQty) if item.BalQty else 0
                 current_price = float(item.OvrsDrvtNowPrc) if item.OvrsDrvtNowPrc else 0.0
                 entry_price = float(item.PchsPrc) if item.PchsPrc else 0.0
                 # 이 TR 응답에는 수익률이 없어 명목가 대비 수익률을 직접 계산한다.
@@ -7657,11 +7671,11 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
                         "order_no": getattr(body, 'sOrdNo', 0),
                         "orig_order_no": getattr(body, 'sOrgOrdNo', 0),
                         "side": getattr(body, 'sOrdPtnCode', ''),
-                        "order_qty": int(getattr(body, 'sOrdQty', 0)),
+                        "order_qty": _qty_num(getattr(body, 'sOrdQty', 0)),
                         "order_price": float(getattr(body, 'sOrdPrc', 0)),
-                        "remain_qty": int(getattr(body, 'sOrgOrdUnercQty', 0)),
-                        "modified_qty": int(getattr(body, 'sOrgOrdMdfyQty', 0)),
-                        "cancelled_qty": int(getattr(body, 'sOrgOrdCancQty', 0)),
+                        "remain_qty": _qty_num(getattr(body, 'sOrgOrdUnercQty', 0)),
+                        "modified_qty": _qty_num(getattr(body, 'sOrgOrdMdfyQty', 0)),
+                        "cancelled_qty": _qty_num(getattr(body, 'sOrgOrdCancQty', 0)),
                         "order_time": getattr(body, 'sOrdTime', ''),
                         "market_code": getattr(body, 'sOrdMktCode', ''),
                     }
@@ -13965,16 +13979,27 @@ class NewOrderNodeExecutor(NodeExecutorBase):
 
         exchange = order_raw.get("exchange", "NASDAQ")
         try:
-            quantity = int(float(order_raw.get("quantity", 0)))
+            raw_quantity = float(order_raw.get("quantity", 0))
         except (ValueError, TypeError):
-            quantity = 0
+            raw_quantity = 0.0
+        # 주문 수량은 정수만 송신한다(COSAT00301 InBlock OrdQty). 소수점 잔고
+        # (예: 0.847972주)는 정수부만 주문하고 잔량은 결과에 명시한다 —
+        # 종전의 int() 절단은 소수점 전량매도를 **조용히** 소멸시켰다.
+        quantity = int(raw_quantity)
+        fractional_remainder = round(raw_quantity - quantity, 8)
         try:
             price = float(order_raw.get("price", 0.0))
         except (ValueError, TypeError):
             price = 0.0
 
-        # quantity가 없으면 None
+        # quantity가 없으면 None (소수점만 보유한 경우 포함 —
+        # _diagnose_empty_reason 이 FRACTIONAL_ONLY 로 사유를 밝힌다)
         if quantity <= 0:
+            if fractional_remainder > 0:
+                logger.warning(
+                    f"_normalize_order: fractional-only quantity {raw_quantity} for "
+                    f"{symbol} — integer order not possible, skipping"
+                )
             return None
 
         # price 필드 자동 탐색 (MarketDataNode 바인딩 시)
@@ -13987,12 +14012,21 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                     except (ValueError, TypeError):
                         pass
 
-        return {
+        normalized = {
             "symbol": symbol,
             "exchange": exchange,
             "quantity": int(quantity),
             "price": float(price) if price else 0.0,
         }
+        if fractional_remainder > 0:
+            # 소수점 잔량이 잘렸음을 결과에 남긴다(숨은 절단 금지). 소비부는
+            # 필요한 키만 읽으므로 추가 키는 하위호환에 안전하다.
+            normalized["fractional_remainder"] = fractional_remainder
+            logger.warning(
+                f"_normalize_order: floored fractional quantity {raw_quantity} -> "
+                f"{quantity} for {symbol} (remainder {fractional_remainder})"
+            )
+        return normalized
 
     def _diagnose_empty_reason(
         self,
@@ -14057,6 +14091,21 @@ class NewOrderNodeExecutor(NodeExecutorBase):
             err = self._extract_upstream_error(candidate)
             if err is not None:
                 return EmptyOrderReason.FETCH_FAILED, err
+
+        # 4.5) 소수점만 보유(0 < 수량 < 1) → 정수 주문 불가로 스킵된 케이스.
+        #     "신호 없음" 으로 뭉개지 않고 사유를 명시한다 (prod 2026-08-24
+        #     IBM 0.847972주 실측 — 소수점 잔고는 실계좌에 실존한다).
+        if isinstance(order, dict):
+            try:
+                _q = float(order.get("quantity", 0))
+            except (ValueError, TypeError):
+                _q = 0.0
+            if 0 < _q < 1:
+                return (
+                    EmptyOrderReason.FRACTIONAL_ONLY,
+                    f"quantity {_q} of {order.get('symbol', '?')} is fractional-only; "
+                    "integer orders cannot include it",
+                )
 
         # 5) 주문 대상 자체가 비었으면(종목 미지정) → 설정 누락.
         #    order 가 명시적으로 비어있고(빈 리스트/빈 dict/None) 상류 실패 신호도
@@ -15009,6 +15058,10 @@ class NewOrderNodeExecutor(NodeExecutorBase):
         ),
         EmptyOrderReason.NO_SYMBOL.value: (
             "No symbol provided to the order node (configuration missing)."
+        ),
+        EmptyOrderReason.FRACTIONAL_ONLY.value: (
+            "Position is fractional-only (less than 1 share); integer-quantity "
+            "orders cannot include the fractional remainder, so no order was placed."
         ),
     }
 

--- a/src/programgarden/tests/test_fractional_order_quantities.py
+++ b/src/programgarden/tests/test_fractional_order_quantities.py
@@ -1,0 +1,77 @@
+"""소수점(fractional) 수량이 주문 정규화·진단에서 조용히 사라지지 않는지 검증.
+
+prod 2026-08-24 실측: IBM 0.847972주(소수점 잔고) 보유 계좌에서 SOXL 전량매도가
+잔고조회 단계에서 죽었다. 엔진 쪽 결함은 두 가지였다 —
+(1) _normalize_order 의 int() 절단이 소수점 전량매도 주문을 **조용히** 소멸시킴
+(2) 소수점만 보유한 경우 사유 없는 no-op ("주문할 종목이 없습니다")
+"""
+import pytest
+
+from programgarden_core.models.order_diagnostics import EmptyOrderReason
+from programgarden.executor import NewOrderNodeExecutor, _qty_num
+
+
+def _executor() -> NewOrderNodeExecutor:
+    # _normalize_order / _diagnose_empty_reason 은 인스턴스 상태를 쓰지 않는다.
+    return NewOrderNodeExecutor.__new__(NewOrderNodeExecutor)
+
+
+class TestQtyNum:
+    def test_integer_stays_int(self):
+        assert _qty_num(16) == 16
+        assert isinstance(_qty_num(16), int)
+        assert isinstance(_qty_num(16.0), int)
+        assert isinstance(_qty_num("16"), int)
+
+    def test_fractional_preserved(self):
+        assert _qty_num(0.847972) == pytest.approx(0.847972)
+        assert _qty_num("0.847972") == pytest.approx(0.847972)
+
+    def test_garbage_defaults(self):
+        assert _qty_num(None) == 0
+        assert _qty_num("abc") == 0
+        assert _qty_num("abc", default=7) == 7
+
+
+class TestNormalizeOrderFractional:
+    def test_fractional_floored_with_remainder(self):
+        out = _executor()._normalize_order(
+            {"symbol": "SOXL", "quantity": 16.847972, "price": 10.0}, {}
+        )
+        assert out is not None
+        assert out["quantity"] == 16
+        assert out["fractional_remainder"] == pytest.approx(0.847972)
+
+    def test_integer_has_no_remainder_key(self):
+        out = _executor()._normalize_order(
+            {"symbol": "SOXL", "quantity": 16, "price": 10.0}, {}
+        )
+        assert out is not None
+        assert out["quantity"] == 16
+        assert "fractional_remainder" not in out
+
+    def test_fractional_only_returns_none(self):
+        out = _executor()._normalize_order(
+            {"symbol": "IBM", "quantity": 0.847972, "price": 10.0}, {}
+        )
+        assert out is None
+
+
+class TestDiagnoseFractionalOnly:
+    def test_fractional_only_reason(self):
+        reason, detail = _executor()._diagnose_empty_reason(
+            {"symbol": "IBM", "quantity": 0.847972, "price": 10.0}, {}, None, None
+        )
+        assert reason == EmptyOrderReason.FRACTIONAL_ONLY
+        assert "0.847972" in detail
+        assert "IBM" in detail
+
+    def test_empty_order_still_no_symbol(self):
+        reason, _ = _executor()._diagnose_empty_reason(None, {}, None, None)
+        assert reason == EmptyOrderReason.NO_SYMBOL
+
+    def test_fractional_only_message_registered(self):
+        assert (
+            EmptyOrderReason.FRACTIONAL_ONLY.value
+            in NewOrderNodeExecutor._EMPTY_ORDER_MESSAGES
+        )


### PR DESCRIPTION
## Summary
- prod 2026-08-24 실사고(IBM 0.847972주 소수점 잔고가 무관 종목 전량매도 잔고조회를 통째로 죽임) 근본 수정
- COSOQ00201 AstkBalQty/AstkSellAbleQty int→float('0.847972' 실측), 행 단위 파싱(1행 실패가 전체를 못 죽임), OutBlock2 전손 error 승격, parse_warnings 부분실패 신호 신설
- GenericTR ResponseParseException — 파싱 실패를 전송 실패와 구분
- 트래커 fail-closed(빈 응답·부분실패가 '보유종목 0개' 로 둔갑 금지) + 미체결 조회가 block1(입력 에코)을 순회하던 기존 결함 수정(block3)
- executor: 소수점 전량매도 정수부 floor + fractional_remainder 관측성 + FRACTIONAL_ONLY 사유 신설, AS/COSAQ00102 소비부 _qty_num(조용한 0 제거), 멱등 키에서 remainder 제외
- COSAT00301 소수점 주문 실측 등재: OrdQty=0.1 → IGW40011 (소수점 주문 불가 확정)
- 방어적 float 스윕: COSAQ00102·COSAQ01400·AS0~AS4 수량 필드

## Validation
- finance 2882 passed · programgarden 1171 passed · core 1520 passed (신규 회귀 테스트 포함, 실제 pydantic 모델로 신고 재현)
- 적대 리뷰 워크플로우(23 에이전트) 확정 15건 전부 반영/수용

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLYLpWLrP87nFErnp9gtHq