### PR TITLE
fix(executor): 실시간 시세 per-symbol 루프 예외 핸들러 UnboundLocalError 제거 (벤치 결함 D1)

### DIFF
--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -10340,6 +10340,7 @@ class MarketDataNodeExecutor(NodeExecutorBase):
             values = []
             
             for symbol_entry in symbols:
+                exchange, symbol = "", ""  # handler-safe defaults: the except below must never touch an unassigned name (UnboundLocalError masked the real cause)
                 try:
                     # 거래소와 심볼 추출
                     exchange = symbol_entry.get("exchange", "NASDAQ")
@@ -10414,7 +10415,7 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                         context.log("warning", f"No data for {exchange}:{symbol}", node_id)
                         
                 except Exception as e:
-                    context.log("warning", f"Failed to fetch {exchange}:{symbol}: {e}", node_id)
+                    context.log("warning", f"Failed to fetch {exchange}:{symbol or symbol_entry!r}: {e}", node_id)
                     continue
             
             return {"values": values}
@@ -10459,6 +10460,7 @@ class MarketDataNodeExecutor(NodeExecutorBase):
             values = []
             
             for symbol_entry in symbols:
+                exchange, symbol = "", ""  # handler-safe defaults: the except below must never touch an unassigned name (UnboundLocalError masked the real cause)
                 try:
                     # 해외선물은 exchange 대신 symbol만 사용 (예: "GCGF25", "CLH25")
                     exchange = symbol_entry.get("exchange", "CME")
@@ -10499,7 +10501,7 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                         context.log("warning", f"No data for {exchange}:{symbol}", node_id)
                         
                 except Exception as e:
-                    context.log("warning", f"Failed to fetch {exchange}:{symbol}: {e}", node_id)
+                    context.log("warning", f"Failed to fetch {exchange}:{symbol or symbol_entry!r}: {e}", node_id)
                     continue
             
             return {"values": values}
@@ -10544,6 +10546,7 @@ class MarketDataNodeExecutor(NodeExecutorBase):
             values = []
 
             for symbol_entry in symbols:
+                symbol = ""  # handler-safe default: the except below must never touch an unassigned name (UnboundLocalError masked the real cause)
                 try:
                     symbol = symbol_entry.get("symbol", "")
                     if not symbol:
@@ -10583,7 +10586,7 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                         context.log("warning", f"No data for KRX:{symbol}", node_id)
 
                 except Exception as e:
-                    context.log("warning", f"Failed to fetch KRX:{symbol}: {e}", node_id)
+                    context.log("warning", f"Failed to fetch KRX:{symbol or symbol_entry!r}: {e}", node_id)
                     continue
 
             return {"values": values}
@@ -10690,6 +10693,7 @@ class FundamentalNodeExecutor(NodeExecutorBase):
             values = []
 
             for symbol_entry in symbols:
+                exchange, symbol = "", ""  # handler-safe defaults: the except below must never touch an unassigned name (UnboundLocalError masked the real cause)
                 try:
                     exchange = symbol_entry.get("exchange", "NASDAQ")
                     symbol = symbol_entry.get("symbol", "")
@@ -10739,7 +10743,7 @@ class FundamentalNodeExecutor(NodeExecutorBase):
                         context.log("warning", f"No data for {exchange}:{symbol}", node_id)
 
                 except Exception as e:
-                    context.log("warning", f"Failed to fetch {exchange}:{symbol}: {e}", node_id)
+                    context.log("warning", f"Failed to fetch {exchange}:{symbol or symbol_entry!r}: {e}", node_id)
                     continue
 
             return {"values": values}
@@ -10780,6 +10784,7 @@ class FundamentalNodeExecutor(NodeExecutorBase):
             values = []
 
             for symbol_entry in symbols:
+                symbol = ""  # handler-safe default: the except below must never touch an unassigned name (UnboundLocalError masked the real cause)
                 try:
                     symbol = symbol_entry.get("symbol", "")
                     if not symbol:
@@ -10812,7 +10817,7 @@ class FundamentalNodeExecutor(NodeExecutorBase):
                         context.log("warning", f"No data for KRX:{symbol}", node_id)
 
                 except Exception as e:
-                    context.log("warning", f"Failed to fetch KRX:{symbol}: {e}", node_id)
+                    context.log("warning", f"Failed to fetch KRX:{symbol or symbol_entry!r}: {e}", node_id)
                     continue
 
             return {"values": values}

--- a/src/programgarden/tests/test_marketdata_handler_unbound_local.py
+++ b/src/programgarden/tests/test_marketdata_handler_unbound_local.py
@@ -1,0 +1,86 @@
+"""MarketDataNode realtime fetchers — the per-symbol except handler must never touch an unassigned name.
+
+Background (AI model benchmark 2026-09-06, D1 in the server repo's
+``.claude/plans/2026-09-06-engine-defects-from-benchmark.md``): each realtime fetch loop
+assigns ``exchange`` / ``symbol`` INSIDE ``try``. When a symbol entry was not a dict (a bare
+``"AAPL"`` string, as several chat models emit) the first statement raised before either name
+existed, the ``except`` then raised ``UnboundLocalError`` itself, and the outer handler reported
+``Market data fetch error: cannot access local variable 'exchange' ...`` — masking the real cause
+and killing the dry_run / save gate regardless of which model built the workflow.
+
+The fix seeds handler-safe defaults at the top of every loop iteration; the handler names the raw
+entry when ``symbol`` is still empty so the log shows what was actually wrong.
+"""
+
+import asyncio
+
+import pytest
+
+import programgarden.executor as ex_mod
+from programgarden.executor import MarketDataNodeExecutor
+
+
+class _Ctx:
+    def __init__(self):
+        self.logs: list[tuple[str, str]] = []
+
+    def get_credential(self):
+        return {"appkey": "k", "appsecret": "s", "paper_trading": False}
+
+    def log(self, level, msg, node_id=None):
+        self.logs.append((level, msg))
+
+
+class _NoData:
+    block = None
+    block1 = None
+
+    def req(self):
+        return self
+
+
+class _Market:
+    def __getattr__(self, _tr):          # g3101 / o3105 / t1102 → "no data" response
+        return lambda body=None, **kw: _NoData()
+
+
+class _Api:
+    def market(self):
+        return _Market()
+
+
+class _LS:
+    def overseas_stock(self):
+        return _Api()
+
+    def overseas_futureoption(self):
+        return _Api()
+
+    def korea_stock(self):
+        return _Api()
+
+
+@pytest.fixture
+def fake_login(monkeypatch):
+    monkeypatch.setattr(ex_mod, "ensure_ls_login", lambda *a, **k: (_LS(), True, None))
+
+
+BAD_ENTRIES = ["AAPL", {"symbol": ""}, {"exchange": "NASDAQ"}, {"symbol": "MSFT", "exchange": "NASDAQ"}]
+
+
+@pytest.mark.parametrize("method", ["_fetch_overseas_stock", "_fetch_overseas_futures", "_fetch_korea_stock"])
+def test_realtime_fetch_bad_symbol_entry_reports_real_cause(fake_login, method):
+    ctx = _Ctx()
+    ex = MarketDataNodeExecutor.__new__(MarketDataNodeExecutor)
+    out = asyncio.run(getattr(ex, method)(BAD_ENTRIES, ctx, "md"))
+
+    # No data for the valid entry, the bad ones skipped — but the node did NOT die.
+    assert out["values"] == []
+    assert not any(lvl == "error" for lvl, _ in ctx.logs), ctx.logs
+    assert not any("cannot access local variable" in m for _, m in ctx.logs), ctx.logs
+
+    # The real cause is named, together with the offending entry.
+    warnings = [m for lvl, m in ctx.logs if lvl == "warning"]
+    assert any("'AAPL'" in m and "'str' object has no attribute 'get'" in m for m in warnings), warnings
+    # The valid dict entry reached the API and got the ordinary "No data" warning.
+    assert any(m.startswith("No data for") and "MSFT" in m for m in warnings), warnings


### PR DESCRIPTION
## Summary
- 실시간 시세 per-symbol 루프 예외 핸들러의 `UnboundLocalError(exchange/symbol)` 제거 — 5개 루프 변수 선초기화 + 경고 메시지에 `symbol_entry!r` (벤치 결함 D1, 예선에서 3건 library 실패 원인)
- 회귀 테스트 추가(19 passed)

후속(별건): 결함 D2 "No symbols provided" 계열(PositionSizing·HistoricalData·MarketData 노드 종목 미연결) — `programgarden_server/.claude/plans/2026-09-06-engine-defects-from-benchmark.md`. PyPI 발행 + sandbox 핀 갱신은 머지 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PugdWQtLhXucrN3a2ggMYM
