### PR TITLE
fix(executor): D2 — "No symbols provided" 4분류 + 주문 노드 no_signal 상속 (1.33.3 / core 1.25.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "programgarden"
-version = "1.33.2"
+version = "1.33.3"
 description = "LS증권 API을 메인으로 제작된 노코딩 시스템 트레이딩 DSL 오픈소스"
 authors = [
     {name = "장용준",email = "coding@programgarden.com"}

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.25.2] - 2026-09-07
+> 코드 변경 없음 — 노드 가이드 문구만. 동반 릴리즈: `programgarden` **1.33.3**(D2 "No symbols provided" 3분류).
+
+### Changed
+- `PositionSizingNode` 가이드: `symbols` 를 ConditionNode.passed_symbols / SymbolFilterNode.symbols 에 묶었을 때 그 목록이
+  비는 것은 정상 무신호(`reason=no_signal`)이지 배선 결함이 아니라는 점, "No symbols provided" **경고**는 소스 미연결·
+  미해석 바인딩일 때만 나온다는 점을 pitfalls 에 명시. 고정 수량 매매는 사이징 없이 조건→주문 직결이 정석임을
+  when_not_to_use 첫 항목으로.
+- 과거시세 노드 3종(해외주식·국내주식·해외선물) 가이드: `{{ item }}`/`{{ nodes.<split>.item }}` 은 종목별 반복 안에서만
+  풀리고, 상류 배열이 비면 빈 시리즈(정상)라는 점.
+- 현재가 노드 3종 가이드: 바인딩된 소스가 비면 error 없이 `values=[]`, `symbols 필드가 필수입니다` 는 소스 미연결·미해석일 때만.
+
 ## [1.25.0] - 2026-08-20
 > 주문 거부에 **재시도 판단**을 필드로 싣는다. 챗봇이 거부를 받고 가장 먼저 답해야 하는
 > 질문은 하나다 — 다시 걸까, 사용자에게 고치라 할까, 기다릴까. 지금까지는 그걸 영어

--- a/src/core/programgarden_core/nodes/backtest_futures.py
+++ b/src/core/programgarden_core/nodes/backtest_futures.py
@@ -200,6 +200,7 @@ class OverseasFuturesHistoricalDataNode(BaseNode):
             "OverseasFuturesHistoricalDataNode.value → LineChartNode (price history display)",
         ],
         "pitfalls": [
+            "`symbol: {{ item }}` / `{{ nodes.<split>.item }}` resolves only inside a per-symbol loop (auto-iterate over an upstream array, or a SplitNode branch). If the upstream array is empty for this run the node logs `No symbols to fetch` and returns an empty series — normal no-signal, not a defect. A `No symbols provided` WARNING means the symbol source is missing or the binding did not resolve",
             "Bind `.time_series` not `.value` to ConditionNode data — the value port wraps the list in a dict",
             "Use OverseasFuturesBrokerNode (not OverseasStockBrokerNode) upstream",
             "Contract month codes change every quarter — update symbol (e.g., ESH26 → ESM26) when rolling",

--- a/src/core/programgarden_core/nodes/backtest_korea_stock.py
+++ b/src/core/programgarden_core/nodes/backtest_korea_stock.py
@@ -199,6 +199,7 @@ class KoreaStockHistoricalDataNode(BaseNode):
             "KoreaStockHistoricalDataNode.value → LineChartNode (domestic price history chart)",
         ],
         "pitfalls": [
+            "`symbol: {{ item }}` / `{{ nodes.<split>.item }}` resolves only inside a per-symbol loop (auto-iterate over an upstream array, or a SplitNode branch). If the upstream array is empty for this run the node logs `No symbols to fetch` and returns an empty series — normal no-signal, not a defect. A `No symbols provided` WARNING means the symbol source is missing or the binding did not resolve",
             "Access time_series via `{{ nodes.historical.value.time_series }}` — the value port wraps the list in a dict",
             "Intraday intervals (1m/5m/15m) not supported for Korean domestic stocks — use 1d minimum",
             "adjust=True is the default; set False only if you specifically need unadjusted prices",

--- a/src/core/programgarden_core/nodes/backtest_stock.py
+++ b/src/core/programgarden_core/nodes/backtest_stock.py
@@ -201,6 +201,7 @@ class OverseasStockHistoricalDataNode(BaseNode):
             "OverseasStockHistoricalDataNode.value → LineChartNode (price chart display)",
         ],
         "pitfalls": [
+            "`symbol: {{ item }}` / `{{ nodes.<split>.item }}` resolves only inside a per-symbol loop (auto-iterate over an upstream array, or a SplitNode branch). If the upstream array is empty for this run the node logs `No symbols to fetch` and returns an empty series — normal no-signal, not a defect. A `No symbols provided` WARNING means the symbol source is missing or the binding did not resolve",
             "Access time_series via `{{ nodes.historical.value.time_series }}` — the value port is a dict, not a plain list",
             "Intraday intervals (1m/5m/15m/1h) may have limited history depth depending on LS Securities API availability",
             "adjust=False (default) returns unadjusted prices; set True when comparing long-term price levels across splits",

--- a/src/core/programgarden_core/nodes/data_futures.py
+++ b/src/core/programgarden_core/nodes/data_futures.py
@@ -178,6 +178,7 @@ class OverseasFuturesMarketDataNode(BaseNode):
             "OverseasFuturesMarketDataNode.values → PositionSizingNode.market_data (with symbols + balance)",
         ],
         "pitfalls": [
+            "If the bound symbol source (ConditionNode.passed_symbols / SymbolFilterNode.symbols) is empty for this run the node returns values=[] with no error (normal no-signal). The `symbols 필드가 필수입니다` error is raised only when no symbol source is configured or the binding did not resolve",
             "Symbol must include contract month code (e.g., ESH26 not ES) — check OverseasFuturesSymbolQueryNode for valid codes",
             "Use OverseasFuturesBrokerNode (not OverseasStockBrokerNode) as the upstream broker",
             "REST polling returns a snapshot; for tick-level streaming use OverseasFuturesRealMarketDataNode",

--- a/src/core/programgarden_core/nodes/data_korea_stock.py
+++ b/src/core/programgarden_core/nodes/data_korea_stock.py
@@ -183,6 +183,7 @@ class KoreaStockMarketDataNode(BaseNode):
             "KoreaStockSymbolQueryNode/ConditionNode.passed_symbols → PositionSizingNode.symbols (canonical symbol list)",
         ],
         "pitfalls": [
+            "If the bound symbol source (ConditionNode.passed_symbols / SymbolFilterNode.symbols) is empty for this run the node returns values=[] with no error (normal no-signal). The `symbols 필드가 필수입니다` error is raised only when no symbol source is configured or the binding did not resolve",
             "KoreaStock does not support paper trading — KoreaStockBrokerNode always uses a live session",
             "Symbol must be a 6-digit KRX code without exchange field — do not include exchange key",
             "REST polling returns a snapshot; for tick-level streaming use KoreaStockRealMarketDataNode",

--- a/src/core/programgarden_core/nodes/data_stock.py
+++ b/src/core/programgarden_core/nodes/data_stock.py
@@ -184,6 +184,7 @@ class OverseasStockMarketDataNode(BaseNode):
             "OverseasStockMarketDataNode.values → PositionSizingNode.market_data (with symbols + balance)",
         ],
         "pitfalls": [
+            "If the bound symbol source (ConditionNode.passed_symbols / SymbolFilterNode.symbols) is empty for this run the node returns values=[] with no error (normal no-signal). The `symbols 필드가 필수입니다` error is raised only when no symbol source is configured or the binding did not resolve",
             "The symbol field must be a single dict — not a list. Use SplitNode for multi-symbol scenarios",
             "REST polling returns a snapshot at call time; for tick-level streaming use OverseasStockRealMarketDataNode",
             "OverseasStockBrokerNode must be upstream via a main edge for connection auto-injection to work",

--- a/src/core/programgarden_core/nodes/risk.py
+++ b/src/core/programgarden_core/nodes/risk.py
@@ -143,6 +143,7 @@ class PositionSizingNode(BaseNode):
             "Standardize risk exposure across different strategies (share the same PositionSizingNode config)",
         ],
         "when_not_to_use": [
+            "Buying/selling a FIXED quantity of every symbol that passed a ConditionNode / SymbolFilterNode — you do not need sizing at all: wire the condition/filter straight into NewOrderNode (it auto-iterates the symbol list) and set `quantity` on the order node",
             "Fixed-quantity simple tests — set `quantity` directly on NewOrderNode and skip sizing entirely",
             "Portfolio-level rebalancing — use PortfolioNode to compute allocations first, then size each leg",
             "Per-leg position-management signals (stop-loss / trailing) — that lives in ConditionNode with position-management plugins",
@@ -292,6 +293,7 @@ class PositionSizingNode(BaseNode):
             "AccountNode + MarketDataNode → PositionSizingNode(atr_based) → NewOrderNode",
         ],
         "pitfalls": [
+            "`symbols` bound to ConditionNode.passed_symbols / SymbolFilterNode.symbols may legitimately be EMPTY on a given run (no symbol met the condition today). The node then emits orders=[] with reason='no_signal' and logs an info line — that is normal runtime behaviour, not a wiring defect, and it does not block saving. A `No symbols provided for position sizing` WARNING means the symbol source itself is missing or the binding did not resolve (unknown node id / output port, or `{{ item }}` used outside a per-symbol loop) — fix the wiring in that case only",
             "`symbol` must be the object form, not a plain string",
             "method='kelly' needs kelly_fraction <= 1.0 (quarter-Kelly = 0.25 is a sane default)",
             "method='atr_based' needs `market_data` bound — otherwise the fallback produces a zero / tiny quantity",

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-core"
-version = "1.25.1"
+version = "1.25.2"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 readme = "README.md"

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,5 +1,43 @@
 ## [Unreleased]
 
+## [1.33.3] - 2026-09-07
+> AI 모델 벤치마크(2026-09-05~06, 서버 repo `.claude/plans/2026-09-06-engine-defects-from-benchmark.md`)가
+> 라이브로 재현한 엔진 결함 2건. 둘 다 **모델 무관** — 어떤 챗봇 모델이 만들어도 같은 자리에서 죽어,
+> 자동매매 저장 통과율을 모델 교체보다 크게 좌우했다. 동반 릴리즈: `core` **1.25.2**(노드 가이드 문구만).
+
+### Fixed
+- **D2 — "No symbols provided" 3분류: 정상 무신호(no_signal) 를 설계 결함으로 찍지 않는다.**
+  `PositionSizingNode` · `HistoricalDataNode` · `MarketDataNode`(현재가·종목정보) 가 빈 종목 목록을 받으면
+  원인 불문 같은 warning 을 남겼고, 챗봇 저장 게이트(pg-ai `_detect_input_warnings`)는 그 문구를 "종목 소스
+  미연결" 로 읽어 저장을 막았다. 그래서 `symbols: {{ nodes.rsi.passed_symbols }}` / `{{ nodes.filter.symbols }}`
+  로 **올바르게** 배선한 워크플로우가 모의 실행 표본에서 오늘 조건 통과 종목이 0 이라는 이유만으로 저장되지
+  못했다(본선 40여 건 관측의 대부분; DeepSeek Pro 실패 2/2 전부, gpt-5.6 6종 중 5종 관통, 재빌드 루프로
+  시나리오당 $4~5 낭비). 이제 `classify_empty_symbol_source()` 가 원본 설정(`ResolvedWorkflow.nodes[id].config`)
+  과 `_input_<id>` 입력 포트를 보고 세 갈래로 가른다:
+  - **no_signal** — 바인딩/입력 포트가 있고 상류가 빈 목록을 냈다 → info 로만 남기고 사이징은
+    `reason=no_signal` 빈 결과, 과거시세는 빈 시리즈, 현재가는 `values=[]`(error 없음). 저장 게이트 통과.
+  - **unresolved** — 표현식이 리터럴로 남았거나(없는 노드, 반복 밖의 `{{ item }}`) **None 으로 풀렸다**(없는
+    포트 — 평가기는 없는 포트를 None 으로 관대하게 푼다) → 종전 warning + 표현식·원인 힌트.
+  - **unbound** — symbols/symbol 자체가 없다 → 종전 warning + 정본 소스(`passed_symbols`/`symbols`/`{{ item }}`) 안내.
+  `{{ item }}` 이 반복 밖에서 리터럴로 남은 경우는 상류 리스트 포트가 **전부 비어** 반복이 안 일어난 것(no_signal)과
+  배열 소스 없이 item 바인딩을 쓴 것(unresolved)을 `_input_<id>` 로 가른다.
+- **사이징 상류 error dict 를 가짜 종목으로 만들던 순서 결함.** `symbols` 에 `{"error": …, "values": []}` 가 오면
+  `_normalize_symbols` 의 dict 분기가 "error"/"values" 라는 종목 2건을 만들어 그대로 사이징했다(빈-목록 분기에
+  영영 안 닿음). 정규화 **전에** error 를 보고 `fetch_failed` 로 돌린다.
+- **주문 노드가 상류의 `reason=no_signal` 을 물려받는다.** 사이징이 빈 종목 목록(조건 미통과)으로 `orders=[]` 를 내면
+  주문 노드는 `order=None` 을 받는데, `_diagnose_empty_reason` 5) 가 그걸 "종목 미지정(no_symbol)" 으로 분류해
+  `_order_failure_from_outputs` 가 조용한 날마다 "설정 누락" 으로 보고했다. 원본 order 표현식의 상류 출력 또는
+  `_input_<id>` 에 `reason=no_signal` 이 있고 실패 마커(error/_partial_failure/fetch_failed)가 없으면 no_signal.
+  `reason` 이 없는 레거시 빈 출력은 종전대로 no_symbol.
+- (D1, 1.33.2 이후 미발행분) **실시간 시세 per-symbol 루프 예외 핸들러의 `UnboundLocalError: exchange / symbol`.**
+  루프 안에서 할당하는 `exchange`/`symbol` 을 inner `except` 가 참조해, 심볼 항목이 dict 가 아니거나 첫 문장이
+  던지면 진짜 원인을 `UnboundLocalError` 로 가렸다(해외주식·해외선물·국내 실시간 5 루프). 루프 진입 직후 선초기화
+  + 핸들러 메시지에 원 항목(`symbol_entry!r`) 표시.
+
+### Tests
+- `tests/test_empty_symbol_source_classification.py`(3분류 단위 + 사이징/과거시세/현재가 executor + 주문 노드 물려받기),
+  `tests/test_marketdata_handler_unbound_local.py`(D1), `tests/test_order_error_mapping.py` 의 no_signal 판정 갱신.
+
 ## [1.33.2] - 2026-08-28
 > 챗봇 자동매매 제작이 **모의 실행(dry_run) 60초 컷**으로 저장되지 못한 사건(prod 대화
 > f2eed93c) 의 엔진 몫. 모의 실행이 "안 끝난 척"이 아니라 정말 86~95초가 걸렸고, 그 대부분이

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -19,8 +19,17 @@
   - **unresolved** — 표현식이 리터럴로 남았거나(없는 노드, 반복 밖의 `{{ item }}`) **None 으로 풀렸다**(없는
     포트 — 평가기는 없는 포트를 None 으로 관대하게 푼다) → 종전 warning + 표현식·원인 힌트.
   - **unbound** — symbols/symbol 자체가 없다 → 종전 warning + 정본 소스(`passed_symbols`/`symbols`/`{{ item }}`) 안내.
-  `{{ item }}` 이 반복 밖에서 리터럴로 남은 경우는 상류 리스트 포트가 **전부 비어** 반복이 안 일어난 것(no_signal)과
-  배열 소스 없이 item 바인딩을 쓴 것(unresolved)을 `_input_<id>` 로 가른다.
+  `{{ item }}` 이 반복 밖에서 리터럴로 남은 경우는 `_input_<id>` 의 **심볼 포트**(`passed_symbols` > `symbols` >
+  `items`/`values`)가 비어 반복이 안 일어난 것(no_signal)과 배열 소스 없이 item 바인딩을 쓴 것(unresolved)을 가른다
+  — ConditionNode 는 0건 통과일 때도 `symbols`/`failed_symbols` 가 비어 있지 않으므로 "모든 리스트 포트가 비어야" 는
+  틀린 규칙이었다(적대 리뷰).
+  - **upstream_failed** — 바인딩이 가리킨 노드 자체가 `error`/`reason=fetch_failed`/`_partial_failure` 를 냈다(현재가·과거시세의
+    `{"values": [], "error": …}`) → 사이징은 `fetch_failed`, 데이터 노드는 종전 warning/error + 상류 사유.
+  - 스칼라(bool/int/str)로 풀린 바인딩(`result`/`is_condition_met`/`count` 를 묶음)과, 엣지로 **비어 있지 않은** `symbols` 가
+    들어왔는데 바인딩이 없어 못 읽은 경우는 설계 결함(unresolved/unbound) — 이전 초안은 둘 다 no_signal 로 삼켰다(적대 리뷰).
+- **사이징의 잔고 미해석은 no_signal 이 아니다.** 종목은 있는데 `balance` 바인딩이 없거나 리터럴로 남으면 종전엔
+  `reason=no_signal`("No available balance") 로 흘러, 위 주문 노드 상속과 합쳐지면 잔고를 못 읽은 워크플로우가 매일 조용한
+  no-op 이 됐다. 이제 `fetch_failed` + "bind `balance` to AccountNode.balance". 잔고 dict 가 있고 매수가능금액이 0 인 경우만 no_signal.
 - **사이징 상류 error dict 를 가짜 종목으로 만들던 순서 결함.** `symbols` 에 `{"error": …, "values": []}` 가 오면
   `_normalize_symbols` 의 dict 분기가 "error"/"values" 라는 종목 2건을 만들어 그대로 사이징했다(빈-목록 분기에
   영영 안 닿음). 정규화 **전에** error 를 보고 `fetch_failed` 로 돌린다.

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -778,6 +778,189 @@ def evaluate_all_bindings(
     return {k: evaluate_value(v) for k, v in config.items()}
 
 
+# ---------------------------------------------------------------------------
+# D2 (AI 모델 벤치마크 2026-09-06): "No symbols provided" 3분류
+#
+# 사이징/과거시세/현재가 노드가 빈 종목 목록을 받는 원인은 세 가지인데, 종전에는 전부
+# 같은 warning("No symbols provided …")으로 찍혔다. 챗봇 저장 게이트(pg-ai
+# `_detect_input_warnings`)는 그 문구를 "설계 결함" 으로 읽어 저장을 막으므로, 조건을
+# 올바르게 배선한 워크플로우가 **모의 실행 표본에서 오늘 조건을 통과한 종목이 0** 이라는
+# 이유만으로 저장되지 못했다(벤치 본선: 모델 무관 최대 실패 원인, 40여 건 중 대부분이
+# `symbols: {{ nodes.rsi.passed_symbols }}` / `{{ nodes.filter.symbols }}` 정상 배선).
+#
+#   no_signal  — 원본 설정에 바인딩(또는 입력 포트)이 있고 상류가 이번 실행에서 빈 목록을
+#                냈다. 정상 런타임(오늘 신호 없음). info 로만 남기고 경고를 찍지 않는다.
+#   unresolved — 바인딩 표현식이 리터럴로 남았다(없는 노드/포트, 반복 밖의 `{{ item }}`).
+#   unbound    — symbols/symbol 자체가 없다(종목 소스 미연결).
+# 뒤의 둘은 설계 결함이라 종전처럼 warning("No symbols provided …") 을 유지한다 — 게이트가
+# 계속 잡아야 하는 케이스다.
+# ---------------------------------------------------------------------------
+EMPTY_SYMBOLS_NO_SIGNAL = "no_signal"
+EMPTY_SYMBOLS_UNRESOLVED = "unresolved"
+EMPTY_SYMBOLS_UNBOUND = "unbound"
+
+_EMPTY_VALUES = (None, "", [], {}, ())
+
+
+def _raw_node_config(node_id: str, workflow: Any, fallback: Dict[str, Any]) -> Dict[str, Any]:
+    """`ResolvedWorkflow.nodes[node_id].config` (평가 전 원본). 없으면 fallback."""
+    try:
+        nodes = getattr(workflow, "nodes", None)
+        node = nodes.get(node_id) if isinstance(nodes, dict) else None
+    except Exception:
+        node = None
+    cfg = getattr(node, "config", None)
+    return cfg if isinstance(cfg, dict) else fallback
+
+
+def _input_namespace(context: "ExecutionContext", node_id: str) -> Dict[str, Any]:
+    """`_input_<node_id>` 의사 노드(엣지로 들어온 상류 출력 전체). 없으면 {}."""
+    try:
+        outputs = context.get_all_outputs(f"_input_{node_id}")
+    except Exception:
+        return {}
+    return outputs if isinstance(outputs, dict) else {}
+
+
+def _contains_expression(value: Any) -> bool:
+    if isinstance(value, str):
+        return "{{" in value
+    if isinstance(value, dict):
+        return any(_contains_expression(v) for v in value.values())
+    if isinstance(value, list):
+        return any(_contains_expression(v) for v in value)
+    return False
+
+
+def _first_expression(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        return value if "{{" in value else None
+    if isinstance(value, dict):
+        for v in value.values():
+            found = _first_expression(v)
+            if found:
+                return found
+    if isinstance(value, list):
+        for v in value:
+            found = _first_expression(v)
+            if found:
+                return found
+    return None
+
+
+def classify_empty_symbol_source(
+    node_id: str,
+    evaluated_config: Dict[str, Any],
+    context: "ExecutionContext",
+    workflow: Any = None,
+    keys: Tuple[str, ...] = ("symbols", "symbol"),
+) -> Tuple[str, str]:
+    """빈 종목 입력의 원인을 (kind, detail) 로 돌려준다.
+
+    kind ∈ {EMPTY_SYMBOLS_NO_SIGNAL, EMPTY_SYMBOLS_UNRESOLVED, EMPTY_SYMBOLS_UNBOUND}.
+    detail 은 사람이 읽는 한 문장(영문 — 챗봇 fix_hint 로 그대로 실린다).
+
+    판정 순서:
+      1. 평가된 값에 `{{ … }}` 가 리터럴로 남아 있다 → 미해석.
+         단 `{{ item }}`/`{{ index }}` 인데 반복 컨텍스트가 없으면, 상류 배열이 비어
+         반복이 안 일어난 것(no_signal)과 배열 소스 없이 item 바인딩을 쓴 것(unresolved)을
+         `_input_<id>` 의 리스트 포트로 가른다.
+      2. 원본 설정에 바인딩/리터럴이 있었거나 입력 포트로 값이 들어왔다 → 상류가 빈 목록을
+         낸 것(no_signal). 원본이 표현식 없는 리터럴 목록인데 정규화 결과가 비었다면 항목
+         모양이 틀린 것(unbound 로 분류하되 detail 로 알린다).
+      3. 그 외 → 종목 소스 미연결(unbound).
+    """
+    import re as _re
+
+    item_re = _re.compile(r"\{\{\s*(item|index)\b")
+    raw = _raw_node_config(node_id, workflow, evaluated_config)
+    inputs = _input_namespace(context, node_id)
+    iterating = getattr(context, "_iteration_item", None) is not None
+
+    # 1) 미해석 표현식
+    for key in keys:
+        value = evaluated_config.get(key)
+        expr = _first_expression(value)
+        if not expr:
+            continue
+        if item_re.search(expr) and not iterating:
+            list_ports = {
+                k: v for k, v in inputs.items()
+                if isinstance(v, list) and not str(k).startswith("_")
+            }
+            if list_ports and all(len(v) == 0 for v in list_ports.values()):
+                return (
+                    EMPTY_SYMBOLS_NO_SIGNAL,
+                    f"`{key}: {expr}` — the upstream array "
+                    f"({', '.join(sorted(list_ports))}) is empty in this run, so there is "
+                    "nothing to iterate (no signal)",
+                )
+            return (
+                EMPTY_SYMBOLS_UNRESOLVED,
+                f"`{key}: {expr}` is an item binding but this node is not being iterated — "
+                "`{{ item }}` only resolves downstream of an array output "
+                "(WatchlistNode.symbols / ConditionNode.passed_symbols / SymbolFilterNode.symbols) "
+                "or inside a SplitNode branch",
+            )
+        return (
+            EMPTY_SYMBOLS_UNRESOLVED,
+            f"`{key}: {expr}` did not resolve — check the node id and output port "
+            "(e.g. `{{ nodes.<condition>.passed_symbols }}` / `{{ nodes.<filter>.symbols }}`)",
+        )
+
+    # 2) 바인딩/입력 포트는 있는데 결과가 빈 목록
+    bound_key = None
+    for key in keys:
+        if raw.get(key) not in _EMPTY_VALUES:
+            bound_key = key
+            break
+    port_key = next((k for k in keys if k in inputs), None)
+
+    if bound_key is not None:
+        raw_value = raw[bound_key]
+        if _contains_expression(raw_value):
+            expr = _first_expression(raw_value)
+            # 표현식이 **빈 목록이 아니라 None** 으로 풀렸다 = 참조한 노드/포트가 없다
+            # (평가기는 없는 포트를 None 으로 관대하게 푼다). 실제 종목 소스(ConditionNode.
+            # passed_symbols / SymbolFilterNode.symbols …)는 비어도 항상 [] 를 낸다.
+            if evaluated_config.get(bound_key) is None and bound_key not in inputs:
+                return (
+                    EMPTY_SYMBOLS_UNRESOLVED,
+                    f"`{bound_key}: {expr}` resolved to nothing — the referenced node id or "
+                    "output port does not exist (check the spelling; e.g. "
+                    "`{{ nodes.<condition>.passed_symbols }}` / `{{ nodes.<filter>.symbols }}`)",
+                )
+            return (
+                EMPTY_SYMBOLS_NO_SIGNAL,
+                f"upstream symbol source `{bound_key}: {expr}` "
+                "produced no symbols in this run (no signal)",
+            )
+        if isinstance(raw_value, (list, dict)):
+            return (
+                EMPTY_SYMBOLS_UNBOUND,
+                f"`{bound_key}` is a literal list but none of its entries is a usable "
+                "{symbol, exchange} object or symbol string",
+            )
+        return (
+            EMPTY_SYMBOLS_NO_SIGNAL,
+            f"symbol source `{bound_key}` resolved to nothing in this run (no signal)",
+        )
+    if port_key is not None:
+        return (
+            EMPTY_SYMBOLS_NO_SIGNAL,
+            f"the upstream node wired into this node emitted an empty `{port_key}` list "
+            "in this run (no signal)",
+        )
+
+    # 3) 소스 없음
+    return (
+        EMPTY_SYMBOLS_UNBOUND,
+        "no symbol source is configured — bind `symbols` to an upstream list "
+        "(`{{ nodes.<condition>.passed_symbols }}` / `{{ nodes.<filter>.symbols }}` / "
+        "`{{ nodes.<watchlist>.symbols }}`) or `symbol` to `{{ item }}` inside a per-symbol loop",
+    )
+
+
 class GenericNodeExecutor(NodeExecutorBase):
     """
     범용 노드 실행기 (커뮤니티 노드 및 execute() 메서드가 있는 노드용)
@@ -10275,7 +10458,18 @@ class MarketDataNodeExecutor(NodeExecutorBase):
             return _df.apply_override(fixture, override)
 
         if not symbols:
-            error_msg = "symbols 필드가 필수입니다. 종목을 직접 입력하거나 WatchlistNode를 연결하세요."
+            # D2: 상류(조건/필터)가 이번 실행에서 빈 목록을 낸 정상 케이스는 error 없이 빈
+            # values 로 흘린다(오늘 조회할 종목 없음). 소스 미연결/미해석만 종전 error.
+            kind, detail = classify_empty_symbol_source(
+                node_id, config, context, kwargs.get("workflow"), keys=("symbol", "symbols")
+            )
+            if kind == EMPTY_SYMBOLS_NO_SIGNAL:
+                context.log("info", f"No symbols to quote in this run — {detail}", node_id)
+                return {"values": []}
+            error_msg = (
+                "symbols 필드가 필수입니다. 종목을 직접 입력하거나 WatchlistNode를 연결하세요. "
+                f"({detail})"
+            )
             context.log("error", error_msg, node_id)
             return {"error": error_msg, "values": []}
 
@@ -10647,7 +10841,17 @@ class FundamentalNodeExecutor(NodeExecutorBase):
                 symbols = [config_symbol]
 
         if not symbols:
-            error_msg = "symbols 필드가 필수입니다. 종목을 직접 입력하거나 WatchlistNode를 연결하세요."
+            # D2: MarketDataNodeExecutor 와 같은 3분류 — 정상 no-signal 은 error 없이 빈 values.
+            kind, detail = classify_empty_symbol_source(
+                node_id, config, context, kwargs.get("workflow"), keys=("symbol", "symbols")
+            )
+            if kind == EMPTY_SYMBOLS_NO_SIGNAL:
+                context.log("info", f"No symbols to look up in this run — {detail}", node_id)
+                return {"values": []}
+            error_msg = (
+                "symbols 필드가 필수입니다. 종목을 직접 입력하거나 WatchlistNode를 연결하세요. "
+                f"({detail})"
+            )
             context.log("error", error_msg, node_id)
             return {"error": error_msg, "values": []}
 
@@ -11003,7 +11207,16 @@ class HistoricalDataNodeExecutor(NodeExecutorBase):
             # / ConditionNode 의 `item.time_series`)이 조용히 None 이 되고 방어적
             # `data or []` 가 그걸 삼켜 에러 없이 빈 결과(count:0)를 낸다.
             # (deep_fixtures.historical_data_fixture 도 이 스키마를 못박는다.)
-            context.log("warning", "No symbols provided", node_id)
+            # D2: 상류 배열이 비어 반복이 없었던 것(정상 no-signal)은 info, 소스 미연결/
+            # 미해석 바인딩(설계 결함)만 warning("No symbols provided …") — 챗봇 저장
+            # 게이트가 이 문구를 결함으로 읽으므로 정상 케이스에는 찍지 않는다.
+            kind, detail = classify_empty_symbol_source(
+                node_id, config, context, kwargs.get("workflow"), keys=("symbol", "symbols")
+            )
+            if kind == EMPTY_SYMBOLS_NO_SIGNAL:
+                context.log("info", f"No symbols to fetch in this run — {detail}", node_id)
+            else:
+                context.log("warning", f"No symbols provided — {detail}", node_id)
             return {
                 "value": None,
                 "values": [],
@@ -12762,18 +12975,43 @@ class PositionSizingNodeExecutor(NodeExecutorBase):
         kelly_fraction = float(evaluated.get("kelly_fraction", 0.25))
         atr_risk_percent = float(evaluated.get("atr_risk_percent", 1.0))
         
+        # 상류가 error 신호를 동봉한 dict(예: `{"error": …, "values": []}`)를 symbols 로
+        # 넘겼으면 fetch_failed. 정규화 **전에** 본다 — `_normalize_symbols` 의 dict 분기는
+        # `{종목: {...}}` 맵 전용이라, error 페이로드를 넣으면 "error"/"values" 라는 가짜
+        # 종목 2건이 만들어져 사이징이 그대로 진행됐다(빈-목록 분기에 영영 안 닿음).
+        if isinstance(symbols_input, dict) and symbols_input.get("error"):
+            err = str(symbols_input.get("error"))
+            context.log(
+                "warning",
+                f"No symbols provided for position sizing — upstream fetch failed: {err}",
+                node_id,
+            )
+            return self._empty_result(EmptyOrderReason.FETCH_FAILED, err)
+
         # 종목 리스트 정규화
         symbols = self._normalize_symbols(symbols_input)
         
         if not symbols:
-            context.log("warning", "No symbols provided for position sizing", node_id)
-            # 상류가 빈 리스트에 error 신호를 동봉했으면 fetch_failed, 아니면 종목 미지정.
-            err = None
-            if isinstance(symbols_input, dict) and symbols_input.get("error"):
-                err = str(symbols_input.get("error"))
-            if err:
-                return self._empty_result(EmptyOrderReason.FETCH_FAILED, err)
-            return self._empty_result(EmptyOrderReason.NO_SYMBOL, "")
+            # D2: "오늘 신호 없음(정상)" 과 "종목 소스 미연결/미해석(설계 결함)" 을 가른다.
+            # 전자는 warning 을 찍지 않는다 — 챗봇 저장 게이트가 "No symbols provided" 를
+            # 설계 결함으로 읽어, 올바로 배선된 워크플로우가 모의 실행 표본에서 조건 통과
+            # 종목이 0 이라는 이유만으로 저장되지 못했다(벤치 본선 최대 실패 원인).
+            kind, detail = classify_empty_symbol_source(
+                node_id, evaluated, context, kwargs.get("workflow"), keys=("symbols", "symbol")
+            )
+            if kind == EMPTY_SYMBOLS_NO_SIGNAL:
+                context.log(
+                    "info",
+                    f"No symbols to size in this run — {detail}; sizing skipped",
+                    node_id,
+                )
+                return self._empty_result(EmptyOrderReason.NO_SIGNAL, detail)
+            context.log(
+                "warning",
+                f"No symbols provided for position sizing — {detail}",
+                node_id,
+            )
+            return self._empty_result(EmptyOrderReason.NO_SYMBOL, detail)
         
         # Refuse to silently zero-out when the upstream AccountNode flagged
         # a partial fetch. fixed_quantity ignores balance entirely, so it
@@ -13919,7 +14157,7 @@ class NewOrderNodeExecutor(NodeExecutorBase):
         if not normalized_order:
             context.log("warning", f"{node_type}: 주문할 종목이 없습니다", node_id)
             reason, detail = self._diagnose_empty_reason(
-                order, config, raw_order_expr, context
+                order, config, raw_order_expr, context, node_id=node_id
             )
             return self._empty_result(reason, detail)
 
@@ -14149,6 +14387,7 @@ class NewOrderNodeExecutor(NodeExecutorBase):
         config: Dict[str, Any],
         raw_order_expr: Any = None,
         context: Optional[ExecutionContext] = None,
+        node_id: Optional[str] = None,
     ) -> tuple:
         """빈 주문 결과의 reason 을 상류 신호로 판정.
 
@@ -14198,6 +14437,23 @@ class NewOrderNodeExecutor(NodeExecutorBase):
             err = self._extract_upstream_error(upstream)
             if err is not None:
                 return EmptyOrderReason.FETCH_FAILED, err
+
+        # 3.5) 상류가 명시적으로 "오늘 신호 없음"(reason=no_signal) 을 냈으면 정상 no-op.
+        #      D2(벤치 2026-09-06): 사이징이 빈 종목 목록(조건 미통과)을 받아 orders=[] 를
+        #      내면 주문 노드는 order=None 을 받는데, 아래 5) 가 그걸 "종목 미지정(no_symbol)"
+        #      으로 분류해 `_order_failure_from_outputs` 가 매 실행 "설정 누락" 으로 보고했다.
+        #      상류의 no_signal 은 실패 신호(error/_partial_failure/fetch_failed)가 없을 때만
+        #      그대로 물려받는다.
+        for candidate in (upstream, _input_namespace(context, node_id) if (context is not None and node_id) else None):
+            if (
+                isinstance(candidate, dict)
+                and candidate.get("reason") == EmptyOrderReason.NO_SIGNAL.value
+                and self._extract_upstream_error(candidate) is None
+            ):
+                return (
+                    EmptyOrderReason.NO_SIGNAL,
+                    str(candidate.get("detail") or candidate.get("message") or ""),
+                )
 
         # 4) 상류가 낸 빈 리스트에 실패 신호 동봉 → 조회 실패(파이프라인 고장).
         #    order/symbols 바인딩 결과가 dict 이면서 error/_partial_failure/

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -798,6 +798,7 @@ def evaluate_all_bindings(
 EMPTY_SYMBOLS_NO_SIGNAL = "no_signal"
 EMPTY_SYMBOLS_UNRESOLVED = "unresolved"
 EMPTY_SYMBOLS_UNBOUND = "unbound"
+EMPTY_SYMBOLS_UPSTREAM_FAILED = "upstream_failed"   # 참조한 노드가 error/fetch_failed 를 냈다
 
 _EMPTY_VALUES = (None, "", [], {}, ())
 
@@ -848,6 +849,51 @@ def _first_expression(value: Any) -> Optional[str]:
     return None
 
 
+def _referenced_node_failure(expr: Optional[str], context: "ExecutionContext") -> Optional[str]:
+    """`{{ nodes.<id>.<port> }}` 가 가리키는 노드의 FULL 출력에 실패 신호(error /
+    reason=fetch_failed / _partial_failure)가 있으면 그 사유, 없으면 None.
+
+    MarketData/HistoricalData 는 조회 실패를 raise 하지 않고 ``{"values": [], "error": …}``
+    로 돌려주므로, 그 ``values`` 를 symbols 로 묶은 하류는 빈 목록만 보고 "오늘 신호 없음"
+    으로 오판할 수 있다 — 여기서 참조 노드 자체를 본다.
+    """
+    if not isinstance(expr, str) or context is None:
+        return None
+    import re as _re
+
+    m = _re.search(r"nodes\.([A-Za-z0-9_\-]+)", expr)
+    if not m:
+        return None
+    try:
+        outputs = context.get_all_outputs(m.group(1))
+    except Exception:
+        return None
+    if not isinstance(outputs, dict) or not outputs:
+        return None
+    return NewOrderNodeExecutor._extract_upstream_error(outputs)
+
+
+# 심볼을 나르는 포트 — `{{ item }}` 이 반복 밖에서 리터럴로 남았을 때 "상류 배열이 비어
+# 반복이 안 일어났다" 를 판정할 축. 메인 루프의 auto-iterate 소스 우선순위(명시 from_port
+# > symbols > 첫 출력)와 맞춘다: ConditionNode 는 0건 통과일 때도 ``symbols``(평가 대상 전체)·
+# ``failed_symbols``·``symbol_results`` 가 **비어 있지 않으므로**, 모든 리스트 포트가 비어야
+# 한다는 규칙은 D2 가 없애려던 바로 그 케이스(조건 미통과 → `symbol: {{ item }}` 경고)를
+# 남긴다. passed_symbols 가 있으면 그것만, 없으면 symbols, 둘 다 없으면 전체 리스트 포트.
+_ITERATION_SYMBOL_PORTS = ("passed_symbols", "symbols", "items", "values")
+
+
+def _upstream_array_is_empty(inputs: Dict[str, Any]) -> Optional[bool]:
+    """True = 반복 소스 배열이 비어 있다(no_signal), False = 배열이 있는데 반복이 안 걸렸다
+    (설계 결함), None = 리스트 포트가 하나도 없다."""
+    for port in _ITERATION_SYMBOL_PORTS:
+        if port in inputs and isinstance(inputs[port], list):
+            return len(inputs[port]) == 0
+    list_ports = [v for k, v in inputs.items() if isinstance(v, list) and not str(k).startswith("_")]
+    if not list_ports:
+        return None
+    return all(len(v) == 0 for v in list_ports)
+
+
 def classify_empty_symbol_source(
     node_id: str,
     evaluated_config: Dict[str, Any],
@@ -884,23 +930,19 @@ def classify_empty_symbol_source(
         if not expr:
             continue
         if item_re.search(expr) and not iterating:
-            list_ports = {
-                k: v for k, v in inputs.items()
-                if isinstance(v, list) and not str(k).startswith("_")
-            }
-            if list_ports and all(len(v) == 0 for v in list_ports.values()):
+            empty = _upstream_array_is_empty(inputs)
+            if empty is True:
                 return (
                     EMPTY_SYMBOLS_NO_SIGNAL,
-                    f"`{key}: {expr}` — the upstream array "
-                    f"({', '.join(sorted(list_ports))}) is empty in this run, so there is "
-                    "nothing to iterate (no signal)",
+                    f"`{key}: {expr}` — the upstream symbol array is empty in this run "
+                    "(no symbol passed / nothing to iterate), so this node was not iterated (no signal)",
                 )
             return (
                 EMPTY_SYMBOLS_UNRESOLVED,
                 f"`{key}: {expr}` is an item binding but this node is not being iterated — "
-                "`{{ item }}` only resolves downstream of an array output "
-                "(WatchlistNode.symbols / ConditionNode.passed_symbols / SymbolFilterNode.symbols) "
-                "or inside a SplitNode branch",
+                "`{{ item }}` only resolves when this node is auto-iterated over an upstream "
+                "array (WatchlistNode.symbols / ConditionNode.passed_symbols / SymbolFilterNode.symbols); "
+                "inside a SplitNode branch use `{{ nodes.<split>.item }}` instead",
             )
         return (
             EMPTY_SYMBOLS_UNRESOLVED,
@@ -920,15 +962,33 @@ def classify_empty_symbol_source(
         raw_value = raw[bound_key]
         if _contains_expression(raw_value):
             expr = _first_expression(raw_value)
+            resolved = evaluated_config.get(bound_key)
+            # 참조한 노드 자체가 실패했다(MarketData/HistoricalData 의 `{"values": [], "error": …}`,
+            # reason=fetch_failed, _partial_failure) → 빈 목록은 신호 없음이 아니라 파이프라인 고장.
+            failure = _referenced_node_failure(expr, context)
+            if failure:
+                return (
+                    EMPTY_SYMBOLS_UPSTREAM_FAILED,
+                    f"upstream node referenced by `{bound_key}: {expr}` failed: {failure}",
+                )
             # 표현식이 **빈 목록이 아니라 None** 으로 풀렸다 = 참조한 노드/포트가 없다
             # (평가기는 없는 포트를 None 으로 관대하게 푼다). 실제 종목 소스(ConditionNode.
             # passed_symbols / SymbolFilterNode.symbols …)는 비어도 항상 [] 를 낸다.
-            if evaluated_config.get(bound_key) is None and bound_key not in inputs:
+            if resolved is None and bound_key not in inputs:
                 return (
                     EMPTY_SYMBOLS_UNRESOLVED,
                     f"`{bound_key}: {expr}` resolved to nothing — the referenced node id or "
                     "output port does not exist (check the spelling; e.g. "
                     "`{{ nodes.<condition>.passed_symbols }}` / `{{ nodes.<filter>.symbols }}`)",
+                )
+            # 스칼라(bool/int/str)로 풀렸다 = 종목 목록이 아닌 포트를 묶었다(`result` /
+            # `is_condition_met` / `count`). 매 실행 빈 목록이 되는 영구 결함이라 warning.
+            if resolved is not None and not isinstance(resolved, (list, dict)):
+                return (
+                    EMPTY_SYMBOLS_UNRESOLVED,
+                    f"`{bound_key}: {expr}` resolved to a {type(resolved).__name__} "
+                    f"({str(resolved)[:40]!r}), not a symbol list — bind a list port "
+                    "(`passed_symbols` / `symbols`), not `result` / `is_condition_met` / `count`",
                 )
             return (
                 EMPTY_SYMBOLS_NO_SIGNAL,
@@ -946,6 +1006,17 @@ def classify_empty_symbol_source(
             f"symbol source `{bound_key}` resolved to nothing in this run (no signal)",
         )
     if port_key is not None:
+        port_value = inputs.get(port_key)
+        # 엣지로 들어온 포트가 **비어 있지 않은데** 이 노드가 빈 목록을 봤다 = 이 노드는
+        # 입력 포트를 읽지 않는다(사이징은 evaluated config 만 본다). 바인딩을 명시해야
+        # 하는 설계 결함이지 "오늘 신호 없음" 이 아니다.
+        if port_value not in _EMPTY_VALUES:
+            return (
+                EMPTY_SYMBOLS_UNBOUND,
+                f"the upstream node emits a non-empty `{port_key}` list but this node has no "
+                f"`{port_key}` binding to consume it — bind `{port_key}: "
+                "{{ nodes.<upstream>." + port_key + " }}` explicitly",
+            )
         return (
             EMPTY_SYMBOLS_NO_SIGNAL,
             f"the upstream node wired into this node emitted an empty `{port_key}` list "
@@ -13011,6 +13082,8 @@ class PositionSizingNodeExecutor(NodeExecutorBase):
                 f"No symbols provided for position sizing — {detail}",
                 node_id,
             )
+            if kind == EMPTY_SYMBOLS_UPSTREAM_FAILED:
+                return self._empty_result(EmptyOrderReason.FETCH_FAILED, detail)
             return self._empty_result(EmptyOrderReason.NO_SYMBOL, detail)
         
         # Refuse to silently zero-out when the upstream AccountNode flagged
@@ -13055,6 +13128,18 @@ class PositionSizingNodeExecutor(NodeExecutorBase):
                     or "balance fetch partially failed"
                 )
                 return self._empty_result(EmptyOrderReason.FETCH_FAILED, detail)
+            # 잔고 입력 자체가 없거나 미해석(`{{ … }}` 리터럴) = 읽지 못한 것이지 "오늘
+            # 신호 없음" 이 아니다. 종목은 있는데 잔고가 안 묶인 채 no_signal 로 흘리면
+            # 하류 주문 노드(D2 상속)까지 조용한 no-op 이 된다. 실제로 잔고 dict 가 있고
+            # 매수가능금액이 0 인 경우만 정상 no_signal(현금 없음).
+            if balance_data in (None, "", {}, [], ()) or (
+                isinstance(balance_data, str) and "{{" in balance_data
+            ):
+                return self._empty_result(
+                    EmptyOrderReason.FETCH_FAILED,
+                    "balance input is missing or unresolved — bind `balance` to "
+                    "AccountNode.balance (every sizing method except fixed_quantity needs it)",
+                )
             return self._empty_result(
                 EmptyOrderReason.NO_SIGNAL,
                 "No available balance for position sizing",

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.33.2"
+version = "1.33.3"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"

--- a/src/programgarden/tests/test_empty_symbol_source_classification.py
+++ b/src/programgarden/tests/test_empty_symbol_source_classification.py
@@ -1,0 +1,314 @@
+"""D2 — "No symbols provided" 3분류 (AI 모델 벤치마크 2026-09-06, 서버 repo
+``.claude/plans/2026-09-06-engine-defects-from-benchmark.md`` D2).
+
+배경: 사이징/과거시세/현재가 노드가 빈 종목 목록을 받으면 종전엔 원인 불문 같은
+warning("No symbols provided …")을 찍었다. 챗봇 저장 게이트(pg-ai ``_detect_input_warnings``)는
+그 문구를 설계 결함으로 읽어 저장을 막으므로, ``symbols: {{ nodes.rsi.passed_symbols }}`` 로
+**올바르게** 배선한 워크플로우가 모의 실행 표본에서 오늘 조건 통과 종목이 0 이라는 이유만으로
+저장되지 못했다(본선 40여 건 중 대부분, 모델 무관). 수정 후:
+
+- 바인딩/입력 포트가 있고 상류가 빈 목록을 냈다 → ``no_signal`` (info, warning 없음)
+- 바인딩 표현식이 리터럴로 남았다(없는 노드/포트, 반복 밖의 ``{{ item }}``) → ``unresolved`` (warning)
+- symbols/symbol 자체가 없다 → ``unbound`` (warning)
+- 주문 노드는 상류 ``reason=no_signal`` 을 그대로 물려받는다(종전엔 ``no_symbol`` "설정 누락").
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from programgarden.executor import (
+    EMPTY_SYMBOLS_NO_SIGNAL,
+    EMPTY_SYMBOLS_UNBOUND,
+    EMPTY_SYMBOLS_UNRESOLVED,
+    HistoricalDataNodeExecutor,
+    MarketDataNodeExecutor,
+    NewOrderNodeExecutor,
+    PositionSizingNodeExecutor,
+    classify_empty_symbol_source,
+)
+from programgarden_core.models.order_diagnostics import EmptyOrderReason
+
+
+class _Ctx:
+    """최소 ExecutionContext — 로그 수집 + `_input_<id>` 의사 노드 + 표현식 컨텍스트."""
+
+    def __init__(self, inputs: Optional[Dict[str, Any]] = None, node_outputs: Optional[Dict[str, Dict[str, Any]]] = None):
+        self.logs: List[Dict[str, Any]] = []
+        self._inputs = inputs or {}
+        self._node_outputs = node_outputs or {}
+        self.is_dry_run = True
+        self.is_deep_validate = False
+        self._iteration_item: Any = None
+        self._iteration_index = 0
+        self._iteration_total = 0
+
+    def log(self, level: str, message: str, node_id: Optional[str] = None, data: Any = None) -> None:
+        self.logs.append({"level": level, "message": message, "node_id": node_id})
+
+    def get_output(self, node_id: str, port_name: Optional[str] = None) -> Any:
+        if node_id.startswith("_input_"):
+            return self._inputs if port_name is None else self._inputs.get(port_name)
+        outs = self._node_outputs.get(node_id, {})
+        return outs if port_name is None else outs.get(port_name)
+
+    def get_all_outputs(self, node_id: str) -> Dict[str, Any]:
+        if node_id.startswith("_input_"):
+            return dict(self._inputs)
+        return dict(self._node_outputs.get(node_id, {}))
+
+    def get_expression_context(self):
+        from programgarden_core.expression.evaluator import ExpressionContext
+        return ExpressionContext(
+            node_outputs={k: dict(v) for k, v in self._node_outputs.items()},
+            item=self._iteration_item,
+            index=self._iteration_index,
+            total=self._iteration_total,
+        )
+
+    def record_deep_unresolved_binding(self, *a, **k) -> None:  # evaluate_all_bindings 가 호출
+        pass
+
+    def warnings_with(self, needle: str) -> List[str]:
+        return [l["message"] for l in self.logs if l["level"] == "warning" and needle.lower() in l["message"].lower()]
+
+    def infos_with(self, needle: str) -> List[str]:
+        return [l["message"] for l in self.logs if l["level"] == "info" and needle.lower() in l["message"].lower()]
+
+
+def _wf(node_id: str, raw_config: Dict[str, Any]):
+    return SimpleNamespace(nodes={node_id: SimpleNamespace(config=raw_config)})
+
+
+# ---------------------------------------------------------------------------
+# 1. 분류기 단위
+# ---------------------------------------------------------------------------
+
+def test_bound_expression_that_evaluated_empty_is_no_signal():
+    raw = {"symbols": "{{ nodes.rsi.passed_symbols }}", "method": "fixed_quantity"}
+    evaluated = {"symbols": [], "method": "fixed_quantity"}
+    kind, detail = classify_empty_symbol_source("sizing", evaluated, _Ctx(), _wf("sizing", raw))
+    assert kind == EMPTY_SYMBOLS_NO_SIGNAL
+    assert "nodes.rsi.passed_symbols" in detail
+
+
+def test_edge_input_port_empty_list_is_no_signal():
+    """설정엔 symbols 가 없지만 엣지로 상류 symbols=[] 가 들어온 경우."""
+    kind, _ = classify_empty_symbol_source(
+        "sizing", {"method": "fixed_quantity"}, _Ctx(inputs={"symbols": []}), _wf("sizing", {"method": "fixed_quantity"})
+    )
+    assert kind == EMPTY_SYMBOLS_NO_SIGNAL
+
+
+def test_no_source_at_all_is_unbound():
+    kind, detail = classify_empty_symbol_source(
+        "sizing", {"method": "fixed_quantity"}, _Ctx(), _wf("sizing", {"method": "fixed_quantity"})
+    )
+    assert kind == EMPTY_SYMBOLS_UNBOUND
+    assert "passed_symbols" in detail  # actionable hint names the canonical sources
+
+
+def test_unresolved_node_reference_is_unresolved():
+    """벤치 실측: `symbol: {{ nodes.split.item }}` 인데 split 노드가 DSL 에 없다."""
+    evaluated = {"symbol": "{{ nodes.split.item }}"}
+    kind, detail = classify_empty_symbol_source(
+        "historical", evaluated, _Ctx(), _wf("historical", dict(evaluated)), keys=("symbol", "symbols")
+    )
+    assert kind == EMPTY_SYMBOLS_UNRESOLVED
+    assert "nodes.split.item" in detail and "did not resolve" in detail
+
+
+def test_item_binding_outside_loop_with_empty_upstream_array_is_no_signal():
+    """`symbol: {{ item }}` 인데 상류 배열(symbols)이 비어 반복이 안 일어난 경우 — 정상."""
+    evaluated = {"symbol": "{{ item }}"}
+    kind, detail = classify_empty_symbol_source(
+        "historical", evaluated, _Ctx(inputs={"symbols": [], "count": 0}), _wf("historical", dict(evaluated)),
+        keys=("symbol", "symbols"),
+    )
+    assert kind == EMPTY_SYMBOLS_NO_SIGNAL
+    assert "empty" in detail
+
+
+def test_item_binding_outside_loop_without_array_source_is_unresolved():
+    """`symbol: {{ item }}` 인데 상류에 배열 포트가 아예 없다 — 설계 결함."""
+    evaluated = {"symbol": "{{ item }}"}
+    kind, detail = classify_empty_symbol_source(
+        "historical", evaluated, _Ctx(inputs={"balance": {"cash": 1}}), _wf("historical", dict(evaluated)),
+        keys=("symbol", "symbols"),
+    )
+    assert kind == EMPTY_SYMBOLS_UNRESOLVED
+    assert "not being iterated" in detail
+
+
+def test_item_binding_with_non_empty_upstream_array_is_unresolved():
+    """배열은 있는데(비어 있지 않음) 반복이 안 걸렸다 — 이 노드까지 배열이 안 흘렀다는 뜻."""
+    evaluated = {"symbol": "{{ item }}"}
+    kind, _ = classify_empty_symbol_source(
+        "historical", evaluated, _Ctx(inputs={"values": [{"x": 1}]}), _wf("historical", dict(evaluated)),
+        keys=("symbol", "symbols"),
+    )
+    assert kind == EMPTY_SYMBOLS_UNRESOLVED
+
+
+def test_literal_list_with_unusable_entries_is_unbound():
+    raw = {"symbols": [1, 2]}
+    kind, detail = classify_empty_symbol_source("sizing", {"symbols": []}, _Ctx(), _wf("sizing", raw))
+    assert kind == EMPTY_SYMBOLS_UNBOUND and "literal list" in detail
+
+
+def test_without_workflow_falls_back_to_evaluated_config():
+    """workflow 가 없으면(레거시/테스트 호출) 평가된 설정만 본다 — 미해석 표현식은 여전히 잡는다."""
+    kind, _ = classify_empty_symbol_source("n", {"symbols": "{{ nodes.x.y }}"}, _Ctx(), None)
+    assert kind == EMPTY_SYMBOLS_UNRESOLVED
+    kind, _ = classify_empty_symbol_source("n", {}, _Ctx(), None)
+    assert kind == EMPTY_SYMBOLS_UNBOUND
+
+
+# ---------------------------------------------------------------------------
+# 2. PositionSizingNodeExecutor — 벤치 실측 모양 그대로
+# ---------------------------------------------------------------------------
+
+def _run_sizing(raw: Dict[str, Any], ctx: _Ctx, evaluated: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    ex = PositionSizingNodeExecutor()
+    return asyncio.run(ex.execute(
+        node_id="sizing", node_type="PositionSizingNode",
+        config=dict(evaluated if evaluated is not None else raw), context=ctx,
+        workflow=_wf("sizing", raw),
+    ))
+
+
+def test_sizing_bound_condition_with_no_pass_today_is_no_signal_without_warning():
+    """본선 최다 실패 모양: `symbols: {{ nodes.rsi.passed_symbols }}`, fixed_quantity 1, 오늘 통과 0."""
+    raw = {"symbols": "{{ nodes.rsi.passed_symbols }}", "method": "fixed_quantity", "fixed_quantity": 1,
+           "balance": "{{ nodes.account.balance }}"}
+    ctx = _Ctx(node_outputs={"rsi": {"passed_symbols": [], "is_condition_met": False},
+                             "account": {"balance": {"orderable_amount": 1000}}})
+    out = _run_sizing(raw, ctx)
+    assert out["reason"] == EmptyOrderReason.NO_SIGNAL.value
+    assert out["orders"] == []
+    assert not ctx.warnings_with("No symbols provided"), ctx.logs
+    assert ctx.infos_with("No symbols to size")
+
+
+def test_sizing_unbound_symbols_keeps_warning_and_no_symbol():
+    raw = {"method": "fixed_quantity", "fixed_quantity": 1}
+    ctx = _Ctx()
+    out = _run_sizing(raw, ctx)
+    assert out["reason"] == EmptyOrderReason.NO_SYMBOL.value
+    warns = ctx.warnings_with("No symbols provided for position sizing")
+    assert warns and "no symbol source" in warns[0]
+    assert out["detail"] and "passed_symbols" in out["detail"]
+
+
+def test_sizing_unresolved_binding_keeps_warning_with_expression():
+    raw = {"symbols": "{{ nodes.trigger_combine.result }}", "method": "fixed_quantity"}
+    ctx = _Ctx()  # trigger_combine 출력 없음 → 표현식 미해석 → 리터럴 유지
+    out = _run_sizing(raw, ctx)
+    assert out["reason"] == EmptyOrderReason.NO_SYMBOL.value
+    warns = ctx.warnings_with("No symbols provided for position sizing")
+    assert warns and "nodes.trigger_combine.result" in warns[0]
+
+
+def test_sizing_upstream_error_dict_is_fetch_failed_with_warning():
+    raw = {"symbols": "{{ nodes.market.result }}", "method": "fixed_percent"}
+    ctx = _Ctx(node_outputs={"market": {"result": {"error": "LS timeout", "values": []}}})
+    out = _run_sizing(raw, ctx)
+    assert out["reason"] == EmptyOrderReason.FETCH_FAILED.value
+    assert ctx.warnings_with("upstream fetch failed")
+
+
+# ---------------------------------------------------------------------------
+# 3. HistoricalDataNodeExecutor / MarketDataNodeExecutor
+# ---------------------------------------------------------------------------
+
+def _run_hist(raw: Dict[str, Any], ctx: _Ctx) -> Dict[str, Any]:
+    ex = HistoricalDataNodeExecutor()
+    return asyncio.run(ex.execute(
+        node_id="historical", node_type="OverseasStockHistoricalDataNode",
+        config=dict(raw), context=ctx, workflow=_wf("historical", raw),
+    ))
+
+
+def test_historical_item_binding_with_empty_upstream_is_info_not_warning():
+    raw = {"symbol": "{{ item }}", "interval": "1d"}
+    ctx = _Ctx(inputs={"symbols": []})
+    out = _run_hist(raw, ctx)
+    assert out == {"value": None, "values": [], "symbols": [], "period": "", "interval": "1d"}
+    assert not ctx.warnings_with("No symbols provided")
+    assert ctx.infos_with("No symbols to fetch")
+
+
+def test_historical_unresolved_split_reference_keeps_warning():
+    raw = {"symbol": "{{ nodes.split.item }}", "interval": "1d"}
+    ctx = _Ctx()
+    out = _run_hist(raw, ctx)
+    assert out["values"] == []
+    warns = ctx.warnings_with("No symbols provided")
+    assert warns and "nodes.split.item" in warns[0]
+
+
+def test_historical_no_source_keeps_warning():
+    ctx = _Ctx()
+    _run_hist({"interval": "1d"}, ctx)
+    assert ctx.warnings_with("No symbols provided")
+
+
+def _run_market(raw: Dict[str, Any], ctx: _Ctx, evaluated: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    ex = MarketDataNodeExecutor()
+    return asyncio.run(ex.execute(
+        node_id="market", node_type="OverseasStockMarketDataNode",
+        config=dict(evaluated if evaluated is not None else raw), context=ctx, workflow=_wf("market", raw),
+    ))
+
+
+def test_market_bound_filter_empty_is_values_without_error():
+    raw = {"symbols": "{{ nodes.filter.symbols }}"}
+    ctx = _Ctx(node_outputs={"filter": {"symbols": []}})
+    out = _run_market(raw, ctx)
+    assert out == {"values": []}
+    assert not [l for l in ctx.logs if l["level"] == "error"]
+    assert ctx.infos_with("No symbols to quote")
+
+
+def test_market_no_source_keeps_error():
+    ctx = _Ctx()
+    out = _run_market({}, ctx)
+    assert "error" in out and "symbols 필드가 필수" in out["error"]
+    assert [l for l in ctx.logs if l["level"] == "error"]
+
+
+# ---------------------------------------------------------------------------
+# 4. NewOrderNodeExecutor — 상류 no_signal 물려받기 (runtime 관측성)
+# ---------------------------------------------------------------------------
+
+def test_order_inherits_upstream_no_signal_from_input_namespace():
+    ctx = _Ctx(inputs={"orders": [], "order": None, "symbols": [], "reason": "no_signal",
+                       "message": "No trading signal today (upstream produced an empty result normally).",
+                       "detail": "upstream symbol source produced no symbols in this run (no signal)"})
+    reason, detail = NewOrderNodeExecutor()._diagnose_empty_reason(None, {}, None, ctx, node_id="order")
+    assert reason == EmptyOrderReason.NO_SIGNAL
+    assert "no signal" in detail
+
+
+def test_order_inherits_upstream_no_signal_via_raw_order_expr():
+    ctx = _Ctx(node_outputs={"sizing": {"orders": [], "order": None, "reason": "no_signal", "detail": "d"}})
+    reason, _ = NewOrderNodeExecutor()._diagnose_empty_reason(None, {}, "{{ nodes.sizing.order }}", ctx, node_id="order")
+    assert reason == EmptyOrderReason.NO_SIGNAL
+
+
+def test_order_still_no_symbol_when_upstream_says_no_symbol():
+    ctx = _Ctx(inputs={"orders": [], "reason": "no_symbol", "detail": "no symbol source is configured"})
+    reason, _ = NewOrderNodeExecutor()._diagnose_empty_reason(None, {}, None, ctx, node_id="order")
+    assert reason == EmptyOrderReason.NO_SYMBOL
+
+
+def test_order_upstream_no_signal_with_error_marker_stays_fetch_failed():
+    """no_signal 이라도 실패 마커(_partial_failure)가 같이 있으면 정상으로 물려받지 않는다."""
+    ctx = _Ctx(inputs={"orders": [], "reason": "no_signal", "_partial_failure": True,
+                       "_failure_reason": "balance fetch partially failed"})
+    reason, _ = NewOrderNodeExecutor()._diagnose_empty_reason(None, {}, None, ctx, node_id="order")
+    assert reason != EmptyOrderReason.NO_SIGNAL

--- a/src/programgarden/tests/test_empty_symbol_source_classification.py
+++ b/src/programgarden/tests/test_empty_symbol_source_classification.py
@@ -312,3 +312,96 @@ def test_order_upstream_no_signal_with_error_marker_stays_fetch_failed():
                        "_failure_reason": "balance fetch partially failed"})
     reason, _ = NewOrderNodeExecutor()._diagnose_empty_reason(None, {}, None, ctx, node_id="order")
     assert reason != EmptyOrderReason.NO_SIGNAL
+
+
+# ---------------------------------------------------------------------------
+# 5. 적대 리뷰(2026-09-07) 반영 — 분류기가 결함을 no_signal 로 삼키지 않는다
+# ---------------------------------------------------------------------------
+
+from programgarden.executor import EMPTY_SYMBOLS_UPSTREAM_FAILED  # noqa: E402
+
+
+def test_non_empty_input_port_without_binding_is_unbound():
+    """엣지로 symbols 가 들어왔는데(비어 있지 않음) 이 노드가 빈 목록을 봤다 = 바인딩 누락."""
+    kind, detail = classify_empty_symbol_source(
+        "sizing", {"method": "fixed_quantity"},
+        _Ctx(inputs={"symbols": [{"symbol": "AAPL", "exchange": "NASDAQ"}]}),
+        _wf("sizing", {"method": "fixed_quantity"}),
+    )
+    assert kind == EMPTY_SYMBOLS_UNBOUND
+    assert "no `symbols` binding" in detail
+
+
+def test_item_binding_with_condition_zero_pass_is_no_signal_despite_other_lists():
+    """ConditionNode 0건 통과: passed_symbols=[] 이지만 symbols/failed_symbols 는 비어 있지 않다."""
+    evaluated = {"symbol": "{{ item }}"}
+    inputs = {
+        "passed_symbols": [],
+        "failed_symbols": [{"symbol": "AAPL"}, {"symbol": "MSFT"}],
+        "symbols": [{"symbol": "AAPL"}, {"symbol": "MSFT"}],
+        "symbol_results": [{"symbol": "AAPL", "passed": False}],
+        "is_condition_met": False,
+    }
+    kind, _ = classify_empty_symbol_source(
+        "historical", evaluated, _Ctx(inputs=inputs), _wf("historical", dict(evaluated)),
+        keys=("symbol", "symbols"),
+    )
+    assert kind == EMPTY_SYMBOLS_NO_SIGNAL
+
+
+def test_item_binding_with_condition_pass_but_no_iteration_is_unresolved():
+    evaluated = {"symbol": "{{ item }}"}
+    inputs = {"passed_symbols": [{"symbol": "AAPL"}], "symbols": [{"symbol": "AAPL"}]}
+    kind, _ = classify_empty_symbol_source(
+        "historical", evaluated, _Ctx(inputs=inputs), _wf("historical", dict(evaluated)),
+        keys=("symbol", "symbols"),
+    )
+    assert kind == EMPTY_SYMBOLS_UNRESOLVED
+
+
+@pytest.mark.parametrize("scalar", [False, True, 0, 3, "AAPL"])
+def test_binding_resolved_to_scalar_is_unresolved(scalar):
+    raw = {"symbols": "{{ nodes.cond.is_condition_met }}", "method": "fixed_quantity"}
+    kind, detail = classify_empty_symbol_source("sizing", {"symbols": scalar}, _Ctx(), _wf("sizing", raw))
+    assert kind == EMPTY_SYMBOLS_UNRESOLVED
+    assert "not a symbol list" in detail
+
+
+def test_referenced_node_error_is_upstream_failed():
+    raw = {"symbols": "{{ nodes.market.values }}", "method": "fixed_percent"}
+    ctx = _Ctx(node_outputs={"market": {"values": [], "error": "MARKET_DATA_FETCH_FAILED: LS timeout"}})
+    kind, detail = classify_empty_symbol_source("sizing", {"symbols": []}, ctx, _wf("sizing", raw))
+    assert kind == EMPTY_SYMBOLS_UPSTREAM_FAILED
+    assert "LS timeout" in detail
+
+
+def test_sizing_referenced_node_error_returns_fetch_failed_with_warning():
+    raw = {"symbols": "{{ nodes.market.values }}", "method": "fixed_percent", "balance": {"orderable_amount": 100}}
+    ctx = _Ctx(node_outputs={"market": {"values": [], "error": "MARKET_DATA_FETCH_FAILED: LS timeout"}})
+    out = _run_sizing(raw, ctx)
+    assert out["reason"] == EmptyOrderReason.FETCH_FAILED.value
+    assert ctx.warnings_with("No symbols provided for position sizing")
+    assert "LS timeout" in out["detail"]
+
+
+def test_sizing_missing_balance_is_fetch_failed_not_no_signal():
+    """종목은 있는데 balance 바인딩이 없다 — 주문 노드가 D2 상속으로 조용히 no-op 되면 안 된다."""
+    raw = {"symbols": [{"symbol": "AAPL", "exchange": "NASDAQ"}], "method": "fixed_percent", "max_percent": 5}
+    ctx = _Ctx()
+    out = _run_sizing(raw, ctx)
+    assert out["reason"] == EmptyOrderReason.FETCH_FAILED.value
+    assert "balance" in out["detail"]
+
+
+def test_sizing_zero_cash_with_balance_present_is_no_signal():
+    raw = {"symbols": [{"symbol": "AAPL", "exchange": "NASDAQ"}], "method": "fixed_percent",
+           "balance": {"orderable_amount": 0}}
+    out = _run_sizing(raw, _Ctx())
+    assert out["reason"] == EmptyOrderReason.NO_SIGNAL.value
+
+
+def test_sizing_unresolved_balance_literal_is_fetch_failed():
+    raw = {"symbols": [{"symbol": "AAPL", "exchange": "NASDAQ"}], "method": "fixed_percent",
+           "balance": "{{ nodes.ghost.balance }}"}
+    out = _run_sizing(raw, _Ctx(), evaluated={**raw, "balance": None})
+    assert out["reason"] == EmptyOrderReason.FETCH_FAILED.value

--- a/src/programgarden/tests/test_order_error_mapping.py
+++ b/src/programgarden/tests/test_order_error_mapping.py
@@ -383,15 +383,27 @@ class TestEmptyOrderRealPathBlocker:
         assert reason == EmptyOrderReason.FETCH_FAILED
         assert "COSOQ02701" in detail
 
-    def test_normal_empty_upstream_via_missing_port_is_no_symbol(self):
-        """상류가 정상 빈 결과(실패 신호 없음) + order=None → no_symbol(설정 누락)."""
+    def test_normal_empty_upstream_via_missing_port_inherits_no_signal(self):
+        """상류가 정상 빈 결과(reason=no_signal, 실패 신호 없음) + order=None → no_signal.
+
+        D2(2026-09-06): 종전엔 "order 페이로드 비어있음 → no_symbol(설정 누락)" 이었으나,
+        상류 사이징이 명시적으로 '오늘 신호 없음' 을 냈으면 주문 노드도 그걸 물려받는다 —
+        조용한 날마다 "설정 누락" 경보가 나던 오분류 제거. fetch_failed 오판 금지는 그대로.
+        """
         ex = NewOrderNodeExecutor()
         upstream = {"orders": [], "order": None, "reason": "no_signal"}
         ctx = self._ctx_with_upstream("sizing", upstream)
         reason, _ = ex._diagnose_empty_reason(
             None, {}, "{{ nodes.sizing.order }}", ctx
         )
-        # 상류 실패 신호 없음 → order 페이로드 비어있음 → no_symbol
+        assert reason != EmptyOrderReason.FETCH_FAILED
+        assert reason == EmptyOrderReason.NO_SIGNAL
+
+    def test_normal_empty_upstream_without_reason_is_still_no_symbol(self):
+        """상류가 reason 을 안 실은 빈 결과(레거시 출력) → 종전대로 no_symbol."""
+        ex = NewOrderNodeExecutor()
+        ctx = self._ctx_with_upstream("sizing", {"orders": [], "order": None})
+        reason, _ = ex._diagnose_empty_reason(None, {}, "{{ nodes.sizing.order }}", ctx)
         assert reason == EmptyOrderReason.NO_SYMBOL
 
     def test_unresolved_literal_expression_is_fetch_failed(self):
@@ -543,10 +555,13 @@ class TestExecuteRawOrderExprWiring:
 
         order_result = result["order_result"]
         assert order_result["success"] is False
-        # No upstream failure signal + empty order payload → no_symbol, and
-        # critically NOT fetch_failed (no false positive).
+        # No upstream failure signal → critically NOT fetch_failed (no false
+        # positive). D2 (2026-09-06): the upstream's explicit ``reason=no_signal``
+        # is now inherited — "no trading signal today" is a normal no-op, not
+        # "configuration missing" (no_symbol), so runtime monitoring stops
+        # raising a daily false alarm on quiet days.
         assert order_result["reason"] != "fetch_failed"
-        assert order_result["reason"] == "no_symbol"
+        assert order_result["reason"] == "no_signal"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
AI 모델 벤치마크(2026-09-05~06)가 라이브로 재현한 **모델 무관 최대 실패 원인** 수정. 사이징·과거시세·현재가·종목정보 노드가 빈 종목 목록을 받으면 원인 불문 같은 warning("No symbols provided …")을 남겼고, 챗봇 저장 게이트가 그 문구를 설계 결함으로 읽어 **올바르게 배선된 워크플로우**(`symbols: {{ nodes.rsi.passed_symbols }}`)가 모의 실행 표본에서 오늘 조건 통과 종목이 0 이라는 이유만으로 저장되지 못했다(보고서 40여 건 전수 분석).

- `classify_empty_symbol_source()`: 원본 설정 + `_input_<id>` 입력 포트로 **no_signal / unresolved / unbound / upstream_failed** 판정. 정상 무신호는 info 만, 나머지는 warning + 고치는 법.
- 주문 노드가 상류 `reason=no_signal` 을 상속(조용한 날 "설정 누락" 오보고 제거), 사이징 상류 error dict 순서 결함, 잔고 미해석 → fetch_failed.
- 적대 리뷰(5차원) 확정 5건 반영(심볼 포트 기준 반복 판정 · upstream_failed · 스칼라/미소비 포트 · 잔고).
- core 노드 가이드 7파일. 버전 programgarden 1.33.3 / core 1.25.2, CHANGELOG.

## Validation
- 신규 `tests/test_empty_symbol_source_classification.py` 31건 + 관련 스위트 144 passed. 전체 스위트 실패·에러는 수정 전과 동일한 환경 의존 건.

## Follow-up
- PyPI 발행 → sandbox·pg-ai·cloudrun·computer_app 핀 갱신.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTu9Ty9gwfE2Qx5PgRyzkp
