### PR TITLE
release: v1.33.4 PyPI 배포 (finance 1.9.3 · programgarden 1.33.4)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "programgarden"
-version = "1.33.3"
+version = "1.33.4"
 description = "LS증권 API을 메인으로 제작된 노코딩 시스템 트레이딩 DSL 오픈소스"
 authors = [
     {name = "장용준",email = "coding@programgarden.com"}

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,5 +1,34 @@
 ## [Unreleased]
 
+## [1.33.4] - 2026-09-08
+> LS증권 OPEN API 공지(**2026-09-12(토) 12:00** 적용)의 국내주식 TR 필드 추가를 반영하는
+> 릴리즈. 엔진 로직 변경은 없고 `finance` 의 TR 블록 스키마만 넓힌다.
+> 동반 릴리즈: `finance` **1.9.3**. (`core` 1.25.2 · `community` 1.15.1 변경 없음.)
+
+### Added
+- **(finance 1.9.3) LS 국내주식 TR 신규 필드 26종 반영** — 공지 대상 8종 중 이 저장소가
+  구현 중인 6종:
+  - InBlock `exchgubun`(거래소구분코드, `'K'`/`'N'`/`'U'`, 기본 `'K'`) — `t1901`·`t1903`·`t1904`
+    (`t8451`·`t8452`·`t8453` 은 이미 보유).
+  - OutBlock `ex_shcode`(거래소별종목코드) — `t1901`·`t1903`·`t1904`(OutBlock·OutBlock1).
+  - OutBlock `nxt_vi_gubun`(NXTVI발동해제) — `t1901`. 기존 `vi_gubun` 의 NXT 대응.
+  - OutBlock KRX 프리/애프터마켓 시간 6종 — `t8451`·`t8452`·`t8453`:
+    `krx_fm_s_time`·`krx_fm_e_time`·`krx_fm_dshmin`·
+    `krx_am_s_time`·`krx_am_e_time`·`krx_am_dshmin`.
+    같은 블록의 기존 `nxt_*` 6종과 1:1 대응.
+
+  반영하지 않으면 신규 필드가 응답에 실려 와도 pydantic 이 미정의 키를 무시해 **오류 없이
+  조용히 버려진다.** 신규 OutBlock 필드는 전부 기본값이 있어 적용일 이전 응답도 그대로
+  파싱되고, InBlock 의 `exchgubun` 기본값 `'K'` 는 `t8451` 계열이 이미 하던 동작과 같다.
+
+### Changed
+- deps: `programgarden-finance` **^1.9.1 → ^1.9.3**.
+
+### Notes
+- `t1902`(ETF시간별추이) · `t1906`(ETF LP호가) 는 이 저장소에 **미구현**이라 공지의 해당
+  항목은 반영 대상이 없다. 신규 TR 로 추가하려면 공지의 "추가 필드" 목록만으로는 부족하고
+  전체 블록 정의(LS 개발자센터 가이드)가 필요하다.
+
 ## [1.33.3] - 2026-09-07
 > AI 모델 벤치마크(2026-09-05~06, 서버 repo `.claude/plans/2026-09-06-engine-defects-from-benchmark.md`)가
 > 라이브로 재현한 엔진 결함 2건. 둘 다 **모델 무관** — 어떤 챗봇 모델이 만들어도 같은 자리에서 죽어,

--- a/src/programgarden/poetry.lock
+++ b/src/programgarden/poetry.lock
@@ -2625,14 +2625,14 @@ pydantic = ">=2.0.0,<3.0.0"
 
 [[package]]
 name = "programgarden-finance"
-version = "1.9.1"
+version = "1.9.3"
 description = "프로그램 동산 운영진이 관리하는 증권사 데이터 오픈소스"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "programgarden_finance-1.9.1-py3-none-any.whl", hash = "sha256:ff5000f8fcb1b250c88b69ec25166f4f9de6c52b8d5ffb4ca64ca2623835a1fe"},
-    {file = "programgarden_finance-1.9.1.tar.gz", hash = "sha256:285709ddcb8dbe8e41a9d8da5b0b5aee30eba32b8854f3faee3b0da2006e50b5"},
+    {file = "programgarden_finance-1.9.3-py3-none-any.whl", hash = "sha256:3b773e3f8de064616e71da25943e3a272b2d9c27918e0cc934cae17472aab39b"},
+    {file = "programgarden_finance-1.9.3.tar.gz", hash = "sha256:2ea283bac4636434a3aca3387885eab4d8761b16602319ef1abc39cc39f6b671"},
 ]
 
 [package.dependencies]
@@ -4179,4 +4179,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "3768c92aed6a66b95c1588a8b5cbaa25d96eb749879c89628ef89552ffd11ead"
+content-hash = "0077dc357caacef7f599acce5ec4c1788a5551c3785a4bbb6449c0c83b5a9817"

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.33.3"
+version = "1.33.4"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
@@ -30,7 +30,7 @@ pytickersymbols = {version = ">=1.17.5", python = ">=3.12,<4.0"}
 aiosqlite = "^0.20.0"
 litellm = ">=1.40.0"
 programgarden-core = "^1.25.0"
-programgarden-finance = "^1.9.1"
+programgarden-finance = "^1.9.3"
 programgarden-community = "^1.15.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
[#38](https://github.com/programgarden/programgarden/pull/38) 의 LS TR 필드 추가분을 PyPI 로 배포하고 버전 상태를 기록한다. **엔진 로직 변경 없음.**

## 배포 완료

| 패키지 | 버전 | PyPI |
|---|---|---|
| programgarden-finance | 1.9.2 → **1.9.3** | https://pypi.org/project/programgarden-finance/1.9.3/ |
| programgarden | 1.33.3 → **1.33.4** | https://pypi.org/project/programgarden/1.33.4/ |
| programgarden-core | 1.25.2 (변경 없음) | — |
| programgarden-community | 1.15.1 (변경 없음) | — |

## 이 커밋이 담은 것

- 루트 `pyproject.toml` 버전 동기화 1.33.3 → 1.33.4
- `src/programgarden/pyproject.toml` — 버전 + deps `programgarden-finance` ^1.9.1 → **^1.9.3**
- `src/programgarden/CHANGELOG.md` — `[1.33.4]` 항목
- `src/programgarden/poetry.lock` — finance 1.9.1 → 1.9.3 재생성 (`poetry check --lock` 통과)

## 내용

LS증권 OPEN API 공지: **2026-09-12(토) 12:00** 국내주식 TR 8종 필드 추가. 구현 중인 6종에 26개 필드 반영 — `exchgubun`(t1901·t1903·t1904 InBlock) · `ex_shcode`(t1901·t1903·t1904·t1904OutBlock1) · `nxt_vi_gubun`(t1901) · KRX 프리/애프터마켓 시간 6종(t8451·t8452·t8453). 미구현 TR `t1902`·`t1906` 은 대상 없음.

신규 OutBlock 필드는 전부 기본값이 있어 적용일 이전 응답도 그대로 파싱된다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uhfp4Us7M3Z1jUHwXXTwTF