### PR TITLE
fix(finance): preserve futures execution evidence and stock pending orders

### DIFF
--- a/src/core/README.md
+++ b/src/core/README.md
@@ -85,3 +85,15 @@ programgarden_core/
 ## 변경 로그
 
 자세한 변경 사항은 `CHANGELOG.md`를 참고하세요.
+
+## Workflow PnL event contract
+
+Futures workflow PnL events preserve native gross estimates separately from
+accounting results. `workflow_*`, `other_*`, `total_*`, account and competition
+monetary/rate scalars remain null when accounting evidence is unavailable.
+`pnl_by_currency` contains gross price-change subtotals by contract currency;
+`monetary_positions` retains their basis/status and unmodified, unconfirmed
+`broker_pnl_amount`. No fee, FX, margin/equity return or verified contest score
+is inferred from these estimates. Actual zero and negative amounts are retained.
+`currency` is null for mixed or unavailable currencies. Consumers must handle
+nullable monetary fields and must not coerce them to zero.

--- a/src/core/programgarden_core/bases/listener.py
+++ b/src/core/programgarden_core/bases/listener.py
@@ -205,8 +205,11 @@ class WorkflowPnLEvent:
     WorkflowPnLEvent separates workflow positions from manual positions
     using FIFO (First-In-First-Out) tracking.
     
-    Used for competition ranking where only workflow-generated trades
-    should be counted for official scoring.
+    This is a local workflow observation. Official competition scoring requires
+    separate broker-verified accounting and must not trust this event alone.
+    Futures monetary scalars are unavailable until their accounting basis is
+    established. Native gross price-change estimates remain in pnl_by_currency
+    and monetary_positions, separately from unconfirmed broker-reported values.
     
     Attributes:
         job_id: Job identifier
@@ -295,9 +298,7 @@ class WorkflowPnLEvent:
                 super().__init__(start_date="20260115")  # 대회 시작일
             
             async def on_workflow_pnl_update(self, event: WorkflowPnLEvent) -> None:
-                # Use workflow_pnl_rate for official competition ranking
-                await update_leaderboard(event.job_id, event.workflow_pnl_rate)
-                # Use competition_workflow_pnl_rate if start_date filtering is needed
+                # Display available local estimates without verifying a score.
                 if event.competition_workflow_pnl_rate is not None:
                     print(f"Competition P&L: {event.competition_workflow_pnl_rate}%")
     """
@@ -306,22 +307,22 @@ class WorkflowPnLEvent:
     product: str  # "overseas_stock" | "overseas_futures" | "korea_stock"
 
     # Workflow position P&L
-    workflow_pnl_rate: Union[Decimal, float]
-    workflow_eval_amount: Union[Decimal, float]
-    workflow_buy_amount: Union[Decimal, float]
-    workflow_pnl_amount: Union[Decimal, float]
+    workflow_pnl_rate: Optional[Union[Decimal, float]]
+    workflow_eval_amount: Optional[Union[Decimal, float]]
+    workflow_buy_amount: Optional[Union[Decimal, float]]
+    workflow_pnl_amount: Optional[Union[Decimal, float]]
     
     # Other (manual/unknown) position P&L
-    other_pnl_rate: Union[Decimal, float]
-    other_eval_amount: Union[Decimal, float]
-    other_buy_amount: Union[Decimal, float]
-    other_pnl_amount: Union[Decimal, float]
+    other_pnl_rate: Optional[Union[Decimal, float]]
+    other_eval_amount: Optional[Union[Decimal, float]]
+    other_buy_amount: Optional[Union[Decimal, float]]
+    other_pnl_amount: Optional[Union[Decimal, float]]
     
     # Total account P&L
-    total_pnl_rate: Union[Decimal, float]
-    total_eval_amount: Union[Decimal, float]
-    total_buy_amount: Union[Decimal, float]
-    total_pnl_amount: Union[Decimal, float]
+    total_pnl_rate: Optional[Union[Decimal, float]]
+    total_eval_amount: Optional[Union[Decimal, float]]
+    total_buy_amount: Optional[Union[Decimal, float]]
+    total_pnl_amount: Optional[Union[Decimal, float]]
     
     # Position details
     workflow_positions: list = field(default_factory=list)  # List[PositionDetail]
@@ -335,9 +336,17 @@ class WorkflowPnLEvent:
     paper_trading: bool = False  # True: 모의투자, False: 실전투자
 
     # Metadata
-    currency: str = "USD"
+    currency: Optional[str] = "USD"
     timestamp: datetime = field(default_factory=datetime.utcnow)
     
+    # Native estimates and broker observations are distinct from account returns.
+    monetary_status: Optional[str] = None
+    monetary_basis: Optional[str] = None
+    monetary_unavailable_reason: Optional[str] = None
+    pnl_by_currency: Dict[str, Any] = field(default_factory=dict)
+    monetary_positions: Dict[str, Any] = field(default_factory=dict)
+    unavailable_position_count: int = 0
+
     # ========== NEW FIELDS (v2.0) ==========
 
     # Workflow product-specific P&L
@@ -890,6 +899,10 @@ class ConsoleExecutionListener(BaseExecutionListener):
 
     async def on_workflow_pnl_update(self, event: WorkflowPnLEvent) -> None:
         """Print workflow P&L update for debugging"""
+        if event.workflow_pnl_rate is None or event.total_pnl_rate is None:
+            print(f"[{event.broker_node_id}] Workflow/account return unavailable "
+                  f"({event.monetary_unavailable_reason or 'missing monetary evidence'})")
+            return
         wf_pnl = float(event.workflow_pnl_rate)
         total_pnl = float(event.total_pnl_rate)
 

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-core"
-version = "1.25.2"
+version = "1.25.3"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 readme = "README.md"

--- a/src/finance/README.md
+++ b/src/finance/README.md
@@ -22,6 +22,17 @@ Programgarden Finance는 AI 시대에 맞춰 파이썬을 모르는 투자자도
 
 ## 설치
 
+Futures account PnL now carries explicit currency, gross-estimate basis and
+availability. Broker-reported amounts are retained separately; mixed or
+unsupported scalar totals are nullable. See the
+[futures PnL currency contract](docs/futures_pnl_currency_basis.md) for the
+USD estimator compatibility boundary and consumer requirements.
+
+The [CIDBQ03000 snapshot reference](docs/cidbq03000_snapshot_evidence.md) records
+the supplied field metadata and two actual paper balance reads, including their
+date and accounting limits. Reported equity and its P&L/fee components must not
+be added twice.
+
 ```bash
 # PyPI에 게시된 경우
 pip install programgarden-finance
@@ -216,7 +227,7 @@ futures.real()    # 실시간 데이터
 
 #### 국내 주식 (88 TR)
 - **시장 정보**: `t9945`(마스터), `t8450`(호가), `t1101`(호가), `t1102`(현재가), `t1104`(현재가시세메모), `t1105`(피봇/디마크), `t1301`(체결), `t1302`(분별주가), `t1305`(기간별주가), `t1308`(시간대별체결챠트), `t1310`(당일전일분틱), `t1410`(초저유동성), `t1427`(상/하한가직전), `t1449`(가격대별매매비중), `t1471`(시간별체결), `t1475`(체결), `t1486`(시간별예상체결가), `t1488`(예상체결가등락율상위), `t8407`(복수종목시세), `t8454`(멀티현재가), `t1404`/`t1405`(프로그램매매), `t1422`/`t1442`(관리/이상종목)
-- **계좌**: `CSPAQ22200`(예수금), `CSPAQ12200`(잔고), `CSPAQ12300`(잔고상세), `CSPAQ13700`(미체결), `CDPCQ04700`(투자가능금액), `FOCCQ33600`(증거금), `CSPAQ00600`(체결내역), `CSPBQ00200`(평가손익), `t0424`(잔고2), `t0425`(종목별잔고)
+- **계좌**: `CSPAQ22200`(예수금), `CSPAQ12200`(잔고), `CSPAQ12300`(잔고상세), `CSPAQ13700`(order/execution history), `CDPCQ04700`(투자가능금액), `FOCCQ33600`(증거금), `CSPAQ00600`(credit/margin limits), `CSPBQ00200`(평가손익), `t0424`(잔고2), `t0425`(종목별잔고)
 - **주문**: `CSPAT00601`(현물주문), `CSPAT00701`(정정), `CSPAT00801`(취소)
 - **랭킹**: `t1441`(등락률), `t1444`(시가총액), `t1452`(거래량), `t1463`(거래대금), `t1466`(전일동시간비), `t1481`(급등락), `t1482`(신고/신저)
 - **차트**: `t8451`(일주월년봉), `t8452`(분봉), `t8453`(틱봉), `t1665`(종합차트)
@@ -237,11 +248,30 @@ futures.real()    # 실시간 데이터
 #### 해외 선물옵션
 - **시장 정보**: `o3101`(선물마스터), `o3104`~`o3107`(거래소/통화/가격단위/정산환율), `o3116`(옵션마스터), `o3121`~`o3128`(각종 시장 정보), `o3136`, `o3137`(추가 시장 정보)
 - **차트**: `o3103`(일별), `o3108`(분봉), `o3117`(틱봉), `o3139`(시간외)
-- **계좌**: `CIDBQ01400`(예수금), `CIDBQ01500`(잔고), `CIDBQ01800`(체결내역), `CIDBQ02400`(미체결), `CIDBQ03000`(일별손익), `CIDBQ05300`(청산가능수량), `CIDEQ00800`(예탁증거금)
+- **계좌**: `CIDBQ01400`(orderable quantity), `CIDBQ01500`(잔고), `CIDBQ01800`(체결내역), `CIDBQ02400`(order execution detail), `CIDBQ03000`(deposit/balance status), `CIDBQ05300`(evaluated deposit totals), `CIDEQ00800`(예탁증거금)
 - **주문**: `CIDBT00100`(신규), `CIDBT00900`(정정), `CIDBT01000`(취소)
 - **실시간**: `OVC`(체결), `OVH`(호가), `TC1`~`TC3`, `WOC`, `WOH`(각종 실시간 데이터)
 
 ## 응답 코드 참조
+
+### Observed overseas futures paper responses
+
+The [local execution parser](docs/futures_execution_history.md) separates positive
+CIDBQ02400 execution observations from unresolved source issues, preserving
+independent dates and milliseconds without an implicit timezone.
+
+The [CIDBQ02400 field contract](docs/cidbq02400_contract.md) records the supplied
+LS execution-detail table: blank dates for same-day queries, `ExecDttm` as the
+execution timestamp, dated order identity, field lengths/scales, and the
+published table/example inconsistencies. It preserves unknown codes without
+inventing accounting behavior.
+
+`CIDBT00100` returned HTTP 200 / `01425` with the original message
+`모의투자 주문가능금액이 부족합니다.` and no order identifier during a
+2026-09-09 paper order. See [observed broker responses](docs/observed_broker_responses.md)
+for the exact request context, message provenance, and subsequent
+`CIDBQ01400.OrdAbleQty` observations. These are TR/account-specific observations,
+not a universal success-code rule or a fill guarantee.
 
 ### 국내 주식 주문 (CSPAT00601 / CSPAT00701 / CSPAT00801)
 
@@ -252,7 +282,12 @@ futures.real()    # 실시간 데이터
 | `01478` | 매도가능수량 부족 | 거부 (LS 측 잔고 검증) |
 | `IGW00201` | 호출 거래건수 초과 | 시스템 (재시도 가능) |
 
-> ⚠️ **주의**: 조회 TR 은 성공 시 `rsp_cd == "00000"` 이지만, **주문 TR (`CSPAT006xx`) 은 방향별 성공 코드 `00040`/`00039` 를 사용**합니다. `rsp_cd != "00000"` 로 실패 판정하면 정상 주문 응답을 거부로 오분류합니다.
+Response codes are TR-specific: the domestic new-order example below expects
+`00040` for buys and `00039` for sells, while the observed paper
+`CIDBQ01400` quantity query returned `00136` with valid output. Do not use
+`rsp_cd == "00000"` as a universal success rule or reuse this new-order
+example to classify modification/cancellation responses. Check the expected
+response blocks and identifiers as well as the code and original message.
 
 ```python
 # 권장 주문 성공 판정

--- a/src/finance/docs/cidbq02400_contract.md
+++ b/src/finance/docs/cidbq02400_contract.md
@@ -1,0 +1,156 @@
+# CIDBQ02400 supplied LS field contract
+
+Source: LS overseas futures order execution detail table and request/response
+example supplied by the repository owner on 2026-09-09. This reference retains
+published field metadata without copying account numbers, credentials, user IDs
+or full account payloads from the example. Length/scale describes the published
+wire format; this documentation does not add restrictive Pydantic validators.
+
+## Request and continuation
+
+Send `ThdayTpCode="0"` with `QrySrtDt`/`QryEndDt` in YYYYMMDD for historical
+queries. Send `ThdayTpCode="1"` with **both date fields empty** for same-day
+queries. The published field descriptions require this even though the example
+combines same-day mode with nonempty dates. Logical collection time windows
+remain separate from these transport fields.
+
+For continuation, send `tr_cont="Y"` and the preceding response's
+`tr_cont_key` while continuation is indicated. `tr_cont="N"` indicates no
+continuation. Keep the request scope fixed across a cursor chain.
+
+| Header field | Type | Required | Length | Published meaning |
+| --- | --- | --- | --- | --- |
+| content-type | String | Y | 100 | application/json; charset=utf-8 |
+| authorization | String | Y | 1000 | OAuth access token; never log |
+| tr_cd | String | Y | 10 | CIDBQ02400 |
+| tr_cont | String | Y | 1 | Y: continuation; N: no continuation |
+| tr_cont_key | String | Y | 18 | Previous continuation key |
+| mac_address | String | Y | 12 | Required for corporate callers |
+
+Response headers publish content-type, tr_cd, tr_cont and tr_cont_key with the
+same types/lengths. All listed body fields are marked required in the supplied
+table; response models retain their existing tolerant defaults.
+
+| Input field | Type | Length | Published meaning |
+| --- | --- | --- | --- |
+| IsuCodeVal | String | 30 | Instrument code |
+| QrySrtDt | String | 8 | Historical start YYYYMMDD; empty for same-day |
+| QryEndDt | String | 8 | Historical end YYYYMMDD; empty for same-day |
+| ThdayTpCode | String | 1 | 0: historical; 1: same-day |
+| OrdStatCode | String | 1 | 0: all; 1: executed; 2: unexecuted |
+| BnsTpCode | String | 1 | 0: all; 1: sell; 2: buy |
+| QryTpCode | String | 1 | 1: reverse; 2: forward |
+| OrdPtnCode | String | 2 | 00: all; 01: regular; 02: Average; 03: Spread |
+| OvrsDrvtFnoTpCode | String | 1 | A: all; F: futures; O: options |
+
+`RecCnt` appears in the supplied request example but is absent from the input
+field table. This discrepancy does not establish a new required request field.
+OutBlock1 echoes the input fields and adds RecCnt (Number, 5), AcntNo (String,
+20), and Pwd (String, 8). Account/password echoes must not be logged.
+
+## Execution evidence and published inconsistencies
+
+`ExecDttm` is **execution datetime**, a 17-character timestamp; the existing
+SDK format is YYYYMMDDHHMMSSsss. `OrdSndDttm` is order send datetime. Do not
+substitute order placement/send time for execution time when counting a contest
+interval. `OrdDt` and `OvrsFutsOrdNo` identify the dated broker order;
+`OvrsFutsExecNo` identifies an execution, and `OvrsFutsOrgOrdNo` is a separate
+original-order link. Multiple execution records for the same dated order do not
+mean multiple orders. A never-executed cancellation contributes zero; canceling
+the unexecuted remainder of a partially executed order leaves one executed order.
+
+The output table says `FutsOrdStatCode` 0=all, 1=executed, 2=unexecuted. However,
+its execution example returns **FutsOrdStatCode="4"**, TrdTpNm="체결",
+TrxStatCodeNm="체결", positive ExecQty, OvrsFutsExecNo and ExecDttm. Preserve
+this inconsistency. Do not exclude execution evidence solely because the output
+code is not "1", or invent a universal meaning for "4". `OrdStatCode` is a
+request filter and must not be confused with the response field.
+
+`TrxStatCodeNm` lists "체결" and "체결취소". These are the supplied original
+labels; the table does not explain how the latter links to an earlier execution
+or changes its accounting. Keep the raw label. It is not sufficient evidence to
+invent a reversal or treat an ordinary unfilled order cancellation as a trade.
+
+The published media map is 00=branch, 22=iPhone, 23=Android, 41=API, 43=Robo API,
+85=HTS, 96=final settlement, LP=loss cut, SK=CashCall and SO=conditional order.
+The example uses **40**, which the table does not map. Preserve it as returned;
+do not classify it by guessing a nearby code.
+
+## OutBlock2 fields
+
+All fields below are required according to the published table. Empty values in
+the example remain possible. Numeric length/scale is transcribed, not a currency
+unit or a statement that fee components are additive.
+
+| Field | Type | Length/scale | Meaning or published values |
+| --- | --- | --- | --- |
+| OrdDt | String | 8 | Order date |
+| OvrsFutsOrdNo | String | 10 | LS order number |
+| OvrsFutsOrgOrdNo | String | 10 | Original LS order number |
+| FcmOrdNo | String | 15 | FCM order number |
+| ExecDt | String | 8 | Execution date |
+| OvrsFutsExecNo | String | 10 | LS execution number |
+| FcmAcntNo | String | 20 | FCM account number; sensitive |
+| IsuCodeVal | String | 30 | Instrument code |
+| IsuNm | String | 50 | Instrument name |
+| AbrdFutsXrcPrc | Number | 30.11 | Exercise price |
+| BnsTpCode | String | 1 | 0: all; 1: sell; 2: buy |
+| BnsTpNm | String | 10 | Direction name |
+| FutsOrdStatCode | String | 1 | 0: all; 1: executed; 2: unexecuted; example discrepancy above |
+| TpCodeNm | String | 50 | 신규, 정정, 취소, 이관, 수관, 소멸, 장애 |
+| FutsOrdTpCode | String | 1 | Table description blank; example has a value |
+| TrdTpNm | String | 20 | 주문, 접수, 확인, 체결, 소멸, 거부 |
+| AbrdFutsOrdPtnCode | String | 1 | Table description blank; do not infer a complete enum |
+| OrdPtnNm | String | 40 | 시장가, 지정가, Stop Market, Stop Limit |
+| OrdPtnTermTpCode | String | 2 | Table description blank |
+| CmnCodeNm | String | 100 | 일반, Spread |
+| AppSrtDt | String | 8 | Application start date |
+| AppEndDt | String | 8 | Application end date |
+| OrdQty | Number | 16 | Order quantity |
+| OvrsDrvtOrdPrc | Number | 30.11 | Order price |
+| OvrsDrvtExecIsuCode | String | 30 | Executed instrument code |
+| ExecIsuNm | String | 50 | Executed instrument name |
+| ExecBnsTpCode | String | 1 | Executed direction code |
+| ExecBnsTpNm | String | 10 | Executed direction name |
+| ExecQty | Number | 16 | Executed quantity |
+| AbrdFutsExecPrc | Number | 30.11 | Execution price |
+| OrdCndiPrc | Number | 30.11 | Order condition price |
+| OvrsDrvtNowPrc | Number | 30.11 | Current price |
+| UnercQty | Number | 16 | Unexecuted quantity |
+| TrxStatCode | String | 2 | Processing status code; enum not supplied |
+| TrxStatCodeNm | String | 40 | 체결, 체결취소; accounting effect not supplied |
+| CsgnCmsn | Number | 19.2 | Consignment commission |
+| FcmCmsn | Number | 21.4 | FCM commission |
+| ThcoCmsn | Number | 19.2 | Company commission |
+| MdaCode | String | 2 | Media code; map and example discrepancy above |
+| MdaCodeNm | String | 40 | Media name |
+| RegTmnlNo | String | 3 | Registered terminal number |
+| RegUserId | String | 16 | Registered user ID; sensitive |
+| OrdSndDttm | String | 17 | Order send datetime |
+| ExecDttm | String | 17 | Execution datetime |
+| EufOneCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| EufTwoCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| LchOneCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| LchTwoCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| TrdOneCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| TrdTwoCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| TrdThreeCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| StrmOneCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| StrmTwoCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| StrmThreeCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| TransOneCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| TransTwoCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| TransThreeCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| TransFourCmsnAmt | Number | 19.2 | Fee component; currency/additivity not supplied |
+| OvrsOptXrcRsvTpCode | String | 1 | 1: exercise at expiry |
+| OvrsDrvtOptTpCode | String | 1 | Overseas derivative option type |
+| SprdBaseIsuYn | String | 1 | Spread base instrument flag |
+| OvrsDrvtIsuCode2 | String | 30 | Second instrument code |
+
+The supplied example returns HTTP-style response fields rsp_cd="00136" and
+rsp_msg="조회가 완료되었습니다.". This is a published example, not a new
+live test. It does not specify retained historical duration, currency per fee
+field, or how to net lifecycle corrections; those facts are not invented here.
+
+See [typed models](../programgarden_finance/ls/overseas_futureoption/accno/CIDBQ02400/blocks.py)
+and [observed paper rejection responses](observed_broker_responses.md).

--- a/src/finance/docs/cidbq03000_snapshot_evidence.md
+++ b/src/finance/docs/cidbq03000_snapshot_evidence.md
@@ -1,0 +1,51 @@
+# CIDBQ03000 deposit/balance snapshots
+
+The supplied LS contract names this TR overseas futures deposit/balance status.
+`AcntTpCode="1"` selects a consignment account. `TrdDt` is the requested trading
+date. The repository example `example/overseas_futureoption/run_CIDBQ03000.py`
+uses a paper account with `RecCnt=1`, `AcntTpCode="1"`, and `TrdDt=""`.
+
+## Observed paper responses, 2026-09-09
+
+Two read-only requests used that same SDK query builder and the platform's shared
+token provider. No order or independent OAuth request was submitted. The blank
+date request completed at18:46:13 KST; the `20260908` request at18:46:14 KST.
+Both returned HTTP200, `rsp_cd="00136"`, and the original message
+`모의투자 조회가 완료되었습니다.`. Both parsed as five balance rows.
+
+The blank request retained blank dates in the echo and each row; do not replace
+those fields with a purported broker-confirmed date. The dated request echoed
+`20260908`. USD, JPY, HKD, CHF and CAD rows were returned. No aggregate target was
+returned in these two responses; the separately supplied LS example has `TOT(USD)`.
+
+| HKD field | Blank date request | `20260908` request |
+| --- | ---: | ---: |
+| `OvrsFutsDps` | 999840.00 | 999840.00 |
+| `CustmMnyioAmt` | 0.00 | 0.00 |
+| `AbrdFutsLqdtPnlAmt` | 0.00 | 0.00 |
+| `AbrdFutsCmsnAmt` | 40.00 | 0.00 |
+| `PrexchDps` | 999800.00 | 999840.00 |
+| `EvalAssetAmt` | 998910.00 | 999840.00 |
+| `AbrdFutsEvalPnlAmt` | -890.00 | 0.00 |
+| `LastSettPnlAmt` | 0.00 | 0.00 |
+
+For this observed HKD snapshot, `999840 - 40 = 999800` and
+`999800 - 890 = 998910`. The change from the dated snapshot's evaluated assets is
+`-930`, matching the observed commission and valuation loss. Adding those
+components again to `EvalAssetAmt` would double count them in this example.
+
+This establishes a working date-specific query and the stated numerical
+relationships in these responses. It does not establish a universal accounting
+formula, historical retention, intraday reset boundary, or the inclusion of
+commission/final settlement in liquidation P&L: both liquidation and final
+settlement values were zero. It is not a verified contest return or MDD.
+
+## Field metadata corrections
+
+The supplied table specifies `OvrsFutsDps` as23.2 and the other monetary fields
+as19.2, `CrcyObjCode` length12, date length8, account number length20 and password
+length8. These are wire metadata, not new runtime validation constraints.
+`LastSettPnlAmt` is labelled final settlement P&L (`최종결제손익금액`); the former
+description “last daily settlement” asserted more than the supplied label.
+Keep native currency and aggregate rows distinct, and preserve missing raw
+fields before typed defaults when deciding whether financial evidence exists.

--- a/src/finance/docs/futures_execution_history.md
+++ b/src/finance/docs/futures_execution_history.md
@@ -1,0 +1,40 @@
+# Local futures execution observations
+
+`parse_futures_execution_history` in
+`programgarden_finance.ls.overseas_futureoption.extension.execution_history`
+accepts CIDBQ02400 response rows or mappings and returns separate `executions`
+and `issues`. It makes no request, places no order and establishes no complete
+query coverage or financial accounting result.
+
+Positive execution observations require explicitly supplied broker order and
+execution identifiers, `OrdDt`, `ExecDt`, a valid 17-digit `ExecDttm`, execution
+symbol/direction/quantity/quote price. Numeric identifiers ignore leading zeros;
+opaque identifiers retain case. Other identifier namespaces are never fallbacks.
+`ExecBnsTpCode` maps 1 to sell and 2 to buy. The output order status is retained,
+not used as a universal 1-only execution filter. Zero and negative futures quote
+prices are valid supplied prices. Missing model defaults are not evidence.
+
+Order date, broker execution date and execution wall time remain independent.
+`execution_wall_time` is a naive datetime preserving the actual milliseconds.
+This API supplies no implicit timezone or inferred UTC instant. A caller must
+provide its broker-timezone configuration and provenance before normalizing time
+for a server. Do not manufacture a date from the order date or claim millisecond
+precision from a seconds-only real-time message.
+
+An ordinary zero execution quantity does not create a fill. A `체결취소` label
+creates `execution_cancellation_effect_unverified` even with zero quantity.
+Other invalid positive rows create an issue with whatever explicit order identity
+is available. Issues must survive downstream reconciliation; ignoring one could
+incorrectly present an earlier fill as current, complete evidence. No cancellation
+netting, deletion or replacement execution is inferred.
+
+The parser retains repeated execution observations. Durable consumers must apply
+source-scoped identity checks and surface conflicting facts, with account,
+credential, mode, order and broker execution date in their documented domain.
+TC3 exchange execution IDs are not interchangeable with CIDBQ02400 LS execution
+IDs. Using both as independent FIFO writers can double-count one economic fill.
+
+Only a narrow status/date/media whitelist is retained as evidence. Entire broker
+payloads, account identifiers, passwords and user registration fields are not
+copied. Local telemetry remains unverified and cannot populate official contest
+or financial accounting results by itself.

--- a/src/finance/docs/futures_pnl_currency_basis.md
+++ b/src/finance/docs/futures_pnl_currency_basis.md
@@ -1,0 +1,109 @@
+# Futures PnL currencies and monetary basis
+
+Futures account tracking separates two different observations:
+
+- `broker_pnl_amount` preserves the supplied `CIDBQ01500.AbrdFutsEvalPnlAmt`,
+  including zero and negative values. `broker_pnl_basis` is always
+  `broker_reported_unconfirmed`: the available broker field description does
+  not establish its monetary unit, mark basis or included costs. A missing
+  response field remains `None`, even when the SDK model has a zero default.
+- `pnl_amount` is a **native-currency gross price-change estimate** from entry
+  price, latest price, quantity and a compatible contract's tick metadata.
+  `pnl_currency`, `pnl_basis="estimated_gross_price_change"`, and
+  `pnl_status="available"` describe this amount. It is not broker net PnL,
+  settlement PnL, account equity, return or MDD. REST refreshes and realtime
+  ticks use this same basis; neither substitutes an estimated USD fee result
+  for the preserved broker amount.
+
+When price/currency/spec/tick evidence is missing or incompatible,
+`pnl_amount`, `pnl_currency` and `pnl_basis` are `None`, `pnl_status` is
+`"unavailable"`, and `pnl_unavailable_reason` describes the missing evidence.
+The existing position `currency` field retains the observed position code; it
+does not prove the broker amount's unit. The legacy `realtime_pnl` field remains
+for API compatibility, but the account tracker no longer populates it with a
+fee-adjusted USD estimate. Position `pnl_rate` remains the existing nominal
+price-change percentage; it is not an account-equity return.
+The tracker still accepts `commission_rate` for constructor compatibility;
+it is not applied to the native gross estimate or preserved broker amount.
+
+## Standalone calculations
+
+`extension.calculator.calculate_futures_pnl` and
+`FuturesPnLCalculator.calculate_realtime_pnl` retain the existing **USD-only
+estimator** behavior for valid USD specifications. Its round-trip fee, tax and
+USD/KRW values are estimates, not observed broker charges. Passing a non-USD
+or blank-currency spec raises `usd_estimator_requires_usd_spec`. Invalid or
+zero tick metadata is rejected instead of used as evidence.
+
+Manual tick inputs in this legacy estimator retain the USD default, made
+explicit by `FuturesTradeInput.manual_currency="USD"`. Non-USD manual values
+are rejected. Supplying USD manual overrides does not silently convert or
+override a contradictory non-USD contract specification.
+
+For a separate native gross estimate, import:
+
+```python
+from decimal import Decimal
+from programgarden_finance.ls.overseas_futureoption.extension.calculator import (
+    calculate_native_gross_pnl,
+)
+from programgarden_finance.ls.overseas_futureoption.extension.symbol_spec_manager import SymbolSpec
+
+contract = SymbolSpec(
+    symbol="SYNTHETIC_HKD", currency="HKD", tick_size=Decimal("1"),
+    tick_value=Decimal("10"),
+)
+estimate = calculate_native_gross_pnl(
+    spec=contract, quantity=1, entry_price=Decimal("25000"),
+    current_price=Decimal("25001"), is_long=True,
+)
+assert estimate.amount == Decimal("10")
+assert estimate.currency == "HKD"
+assert estimate.basis == "estimated_gross_price_change"
+```
+
+`FuturesNativePnLResult` contains `amount`, `currency`, `basis`, `total_ticks`,
+`tick_size_used` and `tick_value_used`. This function applies no fee, tax, FX,
+margin or quote-adjustment assumption. Short positions reverse the price
+movement sign. Metadata must actually apply to the quoted instrument; the
+function does not establish broader broker accounting semantics.
+
+## Account totals
+
+`AccountPnLInfo.pnl_by_currency` maps each currency to a
+`FuturesCurrencyPnL(currency, basis, total_pnl_amount, position_count)` subtotal
+of **available compatible estimates only**. `unavailable_position_count`
+records excluded positions. These subtotals must not be described as complete
+account financial valuations when any position is unavailable.
+
+Legacy `total_pnl_amount`, `currency` and `pnl_basis` are available only when
+all positions have compatible available estimates in a single currency.
+Mixed currencies, unknown positions or incompatible bases make those scalars
+`None` with `pnl_status="unavailable"`. Zero and negative *known* estimates
+remain available; unknown is never silently zero or USD. An empty account is
+unavailable with reason `no_positions`.
+
+`account_pnl_rate`, `total_eval_amount` and `total_margin_used` remain `None`:
+the account model does not have enough evidence to combine raw margins,
+valuation bases and return denominators safely. Raw position margins remain
+available as broker fields, without invented cross-currency aggregation.
+
+## Missing master metadata and compatibility
+
+`SymbolSpec.currency` retains its USD default for existing manually constructed
+USD specs. Actual `o3121` rows explicitly preserve blank `CrncyCd` as an empty
+currency; missing or zero `UntPrc` and `MnChgAmt` remain zero. The manager no
+longer invents USD, tick-size0.01 or tick-value1 for missing broker metadata.
+Native and USD calculators reject those missing/invalid inputs. Valid supplied
+metadata is unchanged.
+
+Consumers must carry amount, currency, basis and availability together.
+REST position estimates also require explicitly supplied `PchsPrc`, `BalQty`
+and a recognized `BnsTpCode` (1 sell, 2 buy). A subsequent price tick cannot
+repair missing quantity, entry or direction evidence. An explicit zero quantity
+is distinct from a missing quantity defaulted to zero by the response model.
+Coercing `None` through `or0`, defaulting currency to USD, mixing currency
+subtotals or filling unknown account-return fields from price×quantity loses
+this contract. Executor/context/event forwarding need the corresponding
+consumer integration before an application can claim this SDK change fixes
+its complete monetary reporting path.

--- a/src/finance/docs/observed_broker_responses.md
+++ b/src/finance/docs/observed_broker_responses.md
@@ -1,0 +1,161 @@
+# Observed LS broker responses
+
+This reference records directly observed responses, scoped to their TR and
+account mode. It is not a universal response-code dictionary. Preserve the
+original `rsp_cd` and `rsp_msg`; do not infer an undocumented rejection cause
+from the code or substitute another broker's message table.
+
+## CIDBT00100: overseas futures paper order rejection
+
+Observed on 2026-09-09 at 11:11:28 KST (UTC+09:00) through the normal
+chat-generated workflow and local desktop runner.
+
+| Field | Observed value |
+| --- | --- |
+| Account mode | Overseas futures PAPER |
+| TR | `CIDBT00100` (new order) |
+| Instrument | `CUSU26`, HKEX |
+| Request | BUY, 1 contract, LIMIT 6.7043 |
+| HTTP status | `200` |
+| `rsp_cd` | `01425` |
+| Original broker message | `모의투자 주문가능금액이 부족합니다.` |
+| Order identifier | Not returned |
+| Outcome | Rejected; no accepted order or new fill confirmed |
+
+The original message means the paper orderable amount is insufficient. This
+observation does not establish the account's currency balances, margin rules,
+funding requirements, or the meaning of this code in another TR/account mode.
+
+The normal failed-order journal preserved the exact message in
+`order_fills.diagnostics.raw_msg` and
+`raw_event.engine_result.diagnostics.raw_msg`. The engine's `error` field
+retained `Empty OrderNo: 모의투자 주문가능금액이 부족합니다.`.
+The `Empty OrderNo:` prefix is added by the engine, not by the broker.
+The failed record was timestamped `2026-09-09T02:11:28.551292Z`.
+A separate task observer captured only the response code; a read-only journal
+inspection recovered the message without issuing another broker request.
+Missing observer output does not mean the broker omitted `rsp_msg`.
+
+HTTP 200 alone does not establish order acceptance. A failed journal record is
+also not an executed trade. Keep acceptance, positive execution and workflow
+terminal status separate when reporting the result.
+
+## CIDBQ01400: subsequent paper orderable-quantity reads
+
+On the same paper account, read-only requests returned HTTP 200,
+`rsp_cd=00136`, and `rsp_msg=모의투자 조회가 완료되었습니다.`.
+Both responses explicitly contained `CIDBQ01400OutBlock2.OrdAbleQty`.
+
+Shared request fields: `RecCnt=1`, `QryTpCode="1"` (new order),
+`BnsTpCode="2"` (buy), and `AbrdFutsOrdPtnCode="2"` (limit).
+
+| Observed at (KST, 2026-09-09) | `IsuCodeVal` | `OvrsDrvtOrdPrc` | `OrdAbleQty` |
+| --- | --- | --- | --- |
+| 11:26:50 | `CUSU26` | 6.7043 | 0 |
+| 11:26:56 | `HMHU26` | 25260.0 | 44 |
+
+The HMHU26 price came from an actual `o3105` response identifying HKEX
+`Mini Hang Seng(2026.09)`, with `TrdP=25260.0`,
+`KorDate=20260909`, and `RcvTm=112652`. It was a last-trade price,
+not a confirmed current ask. The quantity is specific to that account, time,
+instrument, side and limit price; it is not a fill guarantee or a default for
+other users. No order was placed by these quantity queries.
+
+See the typed request/response fields in
+[`CIDBQ01400/blocks.py`](../programgarden_finance/ls/overseas_futureoption/accno/CIDBQ01400/blocks.py).
+These observations do not introduce automatic order retries or change SDK
+success-code classification. Missing output blocks/quantity remain unknown;
+do not replace them with a successful zero result.
+
+## HMHU26: accepted paper order, later execution and holding
+
+On 2026-09-09, a normal chat-generated workflow was validated, saved and run
+through the local desktop UI. It submitted one HMHU26/HKEX PAPER BUY order for
+one contract at LIMIT 25250. No retry or cancellation was submitted.
+
+| Event (KST) | Observed evidence |
+| --- | --- |
+| 12:09:15.501, order response | `CIDBT00100`, HTTP 200, `rsp_cd=00040`, original `rsp_msg=모의투자 매수주문이 완료 되었습니다.`, order ID present |
+| 12:09:17 and 12:09:27, order reads | `CIDBQ01800`, `ExecQty=0`, `UnercQty=1` |
+| 12:09:32.213, actual execution time | `CIDBQ02400.ExecDttm=20260909120932213`, `ExecQty=1`, `AbrdFutsExecPrc=25247`, `UnercQty=0`, execution ID present |
+| 12:09:37.913, execution-detail response | HTTP 200, `rsp_cd=00136`, one row, terminal continuation |
+| 12:09:39.234, holdings response | `CIDBQ01500`, HTTP 200, `rsp_cd=00136`, positive HMHU26 holding |
+
+The execution-detail request used `ThdayTpCode="1"` with both query dates
+empty. Its raw row contained `OrdDt=20260909`, `ExecDt=20260909`,
+`ExecBnsTpCode="2"`, `OvrsDrvtExecIsuCode="HMHU26"`,
+`FutsOrdStatCode="1"`, `TpCodeNm=""`, and `TrdTpNm="매수"`.
+The positive execution quantity, execution ID and actual execution timestamp
+were matched to this submitted order privately. Account and order identifiers
+are intentionally absent from this reference.
+
+The contemporaneous `CIDBQ01800` row retained `FutsOrdStatCode="3"` and
+`TpCodeNm="확인"` even after its `ExecQty` became 1. Preserve these TR-specific
+observations without inventing a shared status-code mapping. The
+[`CIDBQ02400 contract reference`](cidbq02400_contract.md) also retains the
+official table/example discrepancy; this one observed row does not erase it.
+
+The user independently confirmed the holding in the Toohon overseas-futures
+paper account. The finite workflow had already completed at 12:09:24, before
+the actual execution. Its pre-fill order journal and PnL flush therefore do
+not, by themselves, prove post-fill journal ingestion, account return, MDD or
+contest ranking persistence. Those require separate evidence.
+
+## CIDBQ02400: response transaction-code mismatch during paper recovery
+
+At 15:05:25 KST on 2026-09-09, the normal desktop recovery worker requested
+`CIDBQ02400` on the overseas-futures PAPER account. The SDK response passed
+HTTP 200 / `rsp_cd=00136` / no SDK error and retained the original message
+`모의투자 조회가 완료되었습니다.`. Its parsed response header contained
+`tr_cd="CIDBQ"`, while the request header contained `tr_cd="CIDBQ02400"`.
+
+The bounded desktop history adapter rejected this response with its own
+`unexpected_response_tr` error before retaining that page's execution facts.
+This is an application validation failure, not a broker order rejection or
+proof that the previously confirmed HMH execution disappeared. The canonical
+SDK response model does not change the header value. The meaning and accepted
+scope of the shortened response code have been referred to the user for
+confirmation; no alias mapping or response-code inference has been added.
+
+A separate offline fixture exposed case-sensitive HTTP header-name validation.
+That fixture is not the observed cause of this transaction-code value mismatch.
+
+The desktop adapter was subsequently changed to validate the exact authenticated
+HTTPS request, named response blocks and all nine echoed query fields. The
+supplied response-header contract and SDK do not impose the adapter's former
+request/response value-equality condition. This change retains the raw header
+without defining an LS alias; missing or mismatched query echoes still reject
+the page, and historical coverage remains unverified.
+
+At 16:38:02 KST the normal desktop recovery worker retained the original HMHU26
+execution through this path. Its normal server-backed monitoring view showed
+one execution, quantity1, price25247 and execution time12:09:32.213. A second
+automatic poll at16:39:09 retained one observation, with one acknowledged server
+delivery and no duplicate execution. No new order was submitted. The original
+pre-fill parent remains immutable; the displayed filled state comes from its
+separate execution observation and remains explicitly unverified local
+telemetry. This proves post-workflow recovery, not account return/MDD or complete
+contest history. Raw headers from these two successful polls were not archived,
+so this result does not assert their exact response `tr_cd` value.
+
+
+## CSPAQ13700: incomplete domestic-stock history observation
+
+A read-only real-account probe on2026-09-09 at approximately00:43 UTC recorded
+HTTP200, `rsp_cd="01001"`, `tr_cont="N"` and no saved output blocks. The probe
+artifact omitted `rsp_msg`; its original text cannot be recovered from that
+artifact. No meaning for01001, empty-history success, account permission or
+request rejection is established by this record.
+
+The request used all-market/both-side/all-symbol/filled-and-unfilled filters,
+an explicit current KST date and starting order number999999999. Its manually
+constructed body omitted `OrdPtnCode`. This is a request-shape observation,
+not an established cause of the response. A future diagnostic must preserve
+the original code and message without exposing account fields.
+
+The local typed contract describes CSPAQ13700 as order/execution history,
+including per-order cumulative quantities and average execution prices.
+CSPAQ00600 describes credit/margin limits and orderable amounts, not execution
+history. The README shorthand has been corrected to match these model
+contracts. A dated order number does not supply the calendar execution date,
+individual partial-fill ledger or complete historical coverage.

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/accno/CIDBQ02400/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/accno/CIDBQ02400/blocks.py
@@ -7,9 +7,12 @@ Field source policy (per CLAUDE.md ``feedback_no_inferred_formulas`` and the
 2026-05-06 finance TR field metadata plan):
     - Description text mirrors the LS Korean source labels translated into English.
       Korean source label is appended in parentheses for AI chatbot Korean↔English mapping.
-    - Field length, decimal scale, currency unit, and complete enum mappings are NOT declared
-      in the source available to this codebase. Where ambiguous, descriptions state
-      "consume as returned by LS."
+    - The LS field table supplied by the user on 2026-09-09 provides field lengths,
+      numeric scales and selected enums; see docs/cidbq02400_contract.md in this package.
+      Currency units, fee additivity and missing enum meanings remain unspecified.
+    - The published table and example disagree on the output status code and
+      same-day input dates. Preserve the conflict; do not constrain response enums
+      or infer undocumented values from the example.
     - Commission fields (CsgnCmsn, FcmCmsn, ThcoCmsn, etc.) include positive and zero examples.
     - ``examples`` come from ``src/finance/example/overseas_futureoption/run_CIDBQ02400.py``
       where present, plus safe placeholder values ("12345678901" for account numbers).
@@ -41,7 +44,7 @@ class CIDBQ02400InBlock1(BaseModel):
         title="Issue code value (종목코드값)",
         description=(
             "Instrument code for the overseas futures/options symbol to query. "
-            "From the example script: 'ADM23'. Length not declared in available source."
+            "From the example script: 'ADM23'. Published length: 30."
         ),
         examples=["ADM23", "ESM26", "NQU26"],
     )
@@ -50,20 +53,20 @@ class CIDBQ02400InBlock1(BaseModel):
         ...,
         title="Query start date (조회시작일자)",
         description=(
-            "Query start date in YYYYMMDD format. Used for historical queries. "
-            "From the example script: '20230516'."
+            "Query start date in YYYYMMDD format for historical queries (ThdayTpCode='0'). "
+            "Send an empty string for same-day queries (ThdayTpCode='1'). Published length: 8."
         ),
-        examples=["20230516", "20260101"],
+        examples=["20230516", "20260101", ""],
     )
 
     QryEndDt: str = Field(
         ...,
         title="Query end date (조회종료일자)",
         description=(
-            "Query end date in YYYYMMDD format. Used for historical queries. "
-            "From the example script: '20230609'."
+            "Query end date in YYYYMMDD format for historical queries (ThdayTpCode='0'). "
+            "Send an empty string for same-day queries (ThdayTpCode='1'). Published length: 8."
         ),
-        examples=["20230609", "20260131"],
+        examples=["20230609", "20260131", ""],
     )
 
     ThdayTpCode: Literal["0", "1"] = Field(
@@ -158,7 +161,7 @@ class CIDBQ02400OutBlock1(BaseModel):
     AcntNo: str = Field(
         default="",
         title="Account number (계좌번호)",
-        description="Account number for the query. Length not declared in available source.",
+        description="Account number for the query. Published length: 20.",
         examples=["12345678901"],
     )
 
@@ -239,9 +242,9 @@ class CIDBQ02400OutBlock1(BaseModel):
 class CIDBQ02400OutBlock2(BaseModel):
     """CIDBQ02400OutBlock2 — per-order/execution detail row (Occurs).
 
-    One record per order or execution event. Field length, decimal scale, currency unit,
-    and complete enum mappings are not declared in the source available to this codebase —
-    consume as returned by LS.
+    One record per order or execution event. Published lengths and numeric scales
+    are recorded in docs/cidbq02400_contract.md. Currency units and complete enum
+    semantics remain unspecified; consume raw values without invented mappings.
     """
 
     OrdDt: str = Field(
@@ -312,7 +315,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Overseas futures exercise price (해외선물행사가격)",
         description=(
             "Strike / exercise price. 0 for futures contracts. "
-            "Decimal scale not declared in available source."
+            "Published numeric length/scale: 30.11."
         ),
         examples=[0.0, 5000.0],
     )
@@ -335,17 +338,19 @@ class CIDBQ02400OutBlock2(BaseModel):
         default="",
         title="Futures order status code (선물주문상태코드)",
         description=(
-            "Order status code. Enum mapping not declared in available source — "
-            "consume as returned by LS."
+            "Published table: '0'=all, '1'=executed, '2'=unexecuted. The same "
+            "published response example reports '4' with TrdTpNm='체결', positive "
+            "ExecQty, an execution number and ExecDttm. Preserve this discrepancy; "
+            "do not reject other values or identify executed rows using '1' alone."
         ),
-        examples=["", "1", "2"],
+        examples=["", "1", "2", "4"],
     )
 
     TpCodeNm: str = Field(
         default="",
         title="Type code name (구분코드명)",
-        description="Order classification name as returned by LS (e.g., 신규, 정정, 취소).",
-        examples=["", "신규", "정정", "취소"],
+        description="Published classification labels: 신규, 정정, 취소, 이관, 수관, 소멸, 장애.",
+        examples=["", "신규", "정정", "취소", "이관", "수관", "소멸", "장애"],
     )
 
     FutsOrdTpCode: str = Field(
@@ -422,7 +427,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Overseas derivative order price (해외파생주문가격)",
         description=(
             "Order price. 0 for market orders. "
-            "Decimal scale not declared in available source."
+            "Published numeric length/scale: 30.11."
         ),
         examples=[0.0, 4500.25, 1900.0],
     )
@@ -466,7 +471,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         default=0.0,
         title="Overseas futures execution price (해외선물체결가격)",
         description=(
-            "Execution price. Decimal scale not declared in available source."
+            "Execution price. Published numeric length/scale: 30.11."
         ),
         examples=[0.0, 4502.50],
     )
@@ -476,7 +481,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Order condition price (주문조건가격)",
         description=(
             "Stop trigger price. 0 when not applicable. "
-            "Decimal scale not declared in available source."
+            "Published numeric length/scale: 30.11."
         ),
         examples=[0.0, 4490.0],
     )
@@ -486,7 +491,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Overseas derivative current price (해외파생현재가)",
         description=(
             "Current market price at query time. "
-            "Decimal scale not declared in available source."
+            "Published numeric length/scale: 30.11."
         ),
         examples=[0.0, 4510.0],
     )
@@ -511,8 +516,12 @@ class CIDBQ02400OutBlock2(BaseModel):
     TrxStatCodeNm: str = Field(
         default="",
         title="Processing status code name (처리상태코드명)",
-        description="Display name of the processing status.",
-        examples=["", "처리완료"],
+        description=(
+            "Published processing-status labels: 체결, 체결취소. The table does not "
+            "define the numeric code mapping or the latter label's accounting effect; "
+            "retain the original value without inferring an order cancellation or reversal."
+        ),
+        examples=["", "체결", "체결취소"],
     )
 
     CsgnCmsn: float = Field(
@@ -520,7 +529,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Consignment commission (위탁수수료)",
         description=(
             "Commission charged by LS for the consignment. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[5.0, 0.0],
     )
@@ -530,7 +539,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="FCM commission (FCM수수료)",
         description=(
             "Commission charged by the FCM. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 21.4. Currency is not specified."
         ),
         examples=[2.0, 0.0],
     )
@@ -540,7 +549,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Company commission (당사수수료)",
         description=(
             "Internal company commission. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[1.0, 0.0],
     )
@@ -548,8 +557,13 @@ class CIDBQ02400OutBlock2(BaseModel):
     MdaCode: str = Field(
         default="",
         title="Media code (매체코드)",
-        description="Channel/media code used to place the order.",
-        examples=["", "00", "10"],
+        description=(
+            "Published media codes: 00=branch, 22=iPhone, 23=Android, 41=API, "
+            "43=Robo API, 85=HTS, 96=final settlement, LP=loss cut, SK=CashCall, "
+            "SO=conditional order. The example's '40' is not mapped by this table; "
+            "preserve unknown values. Published length: 2."
+        ),
+        examples=["", "00", "41", "43", "40"],
     )
 
     MdaCodeNm: str = Field(
@@ -583,7 +597,11 @@ class CIDBQ02400OutBlock2(BaseModel):
     ExecDttm: str = Field(
         default="",
         title="Execution datetime (체결일시)",
-        description="Execution datetime in YYYYMMDDHHMMSSsss format. Empty for unexecuted orders.",
+        description=(
+            "Actual execution datetime in YYYYMMDDHHMMSSsss format (published length: 17). "
+            "Use this execution timestamp for interval membership, not OrdSndDttm "
+            "(order send time) or the order date. Empty for unexecuted orders."
+        ),
         examples=["", "20230609093016500"],
     )
 
@@ -592,7 +610,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Exchange fee 1 commission amount (거래소비용1수수료금액)",
         description=(
             "Exchange cost 1 fee. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 1.25],
     )
@@ -602,7 +620,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Exchange fee 2 commission amount (거래소비용2수수료금액)",
         description=(
             "Exchange cost 2 fee. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.75],
     )
@@ -612,7 +630,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="London clearing house 1 commission amount (런던청산소1수수료금액)",
         description=(
             "London clearing house cost 1. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.50],
     )
@@ -622,7 +640,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="London clearing house 2 commission amount (런던청산소2수수료금액)",
         description=(
             "London clearing house cost 2. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.25],
     )
@@ -632,7 +650,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Trade 1 commission amount (거래1수수료금액)",
         description=(
             "Trade fee component 1. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.10],
     )
@@ -642,7 +660,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Trade 2 commission amount (거래2수수료금액)",
         description=(
             "Trade fee component 2. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.10],
     )
@@ -652,7 +670,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Trade 3 commission amount (거래3수수료금액)",
         description=(
             "Trade fee component 3. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.05],
     )
@@ -662,7 +680,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Short-term 1 commission amount (단기1수수료금액)",
         description=(
             "Short-term fee component 1. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.05],
     )
@@ -672,7 +690,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Short-term 2 commission amount (단기2수수료금액)",
         description=(
             "Short-term fee component 2. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.05],
     )
@@ -682,7 +700,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Short-term 3 commission amount (단기3수수료금액)",
         description=(
             "Short-term fee component 3. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.05],
     )
@@ -692,7 +710,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Transfer 1 commission amount (전달1수수료금액)",
         description=(
             "Transfer fee component 1. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.02],
     )
@@ -702,7 +720,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Transfer 2 commission amount (전달2수수료금액)",
         description=(
             "Transfer fee component 2. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.02],
     )
@@ -712,7 +730,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Transfer 3 commission amount (전달3수수료금액)",
         description=(
             "Transfer fee component 3. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.02],
     )
@@ -722,7 +740,7 @@ class CIDBQ02400OutBlock2(BaseModel):
         title="Transfer 4 commission amount (전달4수수료금액)",
         description=(
             "Transfer fee component 4. "
-            "Currency and decimal scale not declared in available source."
+            "Published numeric length/scale: 19.2. Currency is not specified."
         ),
         examples=[0.0, 0.01],
     )

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/accno/CIDBQ03000/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/accno/CIDBQ03000/blocks.py
@@ -1,19 +1,22 @@
-"""Pydantic models for LS Securities OpenAPI CIDBQ03000 (Overseas Futures Deposit/Balance Status).
+"""LS Securities OpenAPI CIDBQ03000 overseas futures deposit/balance models.
 
-CIDBQ03000 returns a per-currency snapshot of the overseas futures account's deposit,
-margin, P&L, and orderable/withdrawable amounts for a given trading date.
+The response describes account deposit/balance state for ``TrdDt`` and may
+contain individual currency rows and an aggregate target such as ``TOT(USD)``.
 
-Field source policy (per CLAUDE.md ``feedback_no_inferred_formulas`` and the
-2026-05-06 finance TR field metadata plan):
-    - Description text mirrors the LS Korean source labels translated into English.
-      Korean source label is appended in parentheses for AI chatbot Korean↔English mapping.
-    - Field length, decimal scale, currency unit, and complete enum mappings are NOT declared
-      in the source available to this codebase. Where ambiguous, descriptions state
-      "consume as returned by LS."
-    - PnL fields (AbrdFutsLqdtPnlAmt, AbrdFutsEvalPnlAmt, LastSettPnlAmt) include positive,
-      negative, and zero examples as required by plan policy.
-    - ``examples`` come from ``src/finance/example/overseas_futureoption/run_CIDBQ03000.py``
-      where present, plus safe placeholder values ("12345678901" for account numbers).
+Metadata sources:
+    - The LS request/response table supplied by the user on 2026-09-09 defines
+      field labels, string lengths, numeric lengths/scales and account types.
+      These describe the wire format; the model adds no new validation limits.
+    - The supplied response example contains ``TOT(USD)`` and ``rsp_cd="00136"``.
+    - The repository example uses a blank ``TrdDt``. The supplied table does not
+      define that convention or the available historical query period.
+    - Date-specific responses do not establish intraday reset boundaries or
+      arithmetic relationships between the P&L and commission fields.
+
+Keep the returned currency target and snapshot fields separate. Do not treat
+snapshot components as independent additions to reported equity without a
+confirmed accounting identity. The labels/example do not establish a formula
+between liquidation P&L, final settlement P&L, valuation P&L and commission.
 """
 
 from typing import List, Literal, Optional
@@ -49,7 +52,7 @@ class CIDBQ03000InBlock1(BaseModel):
         title="Account type code (계좌구분코드)",
         description=(
             "'1' = consignment account (위탁계좌), '2' = brokerage account (중개계좌). "
-            "From the example script: '1'."
+            "String length 1 in the supplied request table."
         ),
         examples=["1", "2"],
     )
@@ -58,8 +61,8 @@ class CIDBQ03000InBlock1(BaseModel):
         default="",
         title="Trading date (거래일자)",
         description=(
-            "Trading date in YYYYMMDD format. Pass empty string for the current trading date. "
-            "From the example script: empty string."
+            "Trading date, string length 8, YYYYMMDD. "
+            "The repository example passes an empty string; the supplied table does not define this convention."
         ),
         examples=["", "20260117"],
     )
@@ -107,21 +110,21 @@ class CIDBQ03000OutBlock1(BaseModel):
     RecCnt: int = Field(
         default=0,
         title="Record count (레코드갯수)",
-        description="Echoed record count from the request.",
+        description="Echoed record count. Numeric length 5 in the supplied response table.",
         examples=[0, 1],
     )
 
     AcntTpCode: str = Field(
         default="",
         title="Account type code (계좌구분코드)",
-        description="Echoed account type. '1' = consignment, '2' = brokerage.",
+        description="Echoed account type, string length 1. '1' = consignment, '2' = brokerage.",
         examples=["1", "2"],
     )
 
     AcntNo: str = Field(
         default="",
         title="Account number (계좌번호)",
-        description="Account number for the query. Length not declared in available source.",
+        description="Account number for the query, string length 20.",
         examples=["12345678901"],
     )
 
@@ -129,7 +132,7 @@ class CIDBQ03000OutBlock1(BaseModel):
         default="",
         title="Account password (계좌비밀번호)",
         description=(
-            "Account password as echoed by LS. Treat as sensitive — avoid logging. "
+            "Account password as echoed by LS, string length 8. Treat as sensitive; avoid logging. "
             "Real production responses may mask or omit this value."
         ),
         examples=[""],
@@ -138,7 +141,7 @@ class CIDBQ03000OutBlock1(BaseModel):
     TrdDt: str = Field(
         default="",
         title="Trading date (거래일자)",
-        description="Echoed trading date in YYYYMMDD format.",
+        description="Echoed trading date, string length 8, YYYYMMDD.",
         examples=["", "20260117"],
     )
 
@@ -146,21 +149,23 @@ class CIDBQ03000OutBlock1(BaseModel):
 class CIDBQ03000OutBlock2(BaseModel):
     """CIDBQ03000OutBlock2 — per-currency deposit/balance detail row (Occurs).
 
-    One record per currency. Currency unit, decimal scale, and multiplier are not
-    declared in the source available to this codebase — consume values as returned by LS.
+    The supplied example returns a list containing a ``TOT(USD)`` aggregate row.
+    Keep aggregate and individual currency rows separate; summing them can double
+    count the same balance. Numeric lengths/scales describe the wire format,
+    not conversion rates, arithmetic identities or accumulation/reset periods.
     """
 
     AcntNo: str = Field(
         default="",
         title="Account number (계좌번호)",
-        description="Account number for this record. Length not declared in available source.",
+        description="Account number for this record, string length 20.",
         examples=["12345678901"],
     )
 
     TrdDt: str = Field(
         default="",
         title="Trading date (거래일자)",
-        description="Trading date for this balance record in YYYYMMDD format.",
+        description="Trading date for this balance record, string length 8, YYYYMMDD.",
         examples=["20260117", ""],
     )
 
@@ -168,10 +173,11 @@ class CIDBQ03000OutBlock2(BaseModel):
         default="",
         title="Currency target code (통화대상코드)",
         description=(
-            "Currency code for this record. "
-            "Enum mapping not declared in available source — consume as returned by LS."
+            "Currency target code, string length 12. The supplied example uses the "
+            "aggregate target 'TOT(USD)'. Preserve the target as returned; the "
+            "table does not give a complete enum or conversion rule."
         ),
-        examples=["USD", "HKD"],
+        examples=["TOT(USD)", "USD", "HKD"],
     )
 
     OvrsFutsDps: float = Field(
@@ -179,7 +185,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas futures deposit (해외선물예수금)",
         description=(
             "Deposit balance for overseas futures. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 23.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[10000.0, 0.0],
     )
@@ -189,7 +195,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Customer deposit/withdrawal amount (고객입출금금액)",
         description=(
             "Net customer deposit/withdrawal amount. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[5000.0, -2000.0, 0.0],
     )
@@ -199,7 +205,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas futures liquidation P&L amount (해외선물청산손익금액)",
         description=(
             "Realized P&L from liquidated overseas futures positions. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[1234.56, -789.01, 0.0],
     )
@@ -209,7 +215,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas futures commission amount (해외선물수수료금액)",
         description=(
             "Total commission for overseas futures. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[50.0, 0.0],
     )
@@ -218,8 +224,8 @@ class CIDBQ03000OutBlock2(BaseModel):
         default=0.0,
         title="Pre-exchange deposit (가환전예수금)",
         description=(
-            "Pre-exchange (before FX conversion) deposit amount. "
-            "Currency and decimal scale not declared in available source."
+            "LS-reported deposit amount (가환전예수금). "
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[0.0, 8000.0],
     )
@@ -229,7 +235,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Evaluated asset amount (평가자산금액)",
         description=(
             "Total evaluated asset amount including open positions. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[10000.0, 0.0],
     )
@@ -239,7 +245,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas futures consignment margin amount (해외선물위탁증거금액)",
         description=(
             "Required margin for overseas futures consignment positions. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[5000.0, 0.0],
     )
@@ -249,7 +255,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas futures additional margin amount (해외선물추가증거금액)",
         description=(
             "Additional margin required (variation/call margin). "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[0.0, 1000.0],
     )
@@ -259,7 +265,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas futures withdrawable amount (해외선물인출가능금액)",
         description=(
             "Amount that can be withdrawn from the overseas futures account. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[3000.0, 0.0],
     )
@@ -269,7 +275,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas futures orderable amount (해외선물주문가능금액)",
         description=(
             "Available funds for placing new overseas futures orders. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[5000.0, 0.0],
     )
@@ -279,17 +285,17 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas futures unrealized P&L amount (해외선물평가손익금액)",
         description=(
             "Unrealized (mark-to-market) P&L for overseas futures positions. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[1234.56, -789.01, 0.0],
     )
 
     LastSettPnlAmt: float = Field(
         default=0.0,
-        title="Last settlement P&L amount (최종결제손익금액)",
+        title="Final settlement P&L amount (최종결제손익금액)",
         description=(
-            "P&L from the last daily settlement. "
-            "Currency and decimal scale not declared in available source."
+            "Final settlement P&L amount as reported by LS. "
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[500.0, -200.0, 0.0],
     )
@@ -299,7 +305,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas option settlement amount (해외옵션결제금액)",
         description=(
             "Settlement amount for overseas options. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[0.0, 250.0],
     )
@@ -309,7 +315,7 @@ class CIDBQ03000OutBlock2(BaseModel):
         title="Overseas option balance evaluation amount (해외옵션잔고평가금액)",
         description=(
             "Evaluated balance amount for overseas option positions. "
-            "Currency and decimal scale not declared in available source."
+            "LS numeric length/scale 19.2 (two decimal places). Currency target: CrcyObjCode."
         ),
         examples=[0.0, 750.0],
     )
@@ -331,7 +337,7 @@ class CIDBQ03000Response(BaseModel):
     block2: List[CIDBQ03000OutBlock2] = Field(
         default_factory=list,
         title="Second output block — per-currency balance rows (두 번째 출력 블록 리스트)",
-        description="Per-currency deposit/balance detail rows.",
+        description="Deposit/balance rows, including aggregate currency targets when returned.",
     )
     status_code: Optional[int] = Field(
         None,
@@ -341,7 +347,7 @@ class CIDBQ03000Response(BaseModel):
     rsp_cd: str = Field(
         ...,
         title="LS response code (응답코드)",
-        description="LS response code. '00000' indicates success.",
+        description="LS response code, preserved verbatim. The supplied completed-query example uses '00136'.",
     )
     rsp_msg: str = Field(
         ...,

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/extension/calculator.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/extension/calculator.py
@@ -9,7 +9,7 @@ from decimal import Decimal, ROUND_HALF_UP
 from typing import Optional
 
 from .symbol_spec_manager import SymbolSpecManager, SymbolSpec
-from .models import FuturesTradeInput, FuturesPnLResult
+from .models import FuturesTradeInput, FuturesPnLResult, FuturesNativePnLResult
 
 # ===== 상수 정의 =====
 DEFAULT_EXCHANGE_RATE = Decimal("1400")  # 기본 환율 (원/달러)
@@ -61,6 +61,13 @@ def calculate_futures_pnl(
     Returns:
         FuturesPnLResult: 손익 계산 결과
     """
+    # This legacy API names its values USD. Never apply native non-USD tick
+    # money to USD fees or the USD/KRW rate without an explicit conversion.
+    if spec is not None and spec.currency.strip().upper() != "USD":
+        raise ValueError("usd_estimator_requires_usd_spec")
+    if trade.manual_tick_size is not None or trade.manual_tick_value is not None:
+        if trade.manual_currency.strip().upper() != "USD":
+            raise ValueError("usd_estimator_requires_usd_manual_values")
     safety_margin_applied = False
     
     # 1. Tick Size/Value 결정
@@ -77,6 +84,9 @@ def calculate_futures_pnl(
             f"Symbol spec not provided and manual_tick_size/manual_tick_value not set. "
             f"Provide either spec or manual values."
         )
+
+    if not tick_size.is_finite() or tick_size <= 0 or not tick_value.is_finite() or tick_value <= 0:
+        raise ValueError("missing_or_invalid_tick_metadata")
     
     # 2. 환율 결정
     exchange_rate = trade.exchange_rate
@@ -136,6 +146,44 @@ def calculate_futures_pnl(
         tick_value_used=tick_value,
         exchange_rate_used=exchange_rate,
         is_safety_margin_applied=safety_margin_applied
+    )
+
+
+def calculate_native_gross_pnl(
+    *,
+    spec: SymbolSpec,
+    quantity: int,
+    entry_price: Decimal,
+    current_price: Decimal,
+    is_long: bool = True,
+) -> FuturesNativePnLResult:
+    """Estimate gross linear tick-value price movement in contract currency.
+
+    This is not the broker's accounting valuation, net PnL, equity return or
+    settlement result. No fee, tax, FX or margin assumption is applied.
+    """
+    currency = spec.currency.strip().upper()
+    if len(currency) != 3 or not currency.isalpha():
+        raise ValueError("missing_or_invalid_spec_currency")
+    tick_size = Decimal(str(spec.tick_size))
+    tick_value = Decimal(str(spec.tick_value))
+    if not tick_size.is_finite() or tick_size <= 0 or not tick_value.is_finite() or tick_value <= 0:
+        raise ValueError("missing_or_invalid_tick_metadata")
+    if isinstance(quantity, bool) or not isinstance(quantity, int) or quantity < 0:
+        raise ValueError("invalid_quantity")
+    entry = Decimal(str(entry_price))
+    current = Decimal(str(current_price))
+    if not entry.is_finite() or not current.is_finite():
+        raise ValueError("invalid_position_price")
+    ticks = (current - entry) / tick_size
+    if not is_long:
+        ticks = -ticks
+    return FuturesNativePnLResult(
+        amount=ticks * tick_value * quantity,
+        currency=currency,
+        total_ticks=ticks,
+        tick_size_used=tick_size,
+        tick_value_used=tick_value,
     )
 
 

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/extension/execution_history.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/extension/execution_history.py
@@ -1,0 +1,175 @@
+"""Parse local CIDBQ02400 execution evidence without inferring accounting.
+
+The returned wall time has no implicit timezone. Callers must establish the
+broker timezone before converting it to an instant. Order date, execution date
+and execution wall time remain independent broker fields. This module neither
+establishes complete query coverage nor calculates monetary PnL.
+"""
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+import re
+from typing import Any, Iterable, Mapping
+
+
+SOURCE_TR = "CIDBQ02400"
+EVIDENCE_FIELDS = (
+    "FutsOrdStatCode", "TrxStatCode", "TrxStatCodeNm", "TrdTpNm", "TpCodeNm",
+    "MdaCode", "ExecDt", "ExecDttm",
+)
+
+
+@dataclass(frozen=True)
+class FuturesExecutionObservation:
+    broker_order_no: str
+    broker_order_date: date
+    broker_execution_no: str
+    broker_execution_date: date
+    execution_datetime_raw: str
+    execution_wall_time: datetime
+    symbol: str
+    side: str
+    quantity: Decimal
+    price: Decimal
+    evidence: Mapping[str, Any]
+    source_tr: str = SOURCE_TR
+    source_status: str | None = None
+
+
+@dataclass(frozen=True)
+class FuturesExecutionIssue:
+    reason: str
+    broker_order_no: str | None
+    broker_order_date: date | None
+    broker_execution_no: str | None
+    evidence: Mapping[str, Any]
+    source_tr: str = SOURCE_TR
+
+
+@dataclass(frozen=True)
+class ParsedFuturesExecutions:
+    executions: tuple[FuturesExecutionObservation, ...]
+    issues: tuple[FuturesExecutionIssue, ...]
+
+
+def normalize_broker_identity(value: Any) -> str | None:
+    if isinstance(value, bool) or not isinstance(value, (str, int)):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.isascii() and text.isdecimal():
+        return text.lstrip("0") or None
+    if re.fullmatch(r"[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?", text):
+        return None
+    # Preserve opaque broker strings and their case; never substitute an
+    # exchange execution number or any other identifier namespace.
+    return text
+
+
+def _date(value: Any) -> date | None:
+    if not isinstance(value, str) or len(value) != 8 or not value.isascii() or not value.isdecimal():
+        return None
+    try:
+        return datetime.strptime(value, "%Y%m%d").date()
+    except ValueError:
+        return None
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        amount = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return amount if amount.is_finite() else None
+
+
+def _wall_time(value: Any) -> datetime | None:
+    if not isinstance(value, str) or len(value) != 17 or not value.isascii() or not value.isdecimal():
+        return None
+    try:
+        result = datetime.strptime(value, "%Y%m%d%H%M%S%f")
+        return result if result.strftime("%Y%m%d%H%M%S%f")[:17] == value else None
+    except ValueError:
+        return None
+
+
+def parse_futures_execution_history(rows: Iterable[Any]) -> ParsedFuturesExecutions:
+    """Preserve positive execution facts and report unusable/correction rows.
+
+    Pydantic defaults do not establish that the broker supplied a field.
+    Output status 1 or 4 is not used as a universal execution filter; identity,
+    quantity and explicit execution fields supply the evidence. Ordinary zero
+    quantity rows are ignored. Cancellation labels remain issues even when their
+    quantity is zero. No subtraction, deletion, source alias or fill ID is guessed.
+    """
+    executions: list[FuturesExecutionObservation] = []
+    issues: list[FuturesExecutionIssue] = []
+    for item in rows:
+        if hasattr(item, "model_dump"):
+            row = item.model_dump(exclude_unset=True)
+        elif isinstance(item, Mapping):
+            row = dict(item)
+        else:
+            raise TypeError("History rows must be response models or mappings")
+
+        order_no = normalize_broker_identity(row.get("OvrsFutsOrdNo"))
+        order_date = _date(row.get("OrdDt"))
+        execution_no = normalize_broker_identity(row.get("OvrsFutsExecNo"))
+        evidence = {key: row[key] for key in EVIDENCE_FIELDS if key in row}
+
+        def issue(reason: str) -> None:
+            issues.append(FuturesExecutionIssue(reason, order_no, order_date, execution_no, evidence))
+
+        transaction_label = str(row.get("TrxStatCodeNm") or "").strip()
+        if transaction_label == "체결취소":
+            issue("execution_cancellation_effect_unverified")
+            continue
+        quantity = _decimal(row.get("ExecQty"))
+        if quantity == 0:
+            continue
+        if quantity is None or quantity < 0 or quantity != quantity.to_integral_value():
+            issue("missing_or_invalid_execution_quantity")
+            continue
+        if transaction_label not in ("", "체결"):
+            issue("execution_transaction_label_unverified")
+            continue
+        if order_no is None or order_date is None:
+            issue("missing_or_invalid_broker_order_identity")
+            continue
+        if execution_no is None:
+            issue("missing_or_invalid_broker_execution_number")
+            continue
+        execution_date = _date(row.get("ExecDt"))
+        if execution_date is None:
+            issue("missing_or_invalid_broker_execution_date")
+            continue
+        raw_time = row.get("ExecDttm")
+        wall_time = _wall_time(raw_time)
+        if wall_time is None:
+            issue("missing_or_invalid_execution_datetime")
+            continue
+        side = {"1": "sell", "2": "buy"}.get(str(row.get("ExecBnsTpCode") or "").strip())
+        if side is None:
+            issue("missing_or_invalid_execution_side")
+            continue
+        symbol = row.get("OvrsDrvtExecIsuCode")
+        if not isinstance(symbol, str) or not symbol.strip():
+            issue("missing_execution_symbol")
+            continue
+        price = _decimal(row.get("AbrdFutsExecPrc"))
+        if price is None:
+            issue("missing_or_invalid_execution_price")
+            continue
+        executions.append(FuturesExecutionObservation(
+            broker_order_no=order_no, broker_order_date=order_date,
+            broker_execution_no=execution_no, broker_execution_date=execution_date,
+            execution_datetime_raw=raw_time, execution_wall_time=wall_time,
+            symbol=symbol.strip(), side=side, quantity=quantity, price=price,
+            evidence=evidence,
+            source_status=str(row["FutsOrdStatCode"]) if row.get("FutsOrdStatCode") is not None else None,
+        ))
+    return ParsedFuturesExecutions(tuple(executions), tuple(issues))

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/extension/models.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/extension/models.py
@@ -5,7 +5,7 @@
 """
 
 from decimal import Decimal
-from typing import Optional
+from typing import Dict, Literal, Optional
 from datetime import datetime
 from pydantic import BaseModel, Field
 
@@ -36,6 +36,8 @@ class FuturesTradeInput(BaseModel):
     
     manual_tick_value: Optional[Decimal] = Field(default=None, description="직접 입력 Tick Value")
     """직접 입력 Tick Value"""
+
+    manual_currency: str = Field(default="USD", description="Currency of manual tick values in the legacy USD estimator.")
     
     exchange_rate: Optional[Decimal] = Field(default=None, description="환율 (None이면 기본값 사용)")
     """환율 (None이면 기본값 사용)"""
@@ -81,6 +83,21 @@ class FuturesPnLResult(BaseModel):
     """안전마진 적용 여부"""
 
 
+NativePnLBasis = Literal["estimated_gross_price_change"]
+PnLAvailability = Literal["available", "unavailable"]
+
+
+class FuturesNativePnLResult(BaseModel):
+    """Native-currency gross price-change estimate; excludes fees, tax and FX."""
+
+    amount: Decimal
+    currency: str
+    basis: NativePnLBasis = "estimated_gross_price_change"
+    total_ticks: Decimal
+    tick_size_used: Decimal
+    tick_value_used: Decimal
+
+
 class FuturesPositionItem(BaseModel):
     """해외선물 보유종목(미결제약정) 모델"""
     
@@ -102,10 +119,15 @@ class FuturesPositionItem(BaseModel):
     current_price: Decimal = Field(default=Decimal("0"), description="현재가")
     """현재가"""
     
-    pnl_amount: Decimal = Field(default=Decimal("0"), description="평가손익 ($)")
-    """평가손익 ($)"""
+    pnl_amount: Optional[Decimal] = Field(default=None, description="Native gross price-change estimate; see pnl_currency, pnl_basis and pnl_status.")
+    pnl_currency: Optional[str] = None
+    pnl_basis: Optional[NativePnLBasis] = None
+    pnl_status: PnLAvailability = "unavailable"
+    pnl_unavailable_reason: Optional[str] = None
+    broker_pnl_amount: Optional[Decimal] = Field(default=None, description="Unmodified broker-reported amount; its monetary unit and cost basis remain unconfirmed.")
+    broker_pnl_basis: Literal["broker_reported_unconfirmed"] = "broker_reported_unconfirmed"
     
-    pnl_rate: Decimal = Field(default=Decimal("0"), description="손익률 (%)")
+    pnl_rate: Decimal = Field(default=Decimal("0"), description="Nominal quoted-price change (%), not account-equity return.")
     """손익률 (%)"""
     
     opening_margin: Decimal = Field(default=Decimal("0"), description="개시증거금")
@@ -117,7 +139,7 @@ class FuturesPositionItem(BaseModel):
     margin_call_rate: Decimal = Field(default=Decimal("0"), description="마진콜율")
     """마진콜율"""
     
-    currency: str = Field(default="USD", description="통화")
+    currency: str = Field(default="", description="Observed position currency code; not proof of the broker PnL amount's unit.")
     """통화"""
     
     exchange_code: str = Field(default="", description="거래소코드")
@@ -126,9 +148,9 @@ class FuturesPositionItem(BaseModel):
     last_updated: Optional[datetime] = Field(default=None, description="마지막 업데이트 시간")
     """마지막 업데이트 시간"""
     
-    # 실시간 계산된 손익 (수수료 반영)
-    realtime_pnl: Optional[FuturesPnLResult] = Field(default=None, description="실시간 손익 (수수료 반영)")
-    """실시간 손익 (수수료 반영)"""
+    # Retained for legacy consumers; the account tracker no longer fills this
+    # standalone USD estimator slot with a value in an unverified native unit.
+    realtime_pnl: Optional[FuturesPnLResult] = Field(default=None, description="Legacy USD estimator result; not populated by native account tracking.")
 
 
 class FuturesBalanceInfo(BaseModel):
@@ -205,26 +227,41 @@ class FuturesOpenOrder(BaseModel):
     """마지막 업데이트 시간"""
 
 
+class FuturesCurrencyPnL(BaseModel):
+    """Subtotal of available compatible estimates, not an equity valuation."""
+
+    currency: str
+    basis: NativePnLBasis = "estimated_gross_price_change"
+    total_pnl_amount: Decimal
+    position_count: int
+
+
 class AccountPnLInfo(BaseModel):
-    """계좌 전체 수익률 정보 모델"""
+    """Compatible native estimates and availability, not account accounting."""
     
-    account_pnl_rate: Decimal = Field(default=Decimal("0"), description="계좌 총 수익률 (%)")
+    account_pnl_rate: Optional[Decimal] = Field(default=None, description="Unavailable without a confirmed account-return denominator.")
     """계좌 총 수익률 (%)"""
     
-    total_eval_amount: Decimal = Field(default=Decimal("0"), description="총 평가금액")
+    total_eval_amount: Optional[Decimal] = Field(default=None, description="Unavailable without a confirmed valuation and currency basis.")
     """총 평가금액"""
     
-    total_margin_used: Decimal = Field(default=Decimal("0"), description="총 사용 증거금")
+    total_margin_used: Optional[Decimal] = Field(default=None, description="Unavailable without confirmed margin units; raw position margins are retained separately.")
     """총 사용 증거금"""
     
-    total_pnl_amount: Decimal = Field(default=Decimal("0"), description="총 평가손익")
+    total_pnl_amount: Optional[Decimal] = Field(default=None, description="Single-currency native gross subtotal, only when all positions have compatible available estimates.")
     """총 평가손익"""
     
     position_count: int = Field(default=0, description="보유 포지션 수")
     """보유 포지션 수"""
     
-    currency: str = Field(default="USD", description="통화")
+    currency: Optional[str] = None
     """통화"""
+
+    pnl_status: PnLAvailability = "unavailable"
+    pnl_basis: Optional[NativePnLBasis] = None
+    pnl_unavailable_reason: Optional[str] = None
+    pnl_by_currency: Dict[str, FuturesCurrencyPnL] = Field(default_factory=dict)
+    unavailable_position_count: int = 0
     
     last_updated: Optional[datetime] = Field(default=None, description="마지막 업데이트 시간")
     """마지막 업데이트 시간"""

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/extension/symbol_spec_manager.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/extension/symbol_spec_manager.py
@@ -105,9 +105,11 @@ class SymbolSpecManager:
                             symbol=item.Symbol,
                             symbol_name=item.SymbolNm,
                             exchange_code=item.ExchCd,
-                            tick_size=Decimal(str(item.UntPrc)) if item.UntPrc else Decimal("0.01"),
-                            tick_value=Decimal(str(item.MnChgAmt)) if item.MnChgAmt else Decimal("1"),
-                            currency=item.CrncyCd or "USD",
+                            tick_size=Decimal(str(item.UntPrc)) if item.UntPrc else Decimal("0"),
+                            tick_value=Decimal(str(item.MnChgAmt)) if item.MnChgAmt else Decimal("0"),
+                            # Keep missing broker metadata unknown. The public
+                            # SymbolSpec default remains USD for legacy manual specs.
+                            currency=item.CrncyCd or "",
                             contract_amount=Decimal(str(item.CtrtPrAmt)) if item.CtrtPrAmt else Decimal("0"),
                             opening_margin=Decimal(str(item.OpngMgn)) if item.OpngMgn else Decimal("0"),
                             maintenance_margin=Decimal(str(item.MntncMgn)) if item.MntncMgn else Decimal("0"),

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/extension/tracker.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/extension/tracker.py
@@ -21,11 +21,13 @@ from .models import (
     FuturesBalanceInfo,
     FuturesOpenOrder,
     AccountPnLInfo,
+    FuturesCurrencyPnL,
 )
 from .calculator import (
     FuturesPnLCalculator,
     DEFAULT_FEE_PER_CONTRACT,
     compute_futures_pnl_rate,
+    calculate_native_gross_pnl,
 )
 from .symbol_spec_manager import SymbolSpecManager, SymbolSpec
 from .subscription_manager import SubscriptionManager
@@ -49,6 +51,25 @@ def is_no_data_response(rsp_cd: str, rsp_msg: str) -> bool:
         return False
     msg_lower = (rsp_msg or "").lower()
     return any(pattern in msg_lower for pattern in NO_DATA_PATTERNS)
+
+
+def _response_field_present(item, name: str) -> bool:
+    """A Pydantic default is not evidence that the broker supplied the field."""
+    fields = getattr(item, "model_fields_set", None)
+    return name in fields if fields is not None else hasattr(item, name)
+
+
+def _reported_decimal(item, name: str) -> Optional[Decimal]:
+    if not _response_field_present(item, name):
+        return None
+    value = getattr(item, name, None)
+    if value is None or value == "":
+        return None
+    try:
+        amount = Decimal(str(value))
+        return amount if amount.is_finite() else None
+    except (ArithmeticError, TypeError, ValueError):
+        return None
 
 
 class FuturesAccountTracker:
@@ -98,6 +119,7 @@ class FuturesAccountTracker:
         
         # 데이터 캐시
         self._positions: Dict[str, FuturesPositionItem] = {}
+        self._position_evidence_errors: Dict[str, str] = {}
         self._balance: Optional[FuturesBalanceInfo] = None
         self._open_orders: Dict[str, FuturesOpenOrder] = {}
         self._current_prices: Dict[str, Decimal] = {}
@@ -214,6 +236,7 @@ class FuturesAccountTracker:
             if is_no_data_response(rsp_cd, rsp_msg):
                 logger.info(f"[_fetch_positions] 보유 포지션 없음 (rsp_cd={rsp_cd}, msg={rsp_msg})")
                 self._positions.clear()
+                self._position_evidence_errors.clear()
                 self._notify_position_change()
                 self._last_errors.pop("positions", None)
                 return
@@ -246,13 +269,14 @@ class FuturesAccountTracker:
             now = datetime.now()
             old_symbols = set(self._positions.keys())
             self._positions.clear()
+            self._position_evidence_errors.clear()
             
             # block2에 보유포지션 데이터가 있음
             if hasattr(resp, 'block2') and resp.block2:
                 for item in resp.block2:
                     symbol = getattr(item, 'IsuCodeVal', '')
                     is_long = getattr(item, 'BnsTpCode', '2') == '2'  # 2: 매수
-                    currency = getattr(item, 'CrcyCodeVal', 'USD')
+                    currency = str(getattr(item, 'CrcyCodeVal', '') or '').strip()
                     
                     # SymbolSpecManager에서 거래소 코드 조회
                     spec = self._spec_manager.get_spec(symbol)
@@ -268,7 +292,7 @@ class FuturesAccountTracker:
                         quantity=int(getattr(item, 'BalQty', 0)),
                         entry_price=Decimal(str(getattr(item, 'PchsPrc', 0))),
                         current_price=Decimal(str(getattr(item, 'OvrsDrvtNowPrc', 0))),
-                        pnl_amount=Decimal(str(getattr(item, 'AbrdFutsEvalPnlAmt', 0))),
+                        broker_pnl_amount=_reported_decimal(item, 'AbrdFutsEvalPnlAmt'),
                         opening_margin=Decimal(str(getattr(item, 'CsgnMgn', 0))),
                         maintenance_margin=Decimal(str(getattr(item, 'MaintMgn', 0))),
                         margin_call_rate=Decimal(str(getattr(item, 'MgnclRat', 0))),
@@ -278,6 +302,19 @@ class FuturesAccountTracker:
                     
                     # 현재가 저장
                     self._current_prices[symbol] = position.current_price
+                    for field_name, reason in (
+                        ("PchsPrc", "missing_position_entry_price"),
+                        ("BalQty", "missing_position_quantity"),
+                        ("BnsTpCode", "missing_position_side"),
+                    ):
+                        if not _response_field_present(item, field_name):
+                            self._position_evidence_errors[symbol] = reason
+                            break
+                    if (symbol not in self._position_evidence_errors
+                            and getattr(item, "BnsTpCode", None) not in ("1", "2")):
+                        self._position_evidence_errors[symbol] = "invalid_position_side"
+                    self._update_native_pnl(position,
+                        current_price_available=_response_field_present(item, "OvrsDrvtNowPrc"))
                     
                     # 손익률 계산 (REST/실시간 공용 공식). 헬퍼는 float 반환이므로
                     # Decimal 필드 유지를 위해 Decimal 로 감싼다.
@@ -570,25 +607,10 @@ class FuturesAccountTracker:
                 pos.current_price = price
                 pos.last_updated = datetime.now()
                 
-                # 실시간 손익 계산
-                try:
-                    pnl = self._calculator.calculate_realtime_pnl(
-                        symbol=symbol,
-                        quantity=pos.quantity,
-                        entry_price=pos.entry_price,
-                        current_price=price,
-                        is_long=pos.is_long,
-                        custom_fee_usd=self._commission_rate
-                    )
-                    pos.realtime_pnl = pnl
-                    pos.pnl_amount = pnl.net_pl_usd
-
-                    # 손익률 계산 (REST/실시간 공용 공식). float 반환 → Decimal 유지.
-                    pos.pnl_rate = Decimal(str(compute_futures_pnl_rate(
-                        pos.entry_price, price, pos.is_long
-                    )))
-                except Exception:
-                    pass
+                self._update_native_pnl(pos)
+                pos.pnl_rate = Decimal(str(compute_futures_pnl_rate(
+                    pos.entry_price, price, pos.is_long
+                )))
                 
                 self._notify_position_change()
                 
@@ -642,33 +664,82 @@ class FuturesAccountTracker:
             callback: AccountPnLInfo를 인자로 받는 콜백 함수
         
         Example:
-            tracker.on_account_pnl_change(lambda pnl: print(f"계좌 수익률: {pnl.account_pnl_rate:.2f}%"))
+            tracker.on_account_pnl_change(lambda pnl: print(pnl.pnl_status, pnl.pnl_by_currency))
         """
         self._on_account_pnl_change_callbacks.append(callback)
     
     # ===== 계좌 수익률 계산 =====
+    def _update_native_pnl(self, pos: FuturesPositionItem, *, current_price_available: bool = True) -> None:
+        """Use one gross-estimate basis for REST and ticks; retain broker raw PnL."""
+        pos.pnl_amount = None
+        pos.pnl_currency = None
+        pos.pnl_basis = None
+        pos.pnl_status = "unavailable"
+        pos.pnl_unavailable_reason = None
+        # Legacy fee-adjusted USD estimates must not masquerade as broker PnL.
+        pos.realtime_pnl = None
+        try:
+            spec = self._spec_manager.get_spec(pos.symbol)
+            if spec is None:
+                raise ValueError("missing_symbol_spec")
+            if not pos.currency:
+                raise ValueError("missing_position_currency")
+            if spec.currency.strip().upper() != pos.currency.strip().upper():
+                raise ValueError("position_spec_currency_mismatch")
+            evidence_error = self._position_evidence_errors.get(pos.symbol)
+            if evidence_error:
+                raise ValueError(evidence_error)
+            if not current_price_available:
+                raise ValueError("missing_position_current_price")
+            pnl = calculate_native_gross_pnl(spec=spec, quantity=pos.quantity,
+                entry_price=pos.entry_price, current_price=pos.current_price, is_long=pos.is_long)
+            pos.pnl_amount = pnl.amount
+            pos.pnl_currency = pnl.currency
+            pos.pnl_basis = pnl.basis
+            pos.pnl_status = "available"
+        except (ArithmeticError, TypeError, ValueError) as exc:
+            pos.pnl_unavailable_reason = str(exc)
+
     def _calculate_account_pnl(self) -> AccountPnLInfo:
-        """전체 계좌 수익률 계산 (총 평가손익 / 총 사용증거금)"""
-        total_margin = Decimal("0")
-        total_pnl = Decimal("0")
-        
+        """Aggregate compatible native gross estimates; never mix currencies."""
+        grouped: Dict[str, FuturesCurrencyPnL] = {}
+        unavailable = 0
+        incompatible_basis = False
         for pos in self._positions.values():
-            total_margin += pos.opening_margin
-            total_pnl += pos.pnl_amount
-        
-        # 평가금액 = 사용증거금 + 평가손익
-        total_eval = total_margin + total_pnl
-        
-        # 수익률 = (평가손익 / 사용증거금) * 100
-        pnl_rate = (total_pnl / total_margin * 100) if total_margin > 0 else Decimal("0")
-        
+            if (pos.pnl_status != "available" or pos.pnl_amount is None
+                    or not pos.pnl_amount.is_finite() or not pos.pnl_currency
+                    or not pos.currency or pos.pnl_currency != pos.currency.strip().upper()
+                    or pos.pnl_basis != "estimated_gross_price_change"):
+                unavailable += 1
+                incompatible_basis |= pos.pnl_basis not in (None, "estimated_gross_price_change")
+                continue
+            currency = pos.pnl_currency
+            if currency not in grouped:
+                grouped[currency] = FuturesCurrencyPnL(currency=currency,
+                    total_pnl_amount=Decimal("0"), position_count=0)
+            grouped[currency].total_pnl_amount += pos.pnl_amount
+            grouped[currency].position_count += 1
+
+        reason = None
+        if not self._positions:
+            reason = "no_positions"
+        elif incompatible_basis:
+            reason = "incompatible_monetary_basis"
+        elif unavailable:
+            reason = "unavailable_positions"
+        elif len(grouped) != 1:
+            reason = "mixed_currencies"
+        available = reason is None
+        only = next(iter(grouped.values())) if available else None
         return AccountPnLInfo(
-            account_pnl_rate=pnl_rate,
-            total_eval_amount=total_eval,
-            total_margin_used=total_margin,
-            total_pnl_amount=total_pnl,
+            total_pnl_amount=only.total_pnl_amount if only else None,
             position_count=len(self._positions),
-            currency="USD",
+            currency=only.currency if only else None,
+            pnl_status="available" if available else "unavailable",
+            pnl_basis="estimated_gross_price_change" if available else None,
+            pnl_unavailable_reason=reason,
+            pnl_by_currency=grouped,
+            unavailable_position_count=unavailable,
             last_updated=datetime.now(),
         )
     

--- a/src/finance/programgarden_finance/ls/overseas_stock/extension/tracker.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/extension/tracker.py
@@ -312,45 +312,42 @@ class StockAccountTracker:
                     OrdDt=dt.now().strftime("%Y%m%d"),
                     ExecYn="2",       # 2: 미체결
                     CrcyCode="000",   # 전체
-                    ThdayBnsAppYn="0",
+                    ThdayBnsAppYn="1",
                     LoanBalHldYn="0"
                 ),
             )
             resp = await tr.req_async()
             
-            # 응답 코드 확인
-            rsp_cd = getattr(resp, 'rsp_cd', '')
-            rsp_msg = getattr(resp, 'rsp_msg', '')
-
-            # 전송/파싱 실패 → fail-closed: 기존 상태를 지우지 않고 에러로 남긴다.
-            # (GenericTR fallback 은 rsp_cd="" 인 빈 응답을 주므로, 이 가드가 없으면
-            #  아래 분기를 전부 통과해 "데이터 0건" 이라는 조용한 오답이 된다 —
-            #  prod 2026-08-24 소수점 잔고 파싱 실패에서 실측된 경로)
-            resp_error = getattr(resp, 'error_msg', None)
-            if resp_error:
-                error_msg = f"[미체결 조회 실패] error_msg={resp_error}"
+            rsp_cd = getattr(resp, "rsp_cd", "")
+            rsp_msg = getattr(resp, "rsp_msg", "")
+            resp_error = getattr(resp, "error_msg", None)
+            status = getattr(resp, "status_code", None)
+            rows = getattr(resp, "block3", None) or []
+            # A missing detail block defaults to [] in the SDK. Only a success
+            # envelope with echo and aggregate blocks proves an empty result.
+            valid_empty = (
+                not rows and rsp_cd == "00000"
+                and getattr(resp, "block1", None) is not None
+                and getattr(resp, "block2", None) is not None
+            )
+            if (
+                resp is None or resp_error
+                or (status is not None and status >= 400)
+                or rsp_cd not in SUCCESS_CODES
+                or (not rows and not valid_empty)
+                or any(not item.OrdNo or item.OrdNo <= 0 for item in rows)
+            ):
+                error_msg = (
+                    "COSAQ00102 returned no usable pending-order response: "
+                    f"status_code={status}, rsp_cd={rsp_cd}, rsp_msg={rsp_msg}, "
+                    f"error_msg={resp_error}"
+                )
                 self._last_errors["open_orders"] = error_msg
-                logger.error(f"[_fetch_open_orders] {error_msg}")
+                logger.error("[_fetch_open_orders] %s", error_msg)
                 return
 
-            # "데이터 없음" 응답 → 정상 케이스 (빈 데이터)
-            if is_no_data_response(rsp_cd, rsp_msg):
-                logger.info(f"[_fetch_open_orders] 미체결 주문 없음 (rsp_cd={rsp_cd}, msg={rsp_msg})")
-                self._open_orders.clear()
-                self._notify_open_orders_change()
-                self._last_errors.pop("open_orders", None)
-                return
-            
-            # 성공이 아닌 다른 응답 → 에러
-            if rsp_cd and rsp_cd not in SUCCESS_CODES:
-                error_msg = f"[미체결 조회 실패] rsp_cd={rsp_cd}, msg={rsp_msg}"
-                self._last_errors["open_orders"] = error_msg
-                logger.error(f"[_fetch_open_orders] {error_msg}")
-                return
-            
-            # block 데이터 처리 (block이 비어있으면 미체결 없음 = 정상 케이스)
             now = datetime.now()
-            self._open_orders.clear()
+            open_orders = {}
             
             # 🔴 미체결 행은 block3 다 — 종전 코드는 block1(입력 에코, 단일 모델)을
             # 순회해 (필드명, 값) 튜플에 getattr 기본값만 얻었고, 그 결과
@@ -373,10 +370,11 @@ class StockAccountTracker:
                         currency_code=getattr(item, 'CrcyCode', '') or 'USD',
                         last_updated=now
                     )
-                    self._open_orders[order.order_no] = order
+                    open_orders[order.order_no] = order
             else:
                 logger.info("[_fetch_open_orders] 미체결 주문 없음")
             
+            self._open_orders = open_orders
             self._notify_open_orders_change()
             
             # 성공 시 에러 상태 클리어

--- a/src/finance/pyproject.toml
+++ b/src/finance/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-finance"
-version = "1.9.3"
+version = "1.9.4"
 license = "AGPL-3.0-or-later"
 description = "프로그램 동산 운영진이 관리하는 증권사 데이터 오픈소스"
 readme = "README.md"

--- a/src/finance/tests/test_futures_execution_history.py
+++ b/src/finance/tests/test_futures_execution_history.py
@@ -1,0 +1,146 @@
+"""Canonical local execution evidence uses supplied broker fields, offline."""
+
+from datetime import date, datetime
+from decimal import Decimal
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+from programgarden_finance.ls.overseas_futureoption.accno.CIDBQ02400.blocks import CIDBQ02400OutBlock2
+from programgarden_finance.ls.overseas_futureoption.accno.CIDBQ02400 import TrCIDBQ02400
+from programgarden_finance.ls.overseas_futureoption.extension.execution_history import parse_futures_execution_history
+
+
+@pytest.fixture(autouse=True)
+def deny_network(monkeypatch):
+    def denied(*args, **kwargs):
+        raise AssertionError("Execution parsing tests must remain offline")
+
+    for name in ("connect", "connect_ex", "sendto"):
+        monkeypatch.setattr(socket.socket, name, denied)
+
+
+def row(**changes):
+    return dict(
+        OrdDt="20260909", OvrsFutsOrdNo="0000000123",
+        ExecDt="20260909", OvrsFutsExecNo="0000000456",
+        ExecDttm="20260910001500123", OvrsDrvtExecIsuCode="SYNTHETIC",
+        ExecBnsTpCode="2", ExecQty=1, AbrdFutsExecPrc="100.25",
+        FutsOrdStatCode="1", TrxStatCodeNm="체결", TrdTpNm="매수", MdaCode="41",
+    ) | changes
+
+
+def test_actual_model_preserves_independent_dates_id_and_milliseconds():
+    result = parse_futures_execution_history([CIDBQ02400OutBlock2(**row())])
+    assert not result.issues
+    execution, = result.executions
+    assert execution.broker_order_no == "123" and execution.broker_execution_no == "456"
+    assert execution.broker_order_date == date(2026, 9, 9)
+    assert execution.broker_execution_date == date(2026, 9, 9)
+    assert execution.execution_wall_time == datetime(2026, 9, 10, 0, 15, 0, 123000)
+    assert execution.execution_wall_time.tzinfo is None
+    assert execution.execution_datetime_raw == "20260910001500123"
+    assert execution.quantity == Decimal("1") and execution.price == Decimal("100.25")
+    assert execution.source_tr == "CIDBQ02400" and execution.source_status == "1"
+
+
+def test_actual_sdk_response_builder_preserves_presence_before_canonical_parser():
+    missing_price = row()
+    missing_price.pop("AbrdFutsExecPrc")
+    response = TrCIDBQ02400._build_response(None, SimpleNamespace(status=200), {
+        "rsp_cd": "00136", "rsp_msg": "Synthetic fixture",
+        "CIDBQ02400OutBlock2": [row(), missing_price],
+    }, {}, None)
+    result = parse_futures_execution_history(response.block2)
+    assert len(result.executions) == 1
+    assert result.executions[0].execution_wall_time.microsecond == 123000
+    assert result.issues[0].reason == "missing_or_invalid_execution_price"
+
+
+def test_opaque_broker_identifier_case_is_preserved_without_exchange_fallback():
+    result = parse_futures_execution_history([row(OvrsFutsExecNo=" LS-AbC ", FcmOrdNo="999")])
+    assert result.executions[0].broker_execution_no == "LS-AbC"
+    result = parse_futures_execution_history([row(OvrsFutsExecNo="", FcmOrdNo="999")])
+    assert not result.executions
+    assert result.issues[0].reason == "missing_or_invalid_broker_execution_number"
+
+
+@pytest.mark.parametrize("status", ["1", "4", "2", ""])
+@pytest.mark.parametrize("side,expected", [("1", "sell"), ("2", "buy")])
+def test_side_is_explicit_and_status_is_preserved_without_universal_filter(status, side, expected):
+    result = parse_futures_execution_history([row(FutsOrdStatCode=status, ExecBnsTpCode=side)])
+    assert not result.issues
+    assert result.executions[0].side == expected
+    assert result.executions[0].source_status == status
+
+
+@pytest.mark.parametrize("quantity", [0, 1])
+def test_cancellation_is_an_issue_without_deleting_or_netting_execution(quantity):
+    result = parse_futures_execution_history([row(), row(ExecQty=quantity, TrxStatCodeNm="체결취소")])
+    assert len(result.executions) == 1
+    assert len(result.issues) == 1
+    assert result.issues[0].reason == "execution_cancellation_effect_unverified"
+    assert result.issues[0].broker_order_no == "123"
+    assert result.issues[0].evidence["TrxStatCodeNm"] == "체결취소"
+
+
+@pytest.mark.parametrize("field,reason", [
+    ("OrdDt", "missing_or_invalid_broker_order_identity"),
+    ("OvrsFutsOrdNo", "missing_or_invalid_broker_order_identity"),
+    ("OvrsFutsExecNo", "missing_or_invalid_broker_execution_number"),
+    ("ExecDt", "missing_or_invalid_broker_execution_date"),
+    ("ExecDttm", "missing_or_invalid_execution_datetime"),
+    ("ExecBnsTpCode", "missing_or_invalid_execution_side"),
+    ("OvrsDrvtExecIsuCode", "missing_execution_symbol"),
+    ("AbrdFutsExecPrc", "missing_or_invalid_execution_price"),
+    ("ExecQty", "missing_or_invalid_execution_quantity"),
+])
+def test_response_model_defaults_cannot_supply_missing_execution_facts(field, reason):
+    values = row()
+    values.pop(field)
+    result = parse_futures_execution_history([CIDBQ02400OutBlock2(**values)])
+    assert not result.executions
+    assert result.issues[0].reason == reason
+
+
+@pytest.mark.parametrize("field,value,reason", [
+    ("ExecBnsTpCode", "9", "missing_or_invalid_execution_side"),
+    ("ExecQty", -1, "missing_or_invalid_execution_quantity"),
+    ("ExecQty", "0.5", "missing_or_invalid_execution_quantity"),
+    ("ExecQty", "NaN", "missing_or_invalid_execution_quantity"),
+    ("ExecQty", True, "missing_or_invalid_execution_quantity"),
+    ("AbrdFutsExecPrc", "Infinity", "missing_or_invalid_execution_price"),
+    ("OvrsFutsExecNo", "0000", "missing_or_invalid_broker_execution_number"),
+    ("OvrsFutsExecNo", "123.0", "missing_or_invalid_broker_execution_number"),
+    ("ExecDt", "20260230", "missing_or_invalid_broker_execution_date"),
+    ("ExecDttm", "20260910001500", "missing_or_invalid_execution_datetime"),
+    ("ExecDttm", "20260910001500123456", "missing_or_invalid_execution_datetime"),
+    ("ExecDttm", "20260910251500123", "missing_or_invalid_execution_datetime"),
+    ("TrxStatCodeNm", "UNKNOWN", "execution_transaction_label_unverified"),
+])
+def test_invalid_evidence_stays_issue(field, value, reason):
+    result = parse_futures_execution_history([row(**{field: value})])
+    assert not result.executions and result.issues[0].reason == reason
+
+
+@pytest.mark.parametrize("price", ["0", "-37.63", "100.2500"])
+def test_explicit_zero_negative_and_decimal_quote_are_retained(price):
+    result = parse_futures_execution_history([row(AbrdFutsExecPrc=price)])
+    assert not result.issues and result.executions[0].price == Decimal(price)
+
+
+def test_unfilled_is_not_execution_and_arbitrary_payload_is_not_retained():
+    result = parse_futures_execution_history([
+        row(ExecQty=0, FutsOrdStatCode="2"),
+        row(AcntNo="SYNTHETIC_PRIVATE", Pwd="SYNTHETIC_PRIVATE", RegUserId="SYNTHETIC_PRIVATE"),
+    ])
+    assert len(result.executions) == 1 and not result.issues
+    assert not any(key in result.executions[0].evidence for key in ("AcntNo", "Pwd", "RegUserId"))
+
+
+def test_parser_does_not_invent_or_collapse_identity_for_partial_fill_arrivals():
+    result = parse_futures_execution_history([row(), row(OvrsFutsExecNo="457"), row()])
+    assert [event.broker_execution_no for event in result.executions] == ["456", "457", "456"]
+    # Durable source-scoped idempotency is the store's responsibility.
+    assert not result.issues

--- a/src/finance/tests/test_futures_pnl_currency.py
+++ b/src/finance/tests/test_futures_pnl_currency.py
@@ -1,0 +1,331 @@
+"""Offline monetary-domain regressions; all account data is synthetic."""
+from decimal import Decimal
+from types import SimpleNamespace
+import socket
+
+import pytest
+
+from programgarden_finance.ls.overseas_futureoption.accno.CIDBQ01500.blocks import CIDBQ01500OutBlock2
+from programgarden_finance.ls.overseas_futureoption.market.o3121.blocks import O3121OutBlock
+from programgarden_finance.ls.overseas_futureoption.extension.calculator import (
+    FuturesPnLCalculator, calculate_futures_pnl, calculate_native_gross_pnl,
+)
+from programgarden_finance.ls.overseas_futureoption.extension.models import FuturesTradeInput
+from programgarden_finance.ls.overseas_futureoption.extension.symbol_spec_manager import SymbolSpec, SymbolSpecManager
+from programgarden_finance.ls.overseas_futureoption.extension.tracker import FuturesAccountTracker
+
+D = Decimal
+
+
+@pytest.fixture(autouse=True)
+def deny_network(monkeypatch):
+    def denied(*args, **kwargs):
+        raise AssertionError("Offline currency tests must not access the network")
+    monkeypatch.setattr(socket.socket, "connect", denied)
+    monkeypatch.setattr(socket.socket, "connect_ex", denied)
+    monkeypatch.setattr(socket.socket, "sendto", denied)
+
+
+def spec(symbol="HMH_SYNTHETIC", currency="HKD", tick_value="10"):
+    return SymbolSpec(symbol=symbol, currency=currency, exchange_code="SYNTHETIC",
+        tick_size=D("1"), tick_value=D(tick_value), decimal_places=0)
+
+
+def position_row(symbol="HMH_SYNTHETIC", currency="HKD", entry=25000, current=25010,
+                 broker_pnl=777, quantity=1):
+    return CIDBQ01500OutBlock2(IsuCodeVal=symbol, CrcyCodeVal=currency, BnsTpCode="2",
+        PchsPrc=entry, OvrsDrvtNowPrc=current, AbrdFutsEvalPnlAmt=broker_pnl,
+        BalQty=quantity, CsgnMgn=1000)
+
+
+def tracker_for(rows, specs):
+    async def req_async():
+        return SimpleNamespace(rsp_cd="00000", rsp_msg="Synthetic fixture", block2=rows)
+    account = SimpleNamespace(CIDBQ01500=lambda **kwargs:SimpleNamespace(req_async=req_async))
+    tracker = FuturesAccountTracker(account, market_client=None)
+    tracker._spec_manager._specs = {item.symbol:item for item in specs}
+    return tracker
+
+
+def test_legacy_usd_estimator_numbers_remain_compatible():
+    trade = FuturesTradeInput(symbol="USD_SYNTHETIC", buy_price=100, sell_price=110, qty=1)
+    result = calculate_futures_pnl(trade, spec("USD_SYNTHETIC", "USD"))
+    assert result.gross_pl_usd == D("100")
+    assert result.total_fees_usd == D("15")
+    assert result.net_pl_usd == D("85")
+    assert result.net_pl_krw == D("119000")
+
+
+def test_explicit_usd_manual_estimator_remains_supported():
+    trade = FuturesTradeInput(symbol="MANUAL", buy_price=4000, sell_price=4001, qty=1,
+        manual_tick_size=D("0.25"), manual_tick_value=D("12.5"), manual_currency="USD",
+        custom_fee_usd=D("2"), exchange_rate=D("1300"))
+    result = calculate_futures_pnl(trade)
+    assert result.gross_pl_usd == D("50")
+    assert result.net_pl_usd == D("46")
+    assert result.exchange_rate_used == D("1300")
+
+
+def test_existing_manual_usd_default_is_unchanged():
+    trade = FuturesTradeInput(symbol="MANUAL", buy_price=1, sell_price=2, qty=1,
+        manual_tick_size=1, manual_tick_value=10, custom_fee_usd=0)
+    assert trade.manual_currency == "USD"
+    assert calculate_futures_pnl(trade).net_pl_usd == D("10")
+
+
+def test_realtime_standalone_usd_estimator_is_compatible_and_hkd_is_rejected():
+    manager = SymbolSpecManager(None)
+    manager._specs = {"USD_SYNTHETIC":spec("USD_SYNTHETIC", "USD"), "HMH_SYNTHETIC":spec()}
+    calculator = FuturesPnLCalculator(manager)
+    result = calculator.calculate_realtime_pnl("USD_SYNTHETIC", 1, D("100"), D("110"))
+    assert result.net_pl_usd == D("85")
+    with pytest.raises(ValueError, match="usd_estimator_requires_usd_spec"):
+        calculator.calculate_realtime_pnl("HMH_SYNTHETIC", 1, D("25000"), D("25010"))
+
+
+@pytest.mark.parametrize("currency", ["HKD", "EUR", ""])
+def test_usd_estimator_rejects_non_usd_spec(currency):
+    trade = FuturesTradeInput(symbol="HMH_SYNTHETIC", buy_price=25000, sell_price=25010, qty=1)
+    with pytest.raises(ValueError, match="usd_estimator_requires_usd_spec"):
+        calculate_futures_pnl(trade, spec(currency=currency))
+
+
+def test_usd_estimator_rejects_non_usd_manual_amounts():
+    trade = FuturesTradeInput(symbol="MANUAL", buy_price=1, sell_price=2, qty=1,
+        manual_tick_size=1, manual_tick_value=10, manual_currency="HKD")
+    with pytest.raises(ValueError, match="usd_estimator_requires_usd_manual_values"):
+        calculate_futures_pnl(trade)
+
+
+@pytest.mark.parametrize("current,is_long,quantity,expected", [
+    (25010, True, 1, "100"), (24990, True, 1, "-100"), (25000, True, 1, "0"),
+    (24990, False, 1, "100"), (25010, False, 1, "-100"), (25010, True, 2, "200"),
+])
+def test_native_hkd_gross_has_no_fee_tax_or_fx(current, is_long, quantity, expected):
+    result = calculate_native_gross_pnl(spec=spec(), quantity=quantity, entry_price=D("25000"),
+        current_price=D(current), is_long=is_long)
+    assert result.amount == D(expected)
+    assert result.currency == "HKD"
+    assert result.basis == "estimated_gross_price_change"
+    assert not any(key.endswith(("_usd", "_krw")) for key in result.model_dump())
+
+
+@pytest.mark.parametrize("updates", [{"currency":""}, {"tick_size":D("0")}, {"tick_value":D("0")}])
+def test_native_estimate_requires_currency_and_tick_metadata(updates):
+    with pytest.raises(ValueError):
+        calculate_native_gross_pnl(spec=spec().model_copy(update=updates), quantity=1,
+            entry_price=D("25000"), current_price=D("25010"))
+
+
+@pytest.mark.asyncio
+async def test_rest_tick_refresh_keeps_native_basis_and_broker_raw_separate():
+    tracker = tracker_for([position_row(broker_pnl=777)], [spec()])
+    await tracker._fetch_positions()
+    pos = tracker.get_positions()["HMH_SYNTHETIC"]
+    assert (pos.pnl_amount, pos.pnl_currency, pos.pnl_basis, pos.pnl_status) == (
+        D("100"), "HKD", "estimated_gross_price_change", "available")
+    assert pos.broker_pnl_amount == D("777")
+    assert pos.broker_pnl_basis == "broker_reported_unconfirmed"
+    tracker._on_tick_received(SimpleNamespace(body=SimpleNamespace(symbol=pos.symbol, curpr=25010)))
+    assert pos.pnl_amount == D("100")
+    assert pos.broker_pnl_amount == D("777")
+    assert pos.realtime_pnl is None
+    tracker._on_tick_received(SimpleNamespace(body=SimpleNamespace(symbol=pos.symbol, curpr=24990)))
+    assert pos.pnl_amount == D("-100")
+    assert pos.broker_pnl_amount == D("777")
+    await tracker._fetch_positions()
+    restored = tracker.get_positions()[pos.symbol]
+    assert restored.pnl_amount == D("100")
+    assert restored.broker_pnl_amount == D("777")
+
+
+@pytest.mark.asyncio
+async def test_single_currency_total_does_not_invent_margin_or_equity_return():
+    tracker = tracker_for([position_row()], [spec()])
+    await tracker._fetch_positions()
+    total = tracker._calculate_account_pnl()
+    assert total.total_pnl_amount == D("100")
+    assert total.currency == "HKD" and total.pnl_status == "available"
+    assert total.pnl_basis == "estimated_gross_price_change"
+    assert total.account_pnl_rate is None and total.total_eval_amount is None and total.total_margin_used is None
+    assert tracker.get_positions()["HMH_SYNTHETIC"].opening_margin == D("1000")
+
+
+@pytest.mark.asyncio
+async def test_mixed_currency_totals_remain_separate():
+    tracker = tracker_for([position_row(), position_row("USD_SYNTHETIC", "USD", 100, 110)],
+        [spec(), spec("USD_SYNTHETIC", "USD", "1")])
+    await tracker._fetch_positions()
+    total = tracker._calculate_account_pnl()
+    assert total.total_pnl_amount is None and total.currency is None
+    assert total.pnl_status == "unavailable" and total.pnl_unavailable_reason == "mixed_currencies"
+    assert total.pnl_by_currency["HKD"].total_pnl_amount == D("100")
+    assert total.pnl_by_currency["USD"].total_pnl_amount == D("10")
+    assert total.unavailable_position_count == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("currency,specs,reason", [
+    ("", [spec()], "missing_position_currency"),
+    ("HKD", [], "missing_symbol_spec"),
+    ("HKD", [spec(currency="USD")], "position_spec_currency_mismatch"),
+    ("HKD", [spec(currency="")], "position_spec_currency_mismatch"),
+])
+async def test_unavailable_position_cannot_become_zero_or_usd(currency, specs, reason):
+    tracker = tracker_for([position_row(currency=currency)], specs)
+    await tracker._fetch_positions()
+    pos = tracker.get_positions()["HMH_SYNTHETIC"]
+    assert pos.pnl_amount is None and pos.pnl_currency is None and pos.pnl_status == "unavailable"
+    assert pos.pnl_unavailable_reason == reason
+    total = tracker._calculate_account_pnl()
+    assert total.total_pnl_amount is None and total.currency is None
+    assert total.unavailable_position_count == 1 and not total.pnl_by_currency
+
+
+@pytest.mark.asyncio
+async def test_missing_broker_value_is_not_the_model_default_zero():
+    row = position_row().model_dump()
+    row.pop("AbrdFutsEvalPnlAmt")
+    tracker = tracker_for([CIDBQ01500OutBlock2(**row)], [spec()])
+    await tracker._fetch_positions()
+    assert tracker.get_positions()["HMH_SYNTHETIC"].broker_pnl_amount is None
+
+
+@pytest.mark.asyncio
+async def test_missing_entry_price_stays_unavailable_after_tick():
+    row = position_row().model_dump()
+    row.pop("PchsPrc")
+    tracker = tracker_for([CIDBQ01500OutBlock2(**row)], [spec()])
+    await tracker._fetch_positions()
+    pos = tracker.get_positions()["HMH_SYNTHETIC"]
+    tracker._on_tick_received(SimpleNamespace(body=SimpleNamespace(symbol=pos.symbol, curpr=25010)))
+    assert pos.pnl_amount is None and pos.pnl_unavailable_reason == "missing_position_entry_price"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value,reason", [
+    ("BalQty", None, "missing_position_quantity"),
+    ("BnsTpCode", None, "missing_position_side"),
+    ("BnsTpCode", "0", "invalid_position_side"),
+    ("BnsTpCode", "9", "invalid_position_side"),
+])
+async def test_missing_quantity_or_side_cannot_invent_zero_or_direction(field, value, reason):
+    row = position_row().model_dump()
+    row.pop(field)
+    if value is not None:
+        row[field] = value
+    tracker = tracker_for([CIDBQ01500OutBlock2(**row)], [spec()])
+    await tracker._fetch_positions()
+    pos = tracker.get_positions()["HMH_SYNTHETIC"]
+    for tick in (None, 25010):
+        if tick is not None:
+            tracker._on_tick_received(SimpleNamespace(body=SimpleNamespace(symbol=pos.symbol, curpr=tick)))
+        assert pos.pnl_amount is None and pos.pnl_unavailable_reason == reason
+        assert tracker._calculate_account_pnl().total_pnl_amount is None
+
+
+@pytest.mark.asyncio
+async def test_explicit_zero_quantity_remains_distinct_from_missing_quantity():
+    tracker = tracker_for([position_row(quantity=0)], [spec()])
+    await tracker._fetch_positions()
+    pos = tracker.get_positions()["HMH_SYNTHETIC"]
+    assert pos.quantity == 0 and pos.pnl_amount == D("0")
+    assert pos.pnl_status == "available"
+
+
+@pytest.mark.asyncio
+async def test_missing_current_price_can_be_supplied_by_a_real_tick_shape():
+    row = position_row(broker_pnl=-123).model_dump()
+    row.pop("OvrsDrvtNowPrc")
+    tracker = tracker_for([CIDBQ01500OutBlock2(**row)], [spec()])
+    await tracker._fetch_positions()
+    pos = tracker.get_positions()["HMH_SYNTHETIC"]
+    assert pos.pnl_amount is None and pos.pnl_unavailable_reason == "missing_position_current_price"
+    tracker._on_tick_received(SimpleNamespace(body=SimpleNamespace(symbol=pos.symbol, curpr=25010)))
+    assert pos.pnl_amount == D("100") and pos.pnl_status == "available"
+    assert pos.broker_pnl_amount == D("-123")
+
+
+@pytest.mark.asyncio
+async def test_available_currency_contributions_do_not_hide_an_unknown_position():
+    tracker = tracker_for([position_row(), position_row("USD_SYNTHETIC", "USD", 100, 110)],
+        [spec("USD_SYNTHETIC", "USD", "1")])
+    await tracker._fetch_positions()
+    total = tracker._calculate_account_pnl()
+    assert total.total_pnl_amount is None and total.currency is None
+    assert total.unavailable_position_count == 1 and total.position_count == 2
+    assert total.pnl_by_currency["USD"].position_count == 1
+    assert total.pnl_by_currency["USD"].total_pnl_amount == D("10")
+
+
+@pytest.mark.asyncio
+async def test_zero_and_negative_estimates_are_available_amounts():
+    for price, expected in ((25000, D("0")), (24990, D("-100"))):
+        tracker = tracker_for([position_row(current=price, broker_pnl=0)], [spec()])
+        await tracker._fetch_positions()
+        pos = tracker.get_positions()["HMH_SYNTHETIC"]
+        total = tracker._calculate_account_pnl()
+        assert pos.broker_pnl_amount == D("0")
+        assert total.pnl_status == "available" and total.total_pnl_amount == expected
+
+
+@pytest.mark.asyncio
+async def test_incompatible_basis_does_not_enter_scalar_or_subtotal():
+    tracker = tracker_for([position_row()], [spec()])
+    await tracker._fetch_positions()
+    tracker._positions["HMH_SYNTHETIC"] = tracker._positions["HMH_SYNTHETIC"].model_copy(
+        update={"pnl_basis":"broker_reported_unconfirmed"})
+    total = tracker._calculate_account_pnl()
+    assert total.total_pnl_amount is None and not total.pnl_by_currency
+    assert total.pnl_unavailable_reason == "incompatible_monetary_basis"
+
+
+def test_empty_account_is_unavailable_not_zero_usd():
+    total = tracker_for([], [])._calculate_account_pnl()
+    assert total.total_pnl_amount is None and total.currency is None
+    assert total.pnl_unavailable_reason == "no_positions"
+
+
+@pytest.mark.asyncio
+async def test_actual_master_blank_currency_is_preserved_while_manual_default_stays_usd():
+    item = SimpleNamespace(Symbol="MISSING", SymbolNm="Synthetic", ExchCd="HKEX", UntPrc=1,
+        MnChgAmt=10, CrncyCd="", CtrtPrAmt=0, OpngMgn=0, MntncMgn=0, DotGb=0, BscGdsCd="HMH")
+    async def req_async():
+        return SimpleNamespace(rsp_cd="00000", block=[item])
+    manager = SymbolSpecManager(SimpleNamespace(o3121=lambda **kwargs:SimpleNamespace(req_async=req_async)))
+    await manager._fetch_specs()
+    assert manager.get_spec("MISSING").currency == ""
+    assert SymbolSpec(symbol="MANUAL_USD", tick_size=1, tick_value=10).currency == "USD"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing", ["CrncyCd", "UntPrc", "MnChgAmt"])
+async def test_missing_actual_master_metadata_is_not_fabricated_for_native_estimates(missing):
+    fields = {"Symbol":"HMH_SYNTHETIC", "SymbolNm":"Synthetic", "ExchCd":"HKEX",
+              "CrncyCd":"HKD", "UntPrc":1, "MnChgAmt":10}
+    fields.pop(missing)
+    row = O3121OutBlock(**fields)
+    async def req_async():
+        return SimpleNamespace(rsp_cd="00000", block=[row])
+    manager = SymbolSpecManager(SimpleNamespace(o3121=lambda **kwargs:SimpleNamespace(req_async=req_async)))
+    await manager._fetch_specs()
+    actual_spec = manager.get_spec("HMH_SYNTHETIC")
+    with pytest.raises(ValueError):
+        calculate_native_gross_pnl(spec=actual_spec, quantity=1, entry_price=D("25000"), current_price=D("25010"))
+    tracker = tracker_for([position_row()], [actual_spec])
+    await tracker._fetch_positions()
+    assert tracker.get_positions()["HMH_SYNTHETIC"].pnl_amount is None
+    assert tracker._calculate_account_pnl().total_pnl_amount is None
+
+
+@pytest.mark.asyncio
+async def test_valid_actual_master_metadata_is_preserved():
+    row = O3121OutBlock(Symbol="HMH_SYNTHETIC", SymbolNm="Synthetic", ExchCd="HKEX",
+        CrncyCd="HKD", UntPrc=1, MnChgAmt=10)
+    async def req_async():
+        return SimpleNamespace(rsp_cd="00000", block=[row])
+    manager = SymbolSpecManager(SimpleNamespace(o3121=lambda **kwargs:SimpleNamespace(req_async=req_async)))
+    await manager._fetch_specs()
+    result = calculate_native_gross_pnl(spec=manager.get_spec("HMH_SYNTHETIC"), quantity=1,
+        entry_price=D("25000"), current_price=D("25010"))
+    assert result.currency == "HKD" and result.amount == D("100")

--- a/src/finance/tests/test_stock_tracker_current_open_orders.py
+++ b/src/finance/tests/test_stock_tracker_current_open_orders.py
@@ -1,0 +1,117 @@
+"""The recurring stock pending-order query includes current-day activity."""
+import asyncio
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+from programgarden_finance.ls.overseas_stock.accno.COSAQ00102 import TrCOSAQ00102
+from programgarden_finance.ls.overseas_stock.accno.COSAQ00102.blocks import (
+    COSAQ00102InBlock1, COSAQ00102OutBlock3, COSAQ00102Response,
+)
+from programgarden_finance.ls.overseas_stock.extension.tracker import StockAccountTracker
+
+
+def test_tracker_includes_current_day_and_delivers_pending_row(monkeypatch):
+    def forbidden(*args, **kwargs):
+        raise AssertionError("Network transport is forbidden")
+
+    for method in ("connect", "connect_ex", "sendto"):
+        monkeypatch.setattr(socket.socket, method, forbidden)
+    monkeypatch.setattr(socket, "getaddrinfo", forbidden)
+    requests = []
+    notices = []
+
+    class API:
+        def cosaq00102(self, body):
+            requests.append(body)
+            return self
+
+        async def req_async(self):
+            return COSAQ00102Response(
+                rsp_cd="00000", rsp_msg="Synthetic success",
+                block3=[COSAQ00102OutBlock3(
+                    OrdNo=17, ShtnIsuNo="AAPL", OrdQty=1.25, ExecQty=0.25,
+                    UnercQty=1, OvrsOrdPrc=100,
+                )],
+            )
+
+    tracker = StockAccountTracker(API())
+    tracker._on_open_orders_change_callbacks.append(lambda orders: notices.append(orders))
+    asyncio.run(tracker._fetch_open_orders())
+    assert len(requests) == 1
+    request = requests[0]
+    assert isinstance(request, COSAQ00102InBlock1)
+    assert request.ThdayBnsAppYn == "1"
+    assert request.ExecYn == "2"
+    assert len(request.OrdDt) == 8 and request.OrdDt.isdigit()
+    assert not tracker._last_errors
+    assert notices and len(notices[-1]) == 1
+    pending = next(iter(notices[-1].values()))
+    assert pending.symbol == "AAPL"
+    assert pending.order_qty == 1.25
+    assert pending.executed_qty == 0.25
+    assert pending.remaining_qty == 1
+
+
+def _response(payload, status=200):
+    return TrCOSAQ00102._build_response(
+        TrCOSAQ00102.__new__(TrCOSAQ00102),
+        SimpleNamespace(status_code=status), payload, {}, None,
+    )
+
+
+@pytest.mark.parametrize("failure", [
+    None,
+    _response({}),
+    _response({"rsp_cd": "00000", "rsp_msg": "Synthetic missing blocks"}),
+    _response({"rsp_cd": "SYNTHETIC_UNKNOWN", "rsp_msg": "조회내역 unavailable"}),
+    _response({"rsp_cd": "00000", "rsp_msg": "Synthetic HTTP failure"}, 503),
+    _response({"rsp_cd": "00000", "rsp_msg": "Synthetic missing identity",
+               "COSAQ00102OutBlock3": [{}]}),
+])
+def test_unusable_response_preserves_pending_orders_and_original_diagnostics(failure):
+    class API:
+        def cosaq00102(self, body):
+            return self
+
+        async def req_async(self):
+            return failure
+
+    tracker = StockAccountTracker(API())
+    previous = object()
+    tracker._open_orders = {"17": previous}
+    notices = []
+    tracker._on_open_orders_change_callbacks.append(notices.append)
+    asyncio.run(tracker._fetch_open_orders())
+    assert tracker._open_orders == {"17": previous}
+    assert notices == []
+    diagnostic = tracker._last_errors["open_orders"]
+    assert "COSAQ00102" in diagnostic
+    if failure is not None:
+        assert f"rsp_cd={failure.rsp_cd}" in diagnostic
+        assert f"rsp_msg={failure.rsp_msg}" in diagnostic
+        assert f"error_msg={failure.error_msg}" in diagnostic
+
+
+def test_complete_empty_success_removes_prior_pending_orders():
+    class API:
+        def cosaq00102(self, body):
+            return self
+
+        async def req_async(self):
+            return _response({
+                "rsp_cd": "00000", "rsp_msg": "Synthetic empty success",
+                "COSAQ00102OutBlock1": {}, "COSAQ00102OutBlock2": {},
+                "COSAQ00102OutBlock3": [],
+            })
+
+    tracker = StockAccountTracker(API())
+    tracker._open_orders = {"17": object()}
+    tracker._last_errors["open_orders"] = "Previous failure"
+    notices = []
+    tracker._on_open_orders_change_callbacks.append(notices.append)
+    asyncio.run(tracker._fetch_open_orders())
+    assert tracker._open_orders == {}
+    assert notices == [{}]
+    assert tracker._last_errors == {}


### PR DESCRIPTION
Futures execution recovery needs broker execution identifiers and timestamps, while P&L amounts must remain unavailable when their contract multiplier or currency basis is unverified. This change adds those contracts in core 1.25.3 and finance 1.9.4, documents observed LS responses and preserves stock pending orders when a refresh returns an unusable response.

Validation: 214 focused offline regressions passed and 258 field examples across six TR models validated. Actual paper-futures execution/recovery has been observed; whole-account ROI/MDD verification and nighttime real-stock validation remain open.

Release order: publish core and finance from the merged commit, then release the matching engine 1.33.5 and update consumers together. The new nullable finance amounts must not be deployed with the old engine callback. This dependency PR intentionally leaves engine integration for the following PR so its lock can resolve the actual published artifacts.
