### PR TITLE
fix(engine): reconcile delayed executions and release v1.33.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,3 +283,10 @@ example. Print each tick as it arrives and handle reconnect cleanly.
 ````
 
 </details>
+
+
+### Runtime futures order lifecycle
+
+`WorkflowExecutor.set_order_lifecycle_handler(handler)` installs a synchronous, local-only capability outside DSL and checkpoint data. The handler receives `OrderLifecycleMetadata` and implements `prepare`, `accepted`, and `rejected`. Exact futures broker/credential routing is captured before submission. Operation identity includes job, node, cycle and invocation/iteration identity; order facts are checked separately. A prepared/uncertain replay cannot authorize another transport. A valid broker ACK is frozen before callbacks; local storage failure cannot revoke it.
+
+Handler-managed futures return the accepted `submitted` result with additive parent references. Their app session owns canonical history observation, so legacy startup history repair, post-ACK fill polling and TC3 FIFO writes are skipped. Standalone futures and stocks retain their existing confirmation paths. This capability does not establish complete historical coverage, repair TC3/FIFO accounting or verify workflow returns/MDD.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "programgarden"
-version = "1.33.4"
+version = "1.33.5"
 description = "LS증권 API을 메인으로 제작된 노코딩 시스템 트레이딩 DSL 오픈소스"
 authors = [
     {name = "장용준",email = "coding@programgarden.com"}

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.25.3] - 2026-09-09
+
+### Added
+- Add listener fields for futures P&L currency/basis and preserve unavailable monetary amounts as null.
+- Carry execution lifecycle and recovery evidence without converting acceptance into a fill.
+
+### Notes
+- Pair with finance 1.9.4 and engine 1.33.5 when deploying the new account-tracker contract.
+
 ## [1.25.2] - 2026-09-07
 > 코드 변경 없음 — 노드 가이드 문구만. 동반 릴리즈: `programgarden` **1.33.3**(D2 "No symbols provided" 3분류).
 

--- a/src/finance/CHANGELOG.md
+++ b/src/finance/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [1.9.4] - 2026-09-09
+
+### Added
+- Parse CIDBQ02400 executions using dated order/execution identities, positive executed quantity and ExecDttm.
+- Document supplied CIDBQ02400/CIDBQ03000 fields, observed paper responses and unresolved snapshot scope.
+
+### Fixed
+- Keep futures monetary P&L unavailable when currency, contract multiplier or value basis is unverified.
+- Request today's stock pending orders and preserve prior orders on incomplete/error responses.
+- Distinguish an explicitly empty successful envelope from default empty SDK blocks.
+
+### Notes
+- Paper fill and recovery were observed; complete account ROI/MDD evidence remains unverified.
+- Deploy with the matching engine 1.33.5 to handle nullable finance amounts.
+
 ## [1.9.3] - 2026-09-08
 > LS증권 공지(2026-09-12 12:00 적용)의 **국내주식 TR 필드 추가** 8종 중, 이 라이브러리가
 > 이미 구현한 6종에 신규 필드를 반영한다. 반영이 없으면 NXT VI · 거래소별 종목코드 ·

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## [Unreleased]
 
+## [1.33.5] - 2026-09-09
+
+### Added
+- Add durable order lifecycle hooks for delayed futures execution recovery with original parent identity.
+- Persist execution identities and payloads in the workflow ledger for replay-safe partial fills.
+- Forward AS1.sExecNO through execution context to the durable stock ledger.
+
+### Fixed
+- Keep submitted, partial, filled and rejected outcomes distinct; preserve raw broker diagnostics.
+- Route the canonical order result to downstream consumers and preserve recovery ownership.
+- Correct TC3 side handling and tracker cleanup; retain unavailable futures monetary values instead of nominal-price substitutes.
+- Include current-day stock pending orders and expose unavailable quote/order reads explicitly.
+- (finance 1.9.4) Preserve pending-order cache on unusable responses, canonical futures execution timestamps and documented currency basis.
+
+### Changed
+- Require programgarden-core ^1.25.3 and programgarden-finance ^1.9.4; community remains 1.15.1.
+- (core 1.25.3) Extend listener fields for execution and nullable account monetary evidence.
+
+### Validation and limitations
+- Focused offline regression suites cover execution replay, distinct partial fills, tracker lifecycle, response failures and serialization.
+- Actual paper-futures execution and durable recovery were confirmed. Full-account contest count/ROI/MDD acceptance and nighttime real-stock validation remain follow-ups.
+
 ## [1.33.4] - 2026-09-08
 > LS증권 OPEN API 공지(**2026-09-12(토) 12:00** 적용)의 국내주식 TR 필드 추가를 반영하는
 > 릴리즈. 엔진 로직 변경은 없고 `finance` 의 TR 블록 스키마만 넓힌다.

--- a/src/programgarden/README.md
+++ b/src/programgarden/README.md
@@ -62,6 +62,93 @@ job = await pg.run_async(
 await job.stop()
 ```
 
+Broker account trackers belong to the workflow job. Normal completion, `stop()`,
+`cancel()`, and `force_stop()` cancel pending broker startup/history tasks, stop
+account polling, and close each tracker's dedicated WebSocket. Late account PnL
+callbacks do not restart work after shutdown. This cleanup also covers partially
+initialized trackers and leaves other jobs running.
+Already queued or in-flight PnL notifications have up to one second to finish
+after account trackers stop, before listeners close. On timeout, cleanup logs the
+pending count and cancels those tasks, allowing another 0.25 seconds for cancellation.
+A listener that suppresses cancellation is reported and remains tracked; it cannot
+hold job shutdown indefinitely. Delivery beyond this bounded grace is not guaranteed.
+
+For one-shot workflows, an unhandled `order_result.success=False` returned directly
+by a main-flow node makes the final job status `failed` and emits `WORKFLOW_FAILED`.
+The original broker message remains in node diagnostics and the failure statistics.
+Successful downstream nodes do not erase that rejection. `reason="no_signal"` stays
+a normal no-op. Scheduled/resident workflows continue after a rejected cycle;
+SplitNode and automatic iteration retain their existing item-error continuation
+policies. Final failure is not inferred from cumulative `errors_count` or old logs.
+Raised main-node exceptions retain the existing fail-fast behavior.
+
+New-order nodes for overseas stocks, overseas futures, and Korea stocks expose
+the catalog's `result` port as a list of outcome rows: `{{ nodes.order.result }}`
+can feed TableDisplayNode directly. Each row copies the final `order_result`
+and includes `order_id` from the existing top-level or nested order number.
+Legacy `order_result` and `order_id` outputs are unchanged. The projection occurs
+after fill confirmation, fractional-remainder annotation, and replay marking;
+an accepted order is not promoted to a fill without confirmation. Rejections and
+`no_signal` keep their original diagnostics/reason as an outcome row, with no
+fabricated order number. Dry runs add a `simulated` row while retaining the legacy
+flat simulation envelope; request/credential data is not copied into the row.
+Automatic iteration merges these rows into one list. Implicit SplitNode collection
+of a new-order result retains its legacy `order_result` row shape; explicit
+`nodes.order.result` bindings always read the list. Modify/cancel nodes retain their
+separately declared `modify_result`/`cancel_result` ports and are outside this change.
+
+## Explicit execution identities in local ledgers
+
+`WorkflowPositionTracker.record_fill(..., execution_id=...)` can preserve a
+broker-provided execution identity. Within one ledger/product/provider/mode,
+order date and normalized order number, an identical replay returns the first
+classification without changing FIFO or history. Conflicting facts raise
+`ExecutionIdentityConflictError`. Positive numeric identifiers ignore padding;
+opaque identifiers retain case. Missing, blank and zero identifiers retain legacy
+behavior and are never inferred from time, price or quantity. Every pending
+partial fill is retained while its order acknowledgement is being recorded.
+
+The migration is additive and does not invent identities for existing rows.
+Callers must establish consistent identifier and timestamp semantics first;
+exchange execution numbers and broker execution numbers are not interchangeable.
+This ledger API alone does not reconcile finite workflows after their shutdown.
+
+Standalone futures TC3 callbacks interpret `s_b_ccd="1"` as sell and `"2"` as buy,
+matching the SDK contract. Unknown or blank side codes are logged and skipped
+before any inventory write is scheduled. With an app order lifecycle handler,
+TC3 still bypasses this legacy fill path: canonical REST reconciliation remains
+the sole writer. This side correction does not establish an alias between TC3
+and REST execution identities, dates, or times.
+
+## Futures monetary evidence
+
+Futures workflow PnL events preserve native gross estimates separately from
+accounting results. `workflow_*`, `other_*`, `total_*`, account and competition
+monetary/rate scalars remain null when accounting evidence is unavailable.
+`pnl_by_currency` contains gross price-change subtotals by contract currency;
+`monetary_positions` retains their basis/status and unmodified, unconfirmed
+`broker_pnl_amount`. No fee, FX, margin/equity return or verified contest score
+is inferred from these estimates. Actual zero and negative amounts are retained.
+`currency` is null for mixed or unavailable currencies. Consumers must handle
+nullable monetary fields and must not coerce them to zero.
+
+## Stock read failures
+
+Stock open-order queries include current-day orders (`ThdayBnsAppYn="1"`).
+`OpenOrdersNode` reports unusable `COSAQ00102` responses with `error`,
+`reason="fetch_failed"`, and the original TR, HTTP status and broker response
+fields in `diagnostics`. Its legacy empty payload/count remains for compatibility;
+an error result is unavailable, not evidence of zero orders. A successful empty
+response requires documented success plus parsed echo and aggregate blocks.
+Unknown broker codes receive no inferred meaning.
+
+Stock `MarketDataNode` preserves failed `g3101` attempts under `failures`.
+An entirely failed fetch returns `error` and `reason="fetch_failed"`; mixed
+results retain usable `values` with `_partial_failure` and `_failure_reason`.
+The existing exchange fallback and empty upstream no-signal behavior remain.
+Futures master errors likewise report the observed catalogue and original broker
+fields without inferring account entitlement, token or quota causes.
+
 ### Dry Run (워크플로우 검증용 모의 실행)
 
 실제 주문/알림/Realtime WebSocket 연결 없이 워크플로우를 검증합니다.

--- a/src/programgarden/poetry.lock
+++ b/src/programgarden/poetry.lock
@@ -2610,14 +2610,14 @@ quant-all = ["packaging (>=23)", "pyportfolioopt (>=1.6,<2) ; python_version < \
 
 [[package]]
 name = "programgarden-core"
-version = "1.25.0"
+version = "1.25.3"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "programgarden_core-1.25.0-py3-none-any.whl", hash = "sha256:ed483663b8f7539bbf12f84856abec2a5a2b8fad3ceb60b740fa97df4a1796b9"},
-    {file = "programgarden_core-1.25.0.tar.gz", hash = "sha256:bcb89bfe099aae4e0e2e50aa724cbf90d7a704aeb792932cf01ec5889513b606"},
+    {file = "programgarden_core-1.25.3-py3-none-any.whl", hash = "sha256:67a1acda5cf127d3f9ba3a7fead834323e6c83d6a23d6a63e3bf5957612bb78a"},
+    {file = "programgarden_core-1.25.3.tar.gz", hash = "sha256:70ef83eb725e89051737d54befd52667639533b3b62b89ad3d369255f5fea7a3"},
 ]
 
 [package.dependencies]
@@ -2625,14 +2625,14 @@ pydantic = ">=2.0.0,<3.0.0"
 
 [[package]]
 name = "programgarden-finance"
-version = "1.9.3"
+version = "1.9.4"
 description = "프로그램 동산 운영진이 관리하는 증권사 데이터 오픈소스"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "programgarden_finance-1.9.3-py3-none-any.whl", hash = "sha256:3b773e3f8de064616e71da25943e3a272b2d9c27918e0cc934cae17472aab39b"},
-    {file = "programgarden_finance-1.9.3.tar.gz", hash = "sha256:2ea283bac4636434a3aca3387885eab4d8761b16602319ef1abc39cc39f6b671"},
+    {file = "programgarden_finance-1.9.4-py3-none-any.whl", hash = "sha256:5de04e96537afe70da1ccd4241a1cb56b0650af072abad555a64c6ca056895f9"},
+    {file = "programgarden_finance-1.9.4.tar.gz", hash = "sha256:6a9c75dbaa5a1914067058d6d01e52e6b00b59d2adc589b1ccf105c76c77d5e9"},
 ]
 
 [package.dependencies]
@@ -4179,4 +4179,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "0077dc357caacef7f599acce5ec4c1788a5551c3785a4bbb6449c0c83b5a9817"
+content-hash = "6bdd030a8a8b436efcf1dd67a41e0c7817c7043dd76248de08152986e517e8b7"

--- a/src/programgarden/programgarden/context.py
+++ b/src/programgarden/programgarden/context.py
@@ -153,6 +153,7 @@ class ExecutionContext:
         # sync (appkey, product, paper_trading, *, force_reissue=False, stale_token=None)
         #   -> (token, expires_at_epoch)
         ls_token_provider: Optional[Any] = None,
+        order_lifecycle_handler: Optional[Any] = None,
     ):
         self.job_id = job_id
         self.workflow_id = workflow_id
@@ -162,6 +163,10 @@ class ExecutionContext:
         # Opt-in LS token provider (Verified League §3.2.3). When set, broker
         # logins consume a server-issued token instead of self-issuing.
         self.ls_token_provider = ls_token_provider
+        # Runtime-only capabilities and acceptance guards never enter DSL state
+        # or checkpoint context_params. PAPER orders use the same guard as live.
+        self.order_lifecycle_handler = order_lifecycle_handler
+        self._order_lifecycle_operations: Dict[str, Dict[str, Any]] = {}
 
         # Secrets storage (never logged, separate from context_params)
         self._secrets: Dict[str, Any] = secrets or {}
@@ -1880,7 +1885,7 @@ class ExecutionContext:
         provider: str,
         current_prices: Dict[str, float],
         account_positions: Optional[Dict[str, Any]],
-        currency: str = "USD",
+        currency: Optional[str] = "USD",
     ) -> None:
         """Notify all listeners about workflow P&L update (확장 버전).
         
@@ -1934,6 +1939,10 @@ class ExecutionContext:
             account_positions=account_positions,
             start_date=None,
         )
+        if product == "overseas_futures":
+            from .futures_pnl import unavailable_account_pnl
+
+            account_result = unavailable_account_pnl()
         
         # 3. 리스너별 이벤트 생성 및 전달
         for listener in self._listeners:
@@ -2015,6 +2024,8 @@ class ExecutionContext:
                         account_positions=account_positions,
                         start_date=listener_start_date,
                     )
+                    if product == "overseas_futures":
+                        competition_account = unavailable_account_pnl()
                     
                     event_data.update({
                         "competition_start_date": listener_start_date,
@@ -2036,6 +2047,10 @@ class ExecutionContext:
                         "competition_account_korea_stock_pnl_amount": competition_account.get("account_korea_stock_pnl_amount"),
                     })
                 
+                if product == "overseas_futures":
+                    from .futures_pnl import futures_pnl_metadata
+
+                    event_data.update(futures_pnl_metadata(account_positions))
                 event = WorkflowPnLEvent(**event_data)
                 await listener.on_workflow_pnl_update(event)
                 
@@ -2044,7 +2059,7 @@ class ExecutionContext:
         
         # 디버그 로그
         wf_rate = base_workflow_result.get("workflow_pnl_rate", 0.0)
-        logger.debug(f"📡 notify_workflow_pnl: {broker_node_id} ({product}) wf_rate={wf_rate:.2f}%")
+        logger.debug("notify_workflow_pnl: %s (%s) workflow_rate=%s", broker_node_id, product, wf_rate)
 
     def _calculate_workflow_pnl(
         self,
@@ -2064,6 +2079,13 @@ class ExecutionContext:
         Returns:
             워크플로우 수익률 데이터 dict
         """
+        if product == "overseas_futures":
+            from .futures_pnl import unavailable_workflow_pnl
+
+            # Native estimates do not prove workflow ownership, opening capital,
+            # realized PnL or fees. Do not infer these from the local legacy FIFO.
+            return unavailable_workflow_pnl()
+
         # 트래커 없으면 기본값 (모든 포지션이 "other")
         if self._workflow_position_tracker is None:
             # 트래커 없음 = 모든 포지션이 "other"
@@ -2181,6 +2203,13 @@ class ExecutionContext:
         """
         if not account_positions:
             return {}
+
+        if any(pos.get("product") == "overseas_futures" for pos in account_positions.values()):
+            from .futures_pnl import unavailable_account_pnl
+
+            # Current native gross estimates are exposed separately by currency.
+            # A price-times-quantity fallback is not a futures capital basis.
+            return unavailable_account_pnl()
         
         # 상품별 분류
         overseas_stock_positions = {}
@@ -2515,6 +2544,8 @@ class ExecutionContext:
         price: float,
         fill_time: str,
         commda_code: str = "40",
+        *,
+        execution_id: Optional[str | int] = None,
     ) -> str:
         """Record fill event for FIFO position tracking.
         
@@ -2530,6 +2561,7 @@ class ExecutionContext:
             price: 체결 가격
             fill_time: 체결시각 (HHMMSSsss)
             commda_code: 매체구분코드 ("40"=OPEN API, 기타=수동)
+            execution_id: Optional broker execution number, preserved for durable replay detection.
             
         Returns:
             분류 결과: "workflow" | "manual" | "unknown_api" | "pending"
@@ -2539,6 +2571,7 @@ class ExecutionContext:
             return "skipped"
         
         try:
+            identity_kwargs = {"execution_id": execution_id} if execution_id is not None else {}
             result = await self._workflow_position_tracker.record_fill(
                 order_no=order_no,
                 order_date=order_date,
@@ -2549,6 +2582,7 @@ class ExecutionContext:
                 price=price,
                 fill_time=fill_time,
                 commda_code=commda_code,
+                **identity_kwargs,
             )
             logger.info(f"Recorded workflow fill: {order_no} ({symbol} {side} {quantity}@{price}) → {result}")
 
@@ -2557,7 +2591,10 @@ class ExecutionContext:
                 try:
                     # 현재가로 PnL 계산 (체결가 사용)
                     current_prices = {symbol: price}
-                    currency = "KRW" if self._workflow_product == "korea_stock" else "USD"
+                    currency = (
+                        None if self._workflow_product == "overseas_futures" else
+                        "KRW" if self._workflow_product == "korea_stock" else "USD"
+                    )
                     await self.notify_workflow_pnl(
                         broker_node_id=self._workflow_broker_node_id,
                         product=self._workflow_product,

--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -14,6 +14,8 @@ FIFO 방식으로 포지션을 관리합니다.
 import sqlite3
 import asyncio
 import logging
+import json
+import re
 from dataclasses import dataclass, field
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP
@@ -84,6 +86,11 @@ class PendingFill:
     fill_time: str
     commda_code: str
     received_at: datetime
+    execution_id: Optional[str | int] = None
+
+
+class ExecutionIdentityConflictError(ValueError):
+    """An explicit execution identity was replayed with different fill facts."""
 
 
 class WorkflowPositionTracker:
@@ -122,7 +129,10 @@ class WorkflowPositionTracker:
         self.trading_mode = trading_mode
 
         # 체결 버퍼 (Race Condition 방어)
-        self._pending_fills: Dict[str, PendingFill] = {}  # key: order_no_order_date
+        # Every arrival without an execution ID remains a separate event. An
+        # order can have multiple partial executions before its ACK is recorded.
+        self._pending_fills: Dict[int, PendingFill] = {}
+        self._next_pending_fill = 0
         self._buffer_lock = asyncio.Lock()
 
         # 심볼별 계약 승수(contract multiplier) 캐시.
@@ -141,6 +151,7 @@ class WorkflowPositionTracker:
             # WAL 모드: 멀티 워크플로우 동시 접근 시 SQLITE_BUSY 방지
             conn.execute("PRAGMA journal_mode=WAL")
             conn.execute("PRAGMA busy_timeout=5000")
+            conn.execute("BEGIN IMMEDIATE")
             cursor = conn.cursor()
 
             # 워크플로우 주문 기록
@@ -202,7 +213,10 @@ class WorkflowPositionTracker:
                     commda_code TEXT,
                     realized_pnl REAL,
                     trading_mode TEXT NOT NULL DEFAULT 'live',
-                    created_at TEXT
+                    created_at TEXT,
+                    execution_id TEXT,
+                    normalized_order_no TEXT,
+                    execution_payload TEXT
                 )
             """)
 
@@ -221,6 +235,19 @@ class WorkflowPositionTracker:
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_lots_fifo_v2 ON workflow_position_lots(trading_mode, symbol, fill_datetime)")
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_orders_lookup_v2 ON workflow_orders(trading_mode, order_no, order_date)")
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_lots_remaining_v2 ON workflow_position_lots(trading_mode, symbol, remaining_qty)")
+
+            # Additive migration: old rows have no evidence of execution identity.
+            # Never infer or backfill one from timestamps, prices, or quantities.
+            columns = {row[1] for row in cursor.execute("PRAGMA table_info(trade_history)")}
+            for column in ("execution_id", "normalized_order_no", "execution_payload"):
+                if column not in columns:
+                    cursor.execute(f"ALTER TABLE trade_history ADD COLUMN {column} TEXT")
+            cursor.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_trade_history_execution_v1
+                ON trade_history(product, provider, trading_mode, order_date,
+                                 normalized_order_no, execution_id)
+                WHERE execution_id IS NOT NULL
+            """)
 
             conn.commit()
 
@@ -325,14 +352,17 @@ class WorkflowPositionTracker:
         logger.debug(f"Recorded workflow order: {order_no} ({symbol} {side} {quantity}@{price})")
     
     async def _process_buffered_fill(self, order_no: str, order_date: str) -> None:
-        """버퍼에서 매칭되는 체결 처리"""
-        key = f"{order_no}_{order_date}"
-        
+        """Process all buffered partial fills after recording their order."""
         async with self._buffer_lock:
-            if key in self._pending_fills:
-                fill = self._pending_fills.pop(key)
-                logger.debug(f"Processing buffered fill: {key}")
-                await self._process_fill_internal(fill, "workflow")
+            for key, fill in list(self._pending_fills.items()):
+                if fill.order_date != order_date:
+                    continue
+                matches = fill.order_no == order_no
+                if self._normalize_identifier(fill.execution_id) is not None:
+                    matches = self._normalize_identifier(fill.order_no) == self._normalize_identifier(order_no)
+                if matches:
+                    await self._process_fill_internal(fill, "workflow")
+                    self._pending_fills.pop(key)
     
     async def record_fill(
         self,
@@ -345,6 +375,8 @@ class WorkflowPositionTracker:
         price: float,
         fill_time: str,
         commda_code: str,
+        *,
+        execution_id: Optional[str | int] = None,
     ) -> str:
         """
         체결 기록 및 FIFO 처리
@@ -361,69 +393,157 @@ class WorkflowPositionTracker:
             price: 체결가
             fill_time: 체결시각 (HHMMSSsss)
             commda_code: 매체구분코드 (40=OPEN API)
+            execution_id: Optional broker execution identity. Positive numeric
+                strings/integers ignore padding; opaque strings retain case.
+                None, blank, and zero mean no identity and retain legacy replay
+                behavior. Numeric floats/negative IDs are rejected. Never derive
+                this value from order IDs, timestamps, quantities, or prices.
+
+        Explicit identity is scoped to this ledger, product, provider, mode,
+        order date and normalized order number. Exact replay returns the first
+        stored classification without mutating FIFO/history. Changed symbol,
+        exchange, side, quantity, price, fill time or source code raises
+        ExecutionIdentityConflictError. Callers must supply consistent broker
+        timestamp/field semantics; no timestamp or currency inference occurs.
+        This is a persistence prerequisite, not broker-history/TC3 integration.
             
         Returns:
             분류 결과: "workflow" | "manual" | "unknown_api" | "pending"
         """
-        # 1. 수동 주문 (앱/HTS) - CommdaCode != "40"
-        if commda_code != "40":
-            fill = PendingFill(
-                order_no=order_no, order_date=order_date, symbol=symbol,
-                exchange=exchange, side=side, quantity=quantity, price=price,
-                fill_time=fill_time, commda_code=commda_code, received_at=datetime.now()
-            )
-            await self._process_fill_internal(fill, "manual")
-            return "manual"
-        
-        # 2. API 주문 - DB 확인
-        is_workflow = self._check_workflow_order(order_no, order_date)
-        
-        if is_workflow:
-            fill = PendingFill(
-                order_no=order_no, order_date=order_date, symbol=symbol,
-                exchange=exchange, side=side, quantity=quantity, price=price,
-                fill_time=fill_time, commda_code=commda_code, received_at=datetime.now()
-            )
-            await self._process_fill_internal(fill, "workflow")
-            return "workflow"
-        
-        # 3. API 주문인데 DB에 없음 - 버퍼에 저장
-        key = f"{order_no}_{order_date}"
         fill = PendingFill(
             order_no=order_no, order_date=order_date, symbol=symbol,
             exchange=exchange, side=side, quantity=quantity, price=price,
-            fill_time=fill_time, commda_code=commda_code, received_at=datetime.now()
+            fill_time=fill_time, commda_code=commda_code, received_at=datetime.now(),
+            execution_id=execution_id,
         )
-        
+        identity = self._execution_key(fill)
         async with self._buffer_lock:
+            if identity is not None:
+                for pending in self._pending_fills.values():
+                    if self._execution_key(pending) == identity:
+                        self._assert_same_execution(pending, fill)
+                        return "pending"
+                with sqlite3.connect(self.db_path) as conn:
+                    previous = self._find_execution(conn.cursor(), fill)
+                if previous is not None:
+                    return previous
+
+            if commda_code != "40":
+                return await self._process_fill_internal(fill, "manual")
+            if self._is_workflow_fill(fill):
+                return await self._process_fill_internal(fill, "workflow")
+
+            self._next_pending_fill += 1
+            key = self._next_pending_fill
             self._pending_fills[key] = fill
-        
-        # 타임아웃 후 처리
         asyncio.create_task(self._process_timeout_fill(key))
-        
         logger.debug(f"Buffered fill (waiting for order): {key}")
         return "pending"
-    
-    async def _process_timeout_fill(self, key: str) -> None:
-        """버퍼 타임아웃 후 처리"""
-        await asyncio.sleep(self.FILL_BUFFER_TIMEOUT)
 
+    async def _process_timeout_fill(self, key: int) -> None:
+        """Expire one arrival, without consuming a later partial's timeout."""
+        await asyncio.sleep(self.FILL_BUFFER_TIMEOUT)
         async with self._buffer_lock:
             if key in self._pending_fills:
-                fill = self._pending_fills.pop(key)
-                logger.warning(
-                    f"Fill timeout ({self.FILL_BUFFER_TIMEOUT}s) - classifying as unknown_api: {key} "
-                    f"({fill.symbol} {fill.side} {fill.quantity}@{fill.price}). "
-                    f"워크플로우 주문이었다면 FIFO 수익률이 부정확할 수 있습니다."
-                )
-                await self._process_fill_internal(fill, "unknown_api")
-    
-    async def _process_fill_internal(self, fill: PendingFill, classification: str) -> None:
-        """체결 내부 처리 (FIFO 로직)"""
+                fill = self._pending_fills[key]
+                classification = "workflow" if self._is_workflow_fill(fill) else "unknown_api"
+                if classification == "unknown_api":
+                    logger.warning("Fill expired before its order was recorded; classifying as unknown_api")
+                await self._process_fill_internal(fill, classification)
+                self._pending_fills.pop(key)
+
+    @staticmethod
+    def _normalize_identifier(value: Optional[str | int]) -> Optional[str]:
+        """Normalize proven IDs only; never invent an ID for missing/zero data."""
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, (str, int)):
+            raise ValueError("Execution/order identity must be a string or integer")
+        text = str(value).strip()
+        if not text:
+            return None
+        if re.fullmatch(r"[0-9]+", text):
+            return text.lstrip("0") or None
+        if re.fullmatch(r"[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?", text):
+            raise ValueError("Numeric execution/order identity must be a positive integer")
+        return text
+
+    def _execution_key(self, fill: PendingFill) -> Optional[Tuple[str, ...]]:
+        execution_id = self._normalize_identifier(fill.execution_id)
+        if execution_id is None:
+            return None
+        order_no = self._normalize_identifier(fill.order_no)
+        if order_no is None or not fill.order_date:
+            raise ValueError("Explicit execution identity requires an order number and date")
+        return (self.product, self.provider, self.trading_mode, fill.order_date, order_no, execution_id)
+
+    @staticmethod
+    def _execution_facts(fill: PendingFill) -> Dict[str, Any]:
+        # Decimal equality avoids false conflicts for quantity/price formatting,
+        # while the first supplied values are retained in execution_payload.
+        quantity, price = Decimal(str(fill.quantity)), Decimal(str(fill.price))
+        if not quantity.is_finite() or not price.is_finite():
+            raise ValueError("Explicit execution quantity and price must be finite")
+        return {
+            "symbol": fill.symbol, "exchange": fill.exchange, "side": fill.side,
+            "quantity": quantity, "price": price, "fill_time": fill.fill_time,
+            "commda_code": fill.commda_code,
+        }
+
+    def _assert_same_execution(self, previous: PendingFill, fill: PendingFill) -> None:
+        if self._execution_facts(previous) != self._execution_facts(fill):
+            raise ExecutionIdentityConflictError("Conflicting fill facts for an existing execution identity")
+
+    def _find_execution(self, cursor: sqlite3.Cursor, fill: PendingFill) -> Optional[str]:
+        identity = self._execution_key(fill)
+        if identity is None:
+            return None
+        facts = self._execution_facts(fill)
+        cursor.execute("""
+            SELECT classification, execution_payload FROM trade_history
+            WHERE product = ? AND provider = ? AND trading_mode = ?
+              AND order_date = ? AND normalized_order_no = ? AND execution_id = ?
+        """, identity)
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        stored = json.loads(row[1])
+        stored.pop("reported_execution_id")
+        stored["quantity"] = Decimal(stored["quantity"])
+        stored["price"] = Decimal(stored["price"])
+        if stored != facts:
+            raise ExecutionIdentityConflictError("Conflicting fill facts for an existing execution identity")
+        return row[0]
+
+    def _is_workflow_fill(self, fill: PendingFill) -> bool:
+        identity = self._execution_key(fill)
+        if identity is None:
+            return self._check_workflow_order(fill.order_no, fill.order_date)
+        with sqlite3.connect(self.db_path) as conn:
+            rows = conn.execute("""
+                SELECT order_no FROM workflow_orders
+                WHERE product = ? AND provider = ? AND trading_mode = ? AND order_date = ?
+            """, identity[:4])
+            return any(self._normalize_identifier(row[0]) == identity[4] for row in rows)
+
+    async def _process_fill_internal(self, fill: PendingFill, classification: str) -> str:
+        """Gate explicit replay before atomically mutating FIFO and history."""
         fill_datetime = f"{fill.order_date}_{fill.fill_time}"
 
         with sqlite3.connect(self.db_path) as conn:
+            conn.execute("BEGIN IMMEDIATE")
             cursor = conn.cursor()
+            previous = self._find_execution(cursor, fill)
+            if previous is not None:
+                return previous
+            identity = self._execution_key(fill)
+            payload = None
+            if identity is not None:
+                facts = self._execution_facts(fill)
+                payload = json.dumps({
+                    **facts, "quantity": str(fill.quantity), "price": str(fill.price),
+                    "reported_execution_id": fill.execution_id,
+                }, sort_keys=True)
             realized_pnl = 0.0
 
             if fill.side == "buy":
@@ -449,18 +569,21 @@ class WorkflowPositionTracker:
             cursor.execute("""
                 INSERT INTO trade_history
                 (product, provider, order_no, order_date, symbol, exchange, side, quantity, price,
-                 fill_datetime, classification, commda_code, realized_pnl, trading_mode, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 fill_datetime, classification, commda_code, realized_pnl, trading_mode, created_at,
+                 execution_id, normalized_order_no, execution_payload)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 self.product, self.provider,
                 fill.order_no, fill.order_date, fill.symbol, fill.exchange,
                 fill.side, fill.quantity, fill.price, fill_datetime,
-                classification, fill.commda_code, realized_pnl, self.trading_mode, datetime.now().isoformat()
+                classification, fill.commda_code, realized_pnl, self.trading_mode, datetime.now().isoformat(),
+                identity[5] if identity else None, identity[4] if identity else None, payload,
             ))
 
             conn.commit()
 
         logger.debug(f"Processed fill: {fill.symbol} {fill.side} {fill.quantity}@{fill.price} [{classification}] ({self.trading_mode})")
+        return classification
     
     def _process_sell_fifo(
         self,

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -8,7 +8,7 @@ Workflow execution engine
 - Event-based realtime updates
 """
 
-from typing import Optional, Dict, Any, List, Callable, Awaitable, Set, Tuple
+from typing import Optional, Dict, Any, List, Callable, Awaitable, Set, Tuple, Mapping
 from datetime import datetime
 import asyncio
 import ast
@@ -29,6 +29,10 @@ from programgarden_core import (
     diagnose_missing_order_no,
 )
 from programgarden.context import ExecutionContext, WorkflowEvent
+from programgarden.order_lifecycle import (
+    FUTURES_PRODUCTS, OrderLifecycleMetadata, exact_futures_credential,
+    inject_futures_connection, operation_key,
+)
 from programgarden.reconnect_handler import ReconnectHandler
 from programgarden_core.expression import ExpressionEvaluator, ExpressionContext
 from programgarden_core.bases.listener import (
@@ -3534,17 +3538,11 @@ class SymbolQueryNodeExecutor(NodeExecutorBase):
                     f"error_msg={last_error_msg}" if last_error_msg else "",
                 ) if part
             )
-            hint = (
-                " A non-'00000' rsp_cd means missing overseas-futures market entitlement or a "
-                "rejected token, not a transient collision."
-                if last_rsp_cd and last_rsp_cd != "00000" else ""
-            )
             raise RuntimeError(
                 f"OverseasFuturesSymbolQueryNode[{node_id}]: LS returned an empty overseas-futures "
                 f"master (o3101) on 3 attempts"
-                + (f". LS says: {ls_reason}.{hint}" if ls_reason else
-                   " with no LS response code. The broker session may lack overseas-futures "
-                   "entitlement, or too many requests share this app key.")
+                + (f". LS says: {ls_reason}." if ls_reason else
+                   " with no LS response code.")
             )
 
         wanted_exchange = self.FUTURES_EXCHANGE_CODES.get(futures_exchange, futures_exchange)
@@ -3558,14 +3556,14 @@ class SymbolQueryNodeExecutor(NodeExecutorBase):
         # 요청한 거래소가 이 계좌의 마스터에 아예 없으면 **조용히 빈 배열을 주지 않는다**.
         # 빈 유니버스는 하류를 전부 no-op 시키고 워크플로우는 '성공'한 척 아무것도 안 한다 —
         # 이 저장소가 없애려는 바로 그 무음 실패다. 무엇을 쓸 수 있는지 알려주고 실패한다.
-        # (해외선물 권한은 거래소별이라, 이 계좌에 없는 거래소를 고르면 여기서 걸린다.)
+        # The returned catalogue does not establish the account's entitlements.
         if wanted_exchange and rows and wanted_exchange not in listed_exchanges:
             raise RuntimeError(
                 f"OverseasFuturesSymbolQueryNode[{node_id}]: exchange '{wanted_exchange}' "
                 f"(futures_exchange={futures_exchange!r}) has no contracts in this account's LS "
                 f"master. LS currently lists: {', '.join(listed_exchanges) or '(none)'}. "
-                f"Overseas-futures entitlement is per exchange — check the account, or use "
-                f"futures_exchange='1' for all exchanges."
+                f"LS response: rsp_cd={last_rsp_cd}, rsp_msg={last_rsp_msg}, error_msg={last_error_msg}. "
+                f"Use futures_exchange='1' to select all returned exchanges."
             )
 
         try:
@@ -3856,7 +3854,7 @@ class FuturesContractNodeExecutor(NodeExecutorBase):
                     f"FuturesContractNode[{node_id}]: LS contract-master query (o3101) failed "
                     f"after 3 attempts: {last_error}"
                 ) from last_error
-            # LS 원문 우선 — 추측 문구는 원문이 하나도 없을 때만.
+            # Preserve the original broker response without inferring its cause.
             ls_reason = ", ".join(
                 part for part in (
                     f"rsp_cd={last_rsp_cd}" if last_rsp_cd else "",
@@ -3865,25 +3863,13 @@ class FuturesContractNodeExecutor(NodeExecutorBase):
                 ) if part
             )
             if ls_reason:
-                # rsp_cd 가 비었거나 '00000'(성공)이면 마스터가 진짜로 빈 것, 아니면 그 코드가 원인.
-                if last_rsp_cd and last_rsp_cd != "00000":
-                    hint = (
-                        " A non-'00000' rsp_cd means the broker session lacks overseas-futures "
-                        "market entitlement or the token was rejected — not a transient app-key collision."
-                    )
-                else:
-                    hint = (
-                        " rsp_cd is success/blank, so the master is genuinely empty for this account — "
-                        "check overseas-futures entitlement, or too many requests share this app key."
-                    )
                 raise RuntimeError(
                     f"FuturesContractNode[{node_id}]: LS returned an empty contract master (o3101) "
-                    f"on 3 attempts. LS says: {ls_reason}.{hint}"
+                    f"on 3 attempts. LS says: {ls_reason}."
                 )
             raise RuntimeError(
                 f"FuturesContractNode[{node_id}]: LS returned an empty contract master (o3101) "
-                f"on 3 attempts with no LS response code. The broker session may lack overseas-futures "
-                f"entitlement, or too many requests are sharing this app key at once."
+                f"on 3 attempts with no LS response code."
             )
 
         # 거래소 필터를 걸기 **전** 목록도 들고 있는다 — 실패 메시지의 "쓸 수 있는 코드" 를
@@ -4011,20 +3997,99 @@ class BrokerNodeExecutor(NodeExecutorBase):
     - overseas_futures: FuturesAccountTracker 사용
     """
     
-    # 활성화된 트래커 저장 (Job 종료 시 정리용)
+    # Broker resources and background work belong to their workflow job.
     _active_trackers: Dict[str, Any] = {}
+    _background_tasks: Dict[str, Set[asyncio.Task]] = {}
+    _notification_tasks: Dict[str, Set[asyncio.Task]] = {}
+    # Fit inside WorkflowJob.stop's 5s wait and the desktop runner's 8s ceiling.
+    _PNL_DRAIN_TIMEOUT_SECONDS = 1.0
+    _PNL_CANCEL_TIMEOUT_SECONDS = 0.25
+
+    def _start_background_task(
+        self, context: ExecutionContext, coroutine, *, notification: bool = False,
+    ) -> Optional[asyncio.Task]:
+        """Own broker work; existing PnL delivery gets a bounded shutdown drain."""
+        if context.is_shutdown:
+            coroutine.close()
+            return None
+        task = asyncio.create_task(coroutine)
+        registry = self._notification_tasks if notification else self._background_tasks
+        tasks = registry.setdefault(context.job_id, set())
+        tasks.add(task)
+
+        def done(completed: asyncio.Task) -> None:
+            tasks.discard(completed)
+            if not tasks and registry.get(context.job_id) is tasks:
+                registry.pop(context.job_id, None)
+            if not completed.cancelled():
+                error = completed.exception()
+                if error:
+                    logger.warning("Broker background task failed: %s", type(error).__name__)
+
+        task.add_done_callback(done)
+        return task
+
+    async def _drain_pnl_notifications(self, job_id: str) -> None:
+        """Let existing listener delivery finish, then cancel without an endless wait."""
+        tasks = set(self._notification_tasks.get(job_id, ()))
+        if not tasks:
+            return
+        pending = tasks
+        try:
+            _, pending = await asyncio.wait(tasks, timeout=self._PNL_DRAIN_TIMEOUT_SECONDS)
+            if pending:
+                logger.warning(
+                    "Broker PnL notification drain timed out for job %s; cancelling %d pending task(s)",
+                    job_id, len(pending),
+                )
+        finally:
+            # Also cancel if the outer job cleanup is interrupted. asyncio.wait
+            # keeps this bounded even if a listener suppresses CancelledError.
+            for task in pending:
+                task.cancel()
+            if pending:
+                _, remaining = await asyncio.wait(pending, timeout=self._PNL_CANCEL_TIMEOUT_SECONDS)
+                if remaining:
+                    logger.warning(
+                        "Broker PnL notification cancellation did not finish for job %s; %d task(s) still pending",
+                        job_id, len(remaining),
+                    )
+                # Done callbacks remove finished tasks. Keep resistant tasks in
+                # the registry so another stop/inspection can still see them.
 
     async def cleanup_fill_subscriptions(self, job_id: str) -> None:
-        """BrokerNode가 등록한 fill subscription 콜백 정리
+        """Stop this job's broker tasks, account trackers and fill callbacks.
 
-        Args:
-            job_id: 해당 job의 fill_subscription만 정리
+        Keep the existing entry point used by every WorkflowJob termination path.
+        Cancel startup before taking the resource snapshot: a partially started
+        tracker must never register itself after cleanup has finished.
         """
-        keys_to_remove = []
-        for key, info in self._active_trackers.items():
-            if not key.startswith(job_id):
+        tasks = self._background_tasks.pop(job_id, set())
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        resources = []
+        for key in list(self._active_trackers):
+            if not key.startswith(f"{job_id}_"):
                 continue
+            resources.append((key, self._active_trackers.pop(key)))
+
+        for key, info in resources:
             if info.get("type") != "fill_subscription":
+                tracker = info.get("tracker")
+                if tracker:
+                    try:
+                        await tracker.stop()
+                    except Exception as e:
+                        logger.warning("Failed to stop broker account tracker %s: %s", key, type(e).__name__)
+                real = info.get("real")
+                if real:
+                    try:
+                        await real.close()
+                    except Exception as e:
+                        logger.warning("Failed to close broker account connection %s: %s", key, type(e).__name__)
                 continue
             real = info.get("real")
             if real:
@@ -4042,11 +4107,11 @@ class BrokerNodeExecutor(NodeExecutorBase):
                             pass
                         except Exception as e:
                             logger.warning(f"Failed to cleanup fill subscription {key}/{tr_name}: {e}")
-            keys_to_remove.append(key)
-
-        for key in keys_to_remove:
-            del self._active_trackers[key]
             logger.debug(f"Cleaned up fill subscription: {key}")
+
+        # Workflow shutdown already blocks new callbacks. Stop their producers
+        # before draining the final notifications, while listeners are still open.
+        await self._drain_pnl_notifications(job_id)
 
     async def execute(
         self,
@@ -4140,6 +4205,8 @@ class BrokerNodeExecutor(NodeExecutorBase):
             # 리스너(SSE) · get_state · 체크포인트로 평문이 새어 나간다.
             # product 별 슬롯: 한 워크플로우에 브로커가 둘 이상이면(해외+국내) 단일 슬롯은 덮어써진다.
             context.set_secret(broker_credential_key(product), cred_payload)
+            if credential_id:
+                context.set_secret(f"broker_credentials:{node_id}:{credential_id}", cred_payload)
             # 레거시 단일 슬롯 — 아직 product 별 조회로 이관되지 않은 소비처를 위해 유지한다.
             context.set_secret("credential_id", cred_payload)
             context.log("info", f"Broker credentials stored (paper_trading={paper_trading})", node_id)
@@ -4193,8 +4260,12 @@ class BrokerNodeExecutor(NodeExecutorBase):
         # 모의 실행이 항상 실패했다(2026-08-29 Phase 9.6 실측, 잡 8/8). 샌드박스는
         # 진짜 appsecret 이라 같은 코드가 조용히 통과해 가려져 있던 결함.
         # ========================================
-        if appkey and appsecret and not context.is_dry_run:
-            asyncio.create_task(
+        if (
+            appkey and appsecret and not context.is_dry_run
+            and not (product in FUTURES_PRODUCTS and context.order_lifecycle_handler is not None)
+        ):
+            # Managed futures reconciliation owns its canonical REST history.
+            self._start_background_task(context,
                 self._sync_fill_prices_from_history(
                     node_id=node_id,
                     product=product,
@@ -4213,7 +4284,7 @@ class BrokerNodeExecutor(NodeExecutorBase):
 
         if appkey and appsecret and has_workflow_listener and not context.is_dry_run:
             context.log("info", "WorkflowPnL listener detected - starting account tracking", node_id)
-            asyncio.create_task(
+            self._start_background_task(context,
                 self._start_account_tracking(
                     node_id=node_id,
                     product=product,
@@ -4252,6 +4323,8 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 "provider": provider,
                 "product": product,
                 "paper_trading": paper_trading,
+                "broker_node_id": node_id,
+                "credential_id": credential_id,
             }
         }
 
@@ -4474,6 +4547,7 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 
                 # 필요한 필드 추출
                 order_no = str(getattr(body, 'sOrdNo', ''))
+                execution_id = getattr(body, 'sExecNO', None)
                 order_date = datetime.now().strftime('%Y%m%d')  # AS1에는 sOrdDt 없음
                 symbol = getattr(body, 'sShtnIsuNo', getattr(body, 'sIsuNo', ''))
                 market_code = getattr(body, 'sOrdMktCode', '82')
@@ -4503,6 +4577,7 @@ class BrokerNodeExecutor(NodeExecutorBase):
                         price=exec_price,
                         fill_time=fill_time,
                         commda_code='40',  # OPEN API
+                        execution_id=execution_id,
                     )
                     
                     # AccountTracker refresh로 PnL 이벤트 강제 트리거
@@ -4621,13 +4696,18 @@ class BrokerNodeExecutor(NodeExecutorBase):
             - ordr_no: 주문번호
             - ordr_dt: 주문일자
             - is_cd: 종목코드
-            - s_b_ccd: 매매구분 (1=매수, 2=매도)
+            - s_b_ccd: side (1=sell, 2=buy)
             - ccls_q: 체결수량
             - ccls_prc: 체결가격
             - ccls_tm: 체결시간
             """
             try:
                 if context.is_shutdown:
+                    return
+                if context.order_lifecycle_handler is not None:
+                    # The app session reconciles canonical REST executions.
+                    # TC3 and REST identifiers have no proven alias relation;
+                    # do not also feed this legacy side/date path into FIFO.
                     return
                 body = getattr(resp, 'body', resp)
                 header = getattr(resp, 'header', None)
@@ -4638,14 +4718,15 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 order_date = getattr(body, 'ordr_dt', datetime.now().strftime('%Y%m%d'))
                 symbol = getattr(body, 'is_cd', '')
                 side_code = getattr(body, 's_b_ccd', '')  # 매매구분
+                side = {'1': 'sell', '2': 'buy'}.get(side_code)
+                if side is None:
+                    logger.warning("Ignoring TC3 fill with unknown side code")
+                    return
                 # TC3에서는 ccls_q, ccls_prc가 체결수량/체결가격
                 quantity = int(getattr(body, 'ccls_q', 0) or 0)
                 price_str = str(getattr(body, 'ccls_prc', '0') or '0')
                 price = float(price_str.strip()) if price_str.strip() else 0.0
                 fill_time = getattr(body, 'ccls_tm', datetime.now().strftime('%H%M%S000'))
-
-                # 매매구분
-                side = 'buy' if side_code == '1' else 'sell'
 
                 logger.info(f"[TC3] 체결: svc_id={svc_id}, order_no={order_no}, symbol={symbol}, side={side}, qty={quantity}, price={price}")
 
@@ -5038,9 +5119,11 @@ class BrokerNodeExecutor(NodeExecutorBase):
         """해외주식 계좌 추적기 시작"""
         accno = ls.overseas_stock().accno()
         real = ls.overseas_stock().real()
-        await real.connect()
-
         tracker = accno.account_tracker(real_client=real)
+        self._active_trackers[f"{context.job_id}_{node_id}"] = {
+            "type": "account_tracker", "tracker": tracker, "ls": ls, "real": real,
+        }
+        await real.connect()
 
         # 수익률 콜백 등록
         def on_pnl_change(pnl_info):
@@ -5064,7 +5147,7 @@ class BrokerNodeExecutor(NodeExecutorBase):
                         "product": product,  # 상품 유형 (overseas_stock)
                     }
 
-            asyncio.create_task(
+            self._start_background_task(context,
                 context.notify_workflow_pnl(
                     broker_node_id=node_id,
                     product=product,
@@ -5072,19 +5155,12 @@ class BrokerNodeExecutor(NodeExecutorBase):
                     current_prices=current_prices,
                     account_positions=account_positions if account_positions else None,
                     currency=pnl_info.currency if hasattr(pnl_info, 'currency') else "USD",
-                )
+                ),
+                notification=True,
             )
 
         tracker.on_account_pnl_change(on_pnl_change)
         await tracker.start()
-        
-        # 활성 트래커 저장 (나중에 정리용)
-        tracker_key = f"{context.job_id}_{node_id}"
-        self._active_trackers[tracker_key] = {
-            "tracker": tracker,
-            "ls": ls,
-            "real": real,
-        }
         
         context.log("info", f"StockAccountTracker started for {node_id}", node_id)
     
@@ -5100,12 +5176,15 @@ class BrokerNodeExecutor(NodeExecutorBase):
         accno = ls.overseas_futureoption().accno()
         market = ls.overseas_futureoption().market()
         real = ls.overseas_futureoption().real()
-        await real.connect()
-
         tracker = accno.account_tracker(
             market_client=market,
             real_client=real,
         )
+        self._active_trackers[f"{context.job_id}_{node_id}"] = {
+            "type": "account_tracker", "tracker": tracker, "ls": ls,
+            "real": real, "market": market,
+        }
+        await real.connect()
 
         # 수익률 콜백 등록
         def on_pnl_change(pnl_info):
@@ -5124,11 +5203,16 @@ class BrokerNodeExecutor(NodeExecutorBase):
                         "buy_price": float(pos_item.entry_price) if hasattr(pos_item, 'entry_price') else 0,
                         "current_price": float(pos_item.current_price) if hasattr(pos_item, 'current_price') else 0,
                         "pnl_rate": float(pos_item.pnl_rate) if hasattr(pos_item, 'pnl_rate') else 0,
-                        # 승수(multiplier)가 반영된 트래커 손익금액을 실어 하류 pnl 집계가
-                        # 자체 산술(승수 무시, 1/N 축소) 대신 이 값을 우선 쓰게 한다.
-                        # 트래커는 REST(AbrdFutsEvalPnlAmt)·실시간 틱(net_pl_usd) 양쪽에서
-                        # pnl_amount 를 승수 반영해 갱신하므로 항상 최신값이다.
-                        "pnl_amount": float(pos_item.pnl_amount) if hasattr(pos_item, 'pnl_amount') else 0,
+                        # A native gross estimate and the raw broker observation
+                        # have separate bases. Missing money never becomes zero.
+                        "pnl_amount": float(pos_item.pnl_amount) if getattr(pos_item, "pnl_amount", None) is not None else None,
+                        "currency": getattr(pos_item, "currency", None),
+                        "pnl_currency": getattr(pos_item, "pnl_currency", None),
+                        "pnl_basis": getattr(pos_item, "pnl_basis", None),
+                        "pnl_status": getattr(pos_item, "pnl_status", "unavailable"),
+                        "pnl_unavailable_reason": getattr(pos_item, "pnl_unavailable_reason", None),
+                        "broker_pnl_amount": float(pos_item.broker_pnl_amount) if getattr(pos_item, "broker_pnl_amount", None) is not None else None,
+                        "broker_pnl_basis": getattr(pos_item, "broker_pnl_basis", None),
                         # FuturesPositionItem 은 side 속성이 없고 is_long 만 있다.
                         # 과거 pos_item.side 는 항상 없어 "long" 으로 오라벨돼 숏이
                         # 승수 역산에서 부호가 뒤집혀 폴백됐다. is_long 으로 정확히
@@ -5138,27 +5222,20 @@ class BrokerNodeExecutor(NodeExecutorBase):
                         "product": product,  # 상품 유형 (overseas_futures)
                     }
 
-            asyncio.create_task(
+            self._start_background_task(context,
                 context.notify_workflow_pnl(
                     broker_node_id=node_id,
                     product=product,
                     provider=provider,
                     current_prices=current_prices,
                     account_positions=account_positions if account_positions else None,
-                    currency=pnl_info.currency if hasattr(pnl_info, 'currency') else "USD",
-                )
+                    currency=getattr(pnl_info, "currency", None),
+                ),
+                notification=True,
             )
 
         tracker.on_account_pnl_change(on_pnl_change)
         await tracker.start()
-        
-        tracker_key = f"{context.job_id}_{node_id}"
-        self._active_trackers[tracker_key] = {
-            "tracker": tracker,
-            "ls": ls,
-            "real": real,
-            "market": market,
-        }
         
         context.log("info", f"FuturesAccountTracker started for {node_id}", node_id)
 
@@ -5173,9 +5250,11 @@ class BrokerNodeExecutor(NodeExecutorBase):
         """국내주식 계좌 추적기 시작"""
         accno = ls.korea_stock().accno()
         real = ls.korea_stock().real()
-        await real.connect()
-
         tracker = accno.account_tracker(real_client=real)
+        self._active_trackers[f"{context.job_id}_{node_id}"] = {
+            "type": "account_tracker", "tracker": tracker, "ls": ls, "real": real,
+        }
+        await real.connect()
 
         # 수익률 콜백 등록
         def on_pnl_change(pnl_info):
@@ -5197,7 +5276,7 @@ class BrokerNodeExecutor(NodeExecutorBase):
                         "product": product,
                     }
 
-            asyncio.create_task(
+            self._start_background_task(context,
                 context.notify_workflow_pnl(
                     broker_node_id=node_id,
                     product=product,
@@ -5205,19 +5284,12 @@ class BrokerNodeExecutor(NodeExecutorBase):
                     current_prices=current_prices,
                     account_positions=account_positions if account_positions else None,
                     currency="KRW",
-                )
+                ),
+                notification=True,
             )
 
         tracker.on_account_pnl_change(on_pnl_change)
         await tracker.start()
-
-        # 활성 트래커 저장 (나중에 정리용)
-        tracker_key = f"{context.job_id}_{node_id}"
-        self._active_trackers[tracker_key] = {
-            "tracker": tracker,
-            "ls": ls,
-            "real": real,
-        }
 
         context.log("info", f"KoreaStockAccountTracker started for {node_id}", node_id)
 
@@ -5701,9 +5773,23 @@ class AccountNodeExecutor(NodeExecutorBase):
                     "price": current_price,  # NewOrderNode 호환
                     "entry_price": entry_price,
                     "current_price": current_price,
-                    "pnl_amount": float(item.AbrdFutsEvalPnlAmt) if item.AbrdFutsEvalPnlAmt else 0.0,
+                    # This REST path has no contract tick metadata. Keep the
+                    # broker amount separate from a native gross estimate.
+                    "pnl_amount": None,
+                    "pnl_currency": None,
+                    "pnl_basis": None,
+                    "pnl_status": "unavailable",
+                    "pnl_unavailable_reason": "native_estimate_requires_contract_metadata",
+                    "broker_pnl_amount": (
+                        float(item.AbrdFutsEvalPnlAmt)
+                        if getattr(item, "AbrdFutsEvalPnlAmt", None) is not None
+                        and "AbrdFutsEvalPnlAmt" in getattr(
+                            item, "model_fields_set", {"AbrdFutsEvalPnlAmt"}
+                        ) else None
+                    ),
+                    "broker_pnl_basis": "broker_reported_unconfirmed",
                     "pnl_rate": pnl_rate,  # 명목가 대비 수익률(%) — StopLoss/ProfitTarget 소비
-                    "currency": item.CrcyCodeVal.strip() if item.CrcyCodeVal else "USD",
+                    "currency": item.CrcyCodeVal.strip() if item.CrcyCodeVal else "",
                 })
                 held_symbols.append({"exchange": "HKEX", "symbol": symbol})
 
@@ -5982,7 +6068,7 @@ class OpenOrdersNodeExecutor(NodeExecutorBase):
 
         today = datetime.now().strftime("%Y%m%d")
 
-        response = await ls.overseas_stock().accno().cosaq00102(
+        request = ls.overseas_stock().accno().cosaq00102(
             COSAQ00102InBlock1(
                 RecCnt=1,
                 QryTpCode="1",      # 1: 역순
@@ -5994,17 +6080,60 @@ class OpenOrdersNodeExecutor(NodeExecutorBase):
                 OrdDt=today,
                 ExecYn="2",         # 2: 미체결
                 CrcyCode="000",     # 000: 전체 통화
-                ThdayBnsAppYn="0",
+                ThdayBnsAppYn="1",
                 LoanBalHldYn="0"
             ),
-        ).req_async()
+        )
+        try:
+            response = await request.req_async()
+        except Exception as exc:
+            error = f"COSAQ00102 request failed: {exc}"
+            context.log("error", error, node_id)
+            result = self._empty_result(error)
+            result.update(reason="fetch_failed", diagnostics={
+                "tr": "COSAQ00102", "status_code": None, "rsp_cd": "", "rsp_msg": "",
+                "error_msg": str(exc), "exception_type": type(exc).__name__,
+            })
+            return result
 
-        if response.error_msg:
-            context.log("error", f"COSAQ00102 error: {response.error_msg}", node_id)
-            return self._empty_result(response.error_msg)
+        diagnostics = {
+            "tr": "COSAQ00102",
+            "status_code": getattr(response, "status_code", None),
+            "rsp_cd": getattr(response, "rsp_cd", ""),
+            "rsp_msg": getattr(response, "rsp_msg", ""),
+            "error_msg": getattr(response, "error_msg", None),
+        }
+
+        def unavailable():
+            details = ", ".join(
+                f"{key}={value}" for key, value in diagnostics.items()
+                if value is not None and value != ""
+            )
+            error = f"COSAQ00102 returned no usable pending-order response: {details}"
+            context.log("error", error, node_id)
+            result = self._empty_result(error)
+            result.update(reason="fetch_failed", diagnostics=diagnostics)
+            return result
+
+        status = diagnostics["status_code"]
+        if response is None or diagnostics["error_msg"] or (status is not None and status >= 400):
+            return unavailable()
+
+        rows = response.block3 or []
+        usable_rows = [item for item in rows if item.OrdNo and item.OrdNo > 0]
+        # The SDK defaults a missing detail block to []; it is not empty-result
+        # evidence. Unknown codes remain unclassified, even with echo blocks.
+        valid_empty = (
+            not rows
+            and diagnostics["rsp_cd"] == "00000"
+            and getattr(response, "block1", None) is not None
+            and getattr(response, "block2", None) is not None
+        )
+        if not usable_rows and not valid_empty:
+            return unavailable()
 
         open_orders = []
-        for item in response.block3 or []:
+        for item in usable_rows:
             order_id = str(item.OrdNo) if item.OrdNo else ""
             if not order_id:
                 continue
@@ -6480,10 +6609,10 @@ class RealAccountNodeExecutor(NodeExecutorBase):
         from decimal import Decimal
         
         try:
-            # 해외선물 수수료 설정 읽기 (계약당 고정 금액, USD)
+            # Retain the legacy constructor setting; native estimates exclude fees.
             futures_fee_per_contract = Decimal(str(config.get("futures_fee_per_contract", 7.5)))
             
-            context.log("info", f"Futures fee per contract: ${float(futures_fee_per_contract):.2f} (one-way)", node_id)
+            context.log("info", "Futures position PnL uses native gross price changes; legacy fee configuration is excluded", node_id)
             
             # 각 클라이언트 준비
             accno = ls.overseas_futureoption().accno()
@@ -6494,12 +6623,12 @@ class RealAccountNodeExecutor(NodeExecutorBase):
             if not await real.is_connected():
                 await real.connect()
             
-            # FuturesAccountTracker 생성 (계약당 수수료 적용)
+            # Preserve the constructor's legacy fee argument for compatibility.
             tracker = accno.account_tracker(
                 market_client=market,
                 real_client=real,
                 refresh_interval=sync_interval_sec,
-                commission_rate=futures_fee_per_contract,  # 계약당 수수료
+                commission_rate=futures_fee_per_contract,
             )
             
             # ReconnectHandler 설정 + C-8 연결 알림/reconcile 훅
@@ -6538,35 +6667,10 @@ class RealAccountNodeExecutor(NodeExecutorBase):
                 if context.is_shutdown:
                     return
                 # 포지션 데이터를 list 형태로 변환 (NewOrderNode 호환, position_data 컨벤션)
-                serialized_positions = []
-                for sym, pos in positions.items():
-                    # realtime_pnl이 None이 아닌 경우만 안전하게 접근
-                    realtime_pnl = getattr(pos, 'realtime_pnl', None)
-                    pnl_rate = 0.0
-                    if realtime_pnl is not None and hasattr(realtime_pnl, 'pnl_rate'):
-                        pnl_rate = float(getattr(realtime_pnl, 'pnl_rate', 0) or 0)
-                    elif hasattr(pos, 'pnl_rate') and pos.pnl_rate is not None:
-                        pnl_rate = float(pos.pnl_rate)
-
-                    is_long = getattr(pos, 'is_long', True)
-                    quantity = int(getattr(pos, 'quantity', 0))
-                    current_price = float(getattr(pos, 'current_price', 0))
-                    serialized_positions.append({
-                        "symbol": sym,
-                        "exchange": getattr(pos, 'exchange_code', ''),
-                        "name": getattr(pos, 'symbol_name', sym),
-                        "direction": "long" if is_long else "short",
-                        "close_side": "sell" if is_long else "buy",
-                        "qty": quantity,
-                        "quantity": quantity,  # NewOrderNode 호환
-                        "price": current_price,  # NewOrderNode 호환
-                        "entry_price": float(getattr(pos, 'entry_price', 0)),
-                        "current_price": current_price,
-                        "pnl_amount": float(getattr(pos, 'pnl_amount', 0) or 0),
-                        "pnl_rate": pnl_rate,
-                        "currency": getattr(pos, 'currency', 'USD'),
-                        "product": "overseas_futures",  # 상품 유형
-                    })
+                serialized_positions = [
+                    self._serialize_futures_tracker_position(sym, pos)
+                    for sym, pos in positions.items()
+                ]
                 
                 # 컨텍스트에 최신 데이터 저장
                 context.set_output(node_id, "positions", serialized_positions)
@@ -6584,11 +6688,8 @@ class RealAccountNodeExecutor(NodeExecutorBase):
                 # 디버깅용 logger
                 from datetime import datetime
                 logger.debug(f"[{datetime.now().strftime('%H:%M:%S')}] 📊 해외선물 포지션 업데이트:")
-                for sym, pos in positions.items():
-                    direction = 'LONG' if getattr(pos, 'is_long', True) else 'SHORT'
-                    exchange = getattr(pos, 'exchange_code', '')
-                    pnl = getattr(pos, 'pnl_amount', 0)
-                    logger.debug(f"  {sym}@{exchange} ({direction}): 현재가=${getattr(pos, 'current_price', 0):.2f}, 손익=${pnl:.2f}")
+                for pos in serialized_positions:
+                    self._log_futures_tracker_position(pos)
                 logger.debug(f"  → 트리거할 노드: {trigger_nodes}")
                 
                 # 이벤트 큐에 추가 (스레드 안전하게)
@@ -6666,9 +6767,7 @@ class RealAccountNodeExecutor(NodeExecutorBase):
             logger.debug(f"보유 종목: {result.get('symbols', [])}")
             logger.debug(f"잔고: {result.get('balance', {})}")
             for pos in result.get('positions', []):
-                sym = pos.get('symbol', '')
-                direction = '롱' if pos.get('direction') == 'long' else '숏'
-                logger.debug(f"  - {sym} ({direction}): 수량={pos.get('quantity')}, 진입가=${pos.get('entry_price', 0):.2f}, 현재가=${pos.get('current_price', 0):.2f}, 손익=${pos.get('pnl_amount', 0):.2f}")
+                self._log_futures_tracker_position(pos)
             logger.debug(f"미체결: {list(result.get('open_orders', {}).keys())}")
             logger.debug(f"{'='*60}\n")
 
@@ -6906,6 +7005,55 @@ class RealAccountNodeExecutor(NodeExecutorBase):
             "open_orders": open_orders,
         }
 
+    @staticmethod
+    def _serialize_futures_tracker_position(symbol, pos) -> Dict[str, Any]:
+        """Preserve the SDK's native estimate and separate unconfirmed broker money."""
+        realtime_pnl = getattr(pos, "realtime_pnl", None)
+        pnl_rate = 0.0
+        if realtime_pnl is not None and hasattr(realtime_pnl, "pnl_rate"):
+            pnl_rate = float(getattr(realtime_pnl, "pnl_rate", 0) or 0)
+        elif getattr(pos, "pnl_rate", None) is not None:
+            pnl_rate = float(pos.pnl_rate)
+
+        is_long = getattr(pos, "is_long", True)
+        quantity = int(getattr(pos, "quantity", 0))
+        current_price = float(getattr(pos, "current_price", 0))
+        pnl_amount = getattr(pos, "pnl_amount", None)
+        broker_pnl_amount = getattr(pos, "broker_pnl_amount", None)
+        return {
+            "symbol": symbol,
+            "exchange": getattr(pos, "exchange_code", ""),
+            "name": getattr(pos, "symbol_name", symbol),
+            "direction": "long" if is_long else "short",
+            "close_side": "sell" if is_long else "buy",
+            "qty": quantity,
+            "quantity": quantity,
+            "price": current_price,
+            "product": "overseas_futures",
+            "entry_price": float(getattr(pos, "entry_price", 0)),
+            "current_price": current_price,
+            "pnl_amount": float(pnl_amount) if pnl_amount is not None else None,
+            "pnl_currency": getattr(pos, "pnl_currency", None),
+            "pnl_basis": getattr(pos, "pnl_basis", None),
+            "pnl_status": getattr(pos, "pnl_status", "unavailable"),
+            "pnl_unavailable_reason": getattr(pos, "pnl_unavailable_reason", None),
+            "broker_pnl_amount": float(broker_pnl_amount) if broker_pnl_amount is not None else None,
+            "broker_pnl_basis": getattr(pos, "broker_pnl_basis", "broker_reported_unconfirmed"),
+            "pnl_rate": pnl_rate,
+            "currency": getattr(pos, "currency", ""),
+        }
+
+    @staticmethod
+    def _log_futures_tracker_position(pos) -> None:
+        """Quoted prices have no dollar prefix; unavailable monetary values are safe."""
+        logger.debug(
+            "Futures position %s@%s (%s): quantity=%s entry_quote=%s current_quote=%s "
+            "position_currency=%s pnl_amount=%s pnl_currency=%s pnl_basis=%s pnl_status=%s",
+            pos["symbol"], pos["exchange"], pos["direction"], pos["quantity"],
+            pos["entry_price"], pos["current_price"], pos["currency"],
+            pos["pnl_amount"], pos["pnl_currency"], pos["pnl_basis"], pos["pnl_status"],
+        )
+
     def _get_overseas_futures_tracker_data(self, tracker) -> Dict[str, Any]:
         """해외선물 Tracker에서 현재 데이터 추출
 
@@ -6916,35 +7064,7 @@ class RealAccountNodeExecutor(NodeExecutorBase):
         positions = []
         symbols = []
         for symbol, pos in tracker.get_positions().items():
-            # realtime_pnl이 None이 아닌 dict인 경우만 .get() 호출
-            realtime_pnl = getattr(pos, 'realtime_pnl', None)
-            pnl_rate = 0.0
-            if realtime_pnl is not None and hasattr(realtime_pnl, 'pnl_rate'):
-                pnl_rate = float(getattr(realtime_pnl, 'pnl_rate', 0) or 0)
-            elif hasattr(pos, 'pnl_rate') and pos.pnl_rate is not None:
-                pnl_rate = float(pos.pnl_rate)
-
-            is_long = getattr(pos, 'is_long', True)
-            quantity = int(getattr(pos, 'quantity', 0))
-            current_price = float(getattr(pos, 'current_price', 0))
-
-            positions.append({
-                "symbol": symbol,
-                "exchange": getattr(pos, 'exchange_code', ''),
-                "name": getattr(pos, 'symbol_name', symbol),
-                "direction": "long" if is_long else "short",
-                "close_side": "sell" if is_long else "buy",
-                # REST 스냅샷 갈래(_ls_futureoption_with_tracker)와 같은 키 집합
-                "qty": quantity,
-                "quantity": quantity,  # qty → quantity (NewOrderNode 호환)
-                "price": current_price,  # current_price → price (NewOrderNode 호환)
-                "product": "overseas_futures",
-                "entry_price": float(getattr(pos, 'entry_price', 0)),
-                "current_price": current_price,
-                "pnl_amount": float(getattr(pos, 'pnl_amount', 0) or 0),
-                "pnl_rate": pnl_rate,
-                "currency": getattr(pos, 'currency', 'USD'),
-            })
+            positions.append(self._serialize_futures_tracker_position(symbol, pos))
             symbols.append(symbol)
         
         # balance 추출
@@ -10603,9 +10723,11 @@ class MarketDataNodeExecutor(NodeExecutorBase):
             api = ls.overseas_stock()
             
             values = []
+            failures = []
             
             for symbol_entry in symbols:
                 exchange, symbol = "", ""  # handler-safe defaults: the except below must never touch an unassigned name (UnboundLocalError masked the real cause)
+                attempts = []
                 try:
                     # 거래소와 심볼 추출
                     exchange = symbol_entry.get("exchange", "NASDAQ")
@@ -10641,12 +10763,34 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                             symbol=symbol,
                         )
 
-                        response = api.market().g3101(body=body).req()
-                        if response and response.block:
+                        try:
+                            response = api.market().g3101(body=body).req()
+                            attempt = {
+                                "tr": "g3101",
+                                "exchange_code": exchange_code,
+                                "status_code": getattr(response, "status_code", None),
+                                "rsp_cd": getattr(response, "rsp_cd", ""),
+                                "rsp_msg": getattr(response, "rsp_msg", ""),
+                                "error_msg": getattr(response, "error_msg", None),
+                            }
+                        except Exception as exc:
+                            response = None
+                            attempt = {
+                                "tr": "g3101", "exchange_code": exchange_code,
+                                "status_code": None, "rsp_cd": "", "rsp_msg": "",
+                                "error_msg": str(exc), "exception_type": type(exc).__name__,
+                            }
+                        attempts.append(attempt)
+                        status = attempt["status_code"]
+                        if (
+                            response is not None and getattr(response, "block", None) is not None
+                            and not attempt["error_msg"]
+                            and not (status is not None and status >= 400)
+                        ):
                             used_code = exchange_code
                             break
 
-                    if response and response.block:
+                    if used_code is not None:
                         out_block = response.block
                         from datetime import datetime
 
@@ -10678,11 +10822,36 @@ class MarketDataNodeExecutor(NodeExecutorBase):
                         context.log("debug", f"Fetched {exchange}:{symbol}: price={out_block.price}", node_id)
                     else:
                         context.log("warning", f"No data for {exchange}:{symbol}", node_id)
+                        failures.append({"symbol": symbol, "exchange": exchange, "attempts": attempts})
                         
                 except Exception as e:
                     context.log("warning", f"Failed to fetch {exchange}:{symbol or symbol_entry!r}: {e}", node_id)
+                    failures.append({
+                        "symbol": symbol, "exchange": exchange, "attempts": attempts,
+                        "error_msg": str(e), "exception_type": type(e).__name__,
+                    })
                     continue
-            
+
+            if failures:
+                failure_reason = "g3101 quote unavailable: " + "; ".join(
+                    f"{failure['exchange']}:{failure['symbol']}: "
+                    + "; ".join(
+                        ", ".join(f"{key}={value}" for key, value in attempt.items()
+                                  if value is not None and value != "")
+                        for attempt in failure["attempts"]
+                    )
+                    + (f"; error_msg={failure['error_msg']}" if failure.get("error_msg") else "")
+                    for failure in failures
+                )
+                if not values:
+                    result = self._empty_result(failure_reason)
+                    result.update(reason="fetch_failed", failures=failures)
+                    return result
+                return {
+                    "values": values, "_partial_failure": True,
+                    "_failure_reason": failure_reason, "failures": failures,
+                }
+
             return {"values": values}
             
         except ImportError as e:
@@ -14172,6 +14341,28 @@ class NewOrderNodeExecutor(NodeExecutorBase):
         context: ExecutionContext,
         **kwargs,
     ) -> Dict[str, Any]:
+        """Expose the catalog's result rows after the final order state is known."""
+        outputs = await self._execute_order(node_id, node_type, config, context, **kwargs)
+        inner = outputs.get("order_result")
+        if isinstance(inner, dict):
+            row = {"order_id": "", **copy.deepcopy(inner)}
+            row["order_id"] = outputs.get("order_id") or row.get("order_id") or ""
+        else:
+            # Dry runs keep their legacy flat envelope. Do not copy requested
+            # config/connection data or invent acceptance/fill evidence.
+            row = {key: outputs[key] for key in ("order_id", "status", "dry_run") if key in outputs}
+        # A list matches BaseOrderNode._outputs and auto-iteration's existing
+        # result merge. Legacy keys and their payloads remain untouched.
+        return {**outputs, "result": [row]}
+
+    async def _execute_order(
+        self,
+        node_id: str,
+        node_type: str,
+        config: Dict[str, Any],
+        context: ExecutionContext,
+        **kwargs,
+    ) -> Dict[str, Any]:
         """신규 주문 실행"""
 
         # dry_run: LS API 미호출, 모의 응답 반환
@@ -14201,6 +14392,13 @@ class NewOrderNodeExecutor(NodeExecutorBase):
 
         # === 1. Connection 확인 ===
         broker_connection = config.get("connection")
+        if "Futures" in node_type and isinstance(broker_connection, str):
+            # Explicit tool/standalone bindings retain their route instead of
+            # being overwritten by automatic first-broker selection.
+            broker_connection = evaluate_all_bindings(
+                {"connection": broker_connection}, context, node_id,
+            ).get("connection")
+            config = {**config, "connection": broker_connection}
         if not broker_connection:
             context.log("error", f"{node_type}: connection이 자동 주입되지 않았습니다. 매칭되는 BrokerNode를 확인하세요.", node_id)
             return self._error_result("Missing connection - no matching BrokerNode found")
@@ -14214,7 +14412,7 @@ class NewOrderNodeExecutor(NodeExecutorBase):
             product = "korea_stock"
         elif node_type.startswith("Stock"):
             product = "overseas_stock"
-        elif node_type.startswith("Futures"):
+        elif "Futures" in node_type:
             product = "overseas_futures"
         else:
             product = broker_connection.get("product", "overseas_stock")
@@ -14286,13 +14484,36 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                     f"Drawdown exceeds {drawdown_threshold}% threshold"
                 )
 
+        lifecycle_metadata = None
+        if product in FUTURES_PRODUCTS:
+            try:
+                lifecycle_metadata = self._futures_lifecycle_metadata(
+                    context, node_id, broker_connection, normalized_order, side, order_type,
+                    kwargs.get("order_invocation_id", "main"), kwargs.get("order_iteration_index"),
+                )
+                prior = context._order_lifecycle_operations.get(lifecycle_metadata.operation_key)
+                if prior and prior.get("accepted"):
+                    return self._accepted_replay(prior["accepted"])
+                credential = exact_futures_credential(broker_connection, context)
+            except Exception as exc:
+                return self._error_result(str(exc))
+        else:
+            credential = context.get_credential()
+
+        registry_item = normalized_order
+        if lifecycle_metadata is not None:
+            registry_item = {"operation_key": lifecycle_metadata.operation_key}
+
         # === 3.7. A-4: idempotency 체크 (opt-in: enable_order_idempotency=True) ===
         # 주문이 이미 제출된 경우 (체크포인트 복구 후 재실행 등) LS 재전송 없이
         # 저장된 결과를 반환한다. dry_run / paper_trading은 자동 우회.
         existing_order = context.check_order_already_submitted(
             node_id=node_id,
-            item=normalized_order,
+            item=registry_item,
         )
+        if existing_order is None and lifecycle_metadata is not None:
+            # Preserve conservative replay of pre-lifecycle checkpoint records.
+            existing_order = context.check_order_already_submitted(node_id=node_id, item=normalized_order)
         if existing_order is not None:
             _inner = existing_order.get("order_result")
             _inner = _inner if isinstance(_inner, dict) else {}
@@ -14313,7 +14534,6 @@ class NewOrderNodeExecutor(NodeExecutorBase):
             return replayed
 
         # === 4. LS 로그인 ===
-        credential = context.get_credential()
         if not credential:
             context.log("error", f"{node_type}: Credential not found", node_id)
             return self._error_result("Missing credentials")
@@ -14341,7 +14561,8 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                 )
             elif product in ("overseas_futures", "overseas_futureoption"):
                 order_result = await self._execute_overseas_futures(
-                    ls, normalized_order, side, order_type, config, context, node_id
+                    ls, normalized_order, side, order_type, config, context, node_id,
+                    lifecycle_metadata=lifecycle_metadata,
                 )
             elif product == "korea_stock":
                 order_result = await self._execute_korea_stock(
@@ -14368,6 +14589,14 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                 if isinstance(inner, dict):
                     inner["fractional_remainder"] = fractional_remainder
 
+            # Persist the legacy acceptance registry before any fill wait too.
+            frozen = (context._order_lifecycle_operations.get(lifecycle_metadata.operation_key)
+                      if lifecycle_metadata is not None else None)
+            if not frozen or not frozen.get("accepted"):
+                context.record_order_submitted(
+                    node_id=node_id, order_result=order_result, item=registry_item,
+                )
+
             # === 5.4. DEF-27: 접수(order number) ≠ 체결. 주문 TR 응답은 주문번호만
             # 돌려주므로, 방금 접수된 주문의 체결 여부를 best-effort 로 재조회해
             # order_result.status 를 submitted → filled / partially_filled / open
@@ -14377,20 +14606,21 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                 isinstance(order_result, dict)
                 and isinstance(order_result.get("order_result"), dict)
                 and order_result["order_result"].get("success") is True
+                # The app session journal owns canonical futures history reads.
+                # Its accepted response remains submitted until reconciliation.
+                and not (product in FUTURES_PRODUCTS and context.order_lifecycle_handler is not None)
             ):
                 await self._confirm_order_fill(
                     ls, product, order_type, order_result, config, context, node_id
                 )
 
-            # === 5.5. A-4: 성공 주문 idempotency 레지스트리에 기록 ===
-            context.record_order_submitted(
-                node_id=node_id,
-                order_result=order_result,
-                item=normalized_order,
-            )
             return order_result
 
         except Exception as e:
+            if lifecycle_metadata is not None:
+                accepted = context._order_lifecycle_operations.get(lifecycle_metadata.operation_key, {}).get("accepted")
+                if accepted:
+                    return copy.deepcopy(accepted)
             context.log("error", f"{node_type}: Unexpected error: {e}", node_id)
             return self._error_result(str(e))
 
@@ -15210,131 +15440,176 @@ class NewOrderNodeExecutor(NodeExecutorBase):
             context.log("debug", f"CIDBQ02400 fill query exception: {e}", node_id)
             return 0, 0.0
 
+    @staticmethod
+    def _accepted_replay(output):
+        replay = copy.deepcopy(output)
+        replay["idempotent_replay"] = True
+        replay["order_result"]["idempotent_replay"] = True
+        return replay
+
+    @staticmethod
+    def _futures_lifecycle_metadata(context, node_id, connection, order, side, order_type, invocation_id, iteration_index=None):
+        from dataclasses import replace
+        from datetime import date
+        from decimal import Decimal
+
+        cycle = getattr(context._workflow_job, "_order_cycle", 0)
+        iteration = iteration_index
+        if iteration is None:
+            iteration = context._iteration_index if context._iteration_item is not None else -1
+        key = operation_key(context.job_id, node_id, cycle, iteration, invocation_id)
+        metadata = OrderLifecycleMetadata(
+            operation_key=key, job_id=context.job_id, workflow_id=context.workflow_id,
+            node_id=node_id, cycle=cycle, iteration_index=iteration, invocation_id=invocation_id,
+            broker_node_id=connection["broker_node_id"], credential_id=connection["credential_id"],
+            product=connection["product"], paper_trading=connection["paper_trading"],
+            symbol=order["symbol"], exchange=order["exchange"], side=side, order_type=order_type,
+            quantity=Decimal(str(order["quantity"])),
+            price=Decimal("0") if order_type == "market" else Decimal(str(order["price"])),
+            broker_order_date=date.today(),
+        )
+        prior = context._order_lifecycle_operations.get(key)
+        if prior:
+            # A retry after midnight retains the exact original request date.
+            metadata = replace(metadata, broker_order_date=prior["metadata"].broker_order_date)
+            if metadata != prior["metadata"]:
+                raise ValueError("Order invocation facts conflict with its original operation")
+        return metadata
+
+    @staticmethod
+    def _call_order_lifecycle(handler, method, *args):
+        import inspect
+        result = getattr(handler, method)(*args)
+        if inspect.isawaitable(result):
+            if inspect.iscoroutine(result):
+                result.close()
+            raise TypeError("Order lifecycle handlers must be synchronous local operations")
+        return result
+
     async def _execute_overseas_futures(
-        self,
-        ls,
-        order: Dict[str, Any],
-        side: str,
-        order_type: str,
-        config: Dict[str, Any],
-        context: ExecutionContext,
-        node_id: str,
+        self, ls, order, side, order_type, config, context, node_id,
+        lifecycle_metadata=None,
     ) -> Dict[str, Any]:
-        """해외선물 신규주문 실행 (CIDBT00100) - 단일 종목"""
+        """Submit CIDBT00100 once per invocation; persist ACK before yielding."""
+        from datetime import datetime as dt, timezone
         from programgarden_finance.ls.overseas_futureoption.order.CIDBT00100.blocks import CIDBT00100InBlock1
+        from programgarden_core.models.order_diagnostics import ORDER_ACCEPTED_RSP_CDS
+        from programgarden_finance.ls.overseas_futureoption.extension.execution_history import normalize_broker_identity
 
-        from datetime import datetime as dt
-
-        symbol = order["symbol"]
-        exchange = order["exchange"]
-        qty = order["quantity"]
-        price = order["price"]
-
-        # 매매구분코드: 1=매도, 2=매수
-        bns_tp_code = "1" if side == "sell" else "2"
-
-        # 주문유형코드: 1=시장가, 2=지정가
-        abrd_futs_ord_ptn_code = self.FUTURES_ORDER_TYPE_CODES.get(order_type, "2")
-
-        # 공통 설정
-        expiry_month = config.get("expiry_month", "")
-        today = dt.now().strftime("%Y%m%d")
-
-        # 시장가 주문은 가격 0으로 전송
-        if abrd_futs_ord_ptn_code == "1":  # 시장가
-            price = 0.0
-
+        symbol, exchange, qty = order["symbol"], order["exchange"], order["quantity"]
+        code = self.FUTURES_ORDER_TYPE_CODES.get(order_type, "2")
+        price = 0.0 if code == "1" else order["price"]
+        handler = context.order_lifecycle_handler
+        metadata = lifecycle_metadata
         try:
+            if metadata is None:
+                connection = config.get("connection") or {}
+                exact_futures_credential(connection, context)
+                metadata = self._futures_lifecycle_metadata(
+                    context, node_id, connection, order, side, order_type, "main",
+                )
+            key = metadata.operation_key
+            prior = context._order_lifecycle_operations.get(key)
+            if prior:
+                if prior.get("accepted"):
+                    return self._accepted_replay(prior["accepted"])
+                raise RuntimeError("Order operation is already prepared; reconcile before another submission")
+            # Mark uncertain before the hook: even a disk error must not silently
+            # retry transport. The handler can have committed before raising.
+            entry = {"metadata": metadata, "accepted": None}
+            context._order_lifecycle_operations[key] = entry
+            if handler is not None:
+                saved = self._call_order_lifecycle(handler, "prepare", metadata)
+                if saved is not None:
+                    if not isinstance(saved, Mapping) or saved.get("success") is not True or normalize_broker_identity(saved.get("order_id")) is None:
+                        raise ValueError("Lifecycle prepare returned an invalid accepted result")
+                    output = {"order_id": saved["order_id"], "order_result": copy.deepcopy(dict(saved))}
+                    entry["accepted"] = copy.deepcopy(output)
+                    return self._accepted_replay(output)
+            request_date = metadata.broker_order_date.strftime("%Y%m%d")
             order_api = ls.overseas_futureoption().order().CIDBT00100(
                 CIDBT00100InBlock1(
-                    RecCnt=1,
-                    OrdDt=today,
-                    IsuCodeVal=symbol,
-                    FutsOrdTpCode="1",  # 1=신규
-                    BnsTpCode=bns_tp_code,
-                    AbrdFutsOrdPtnCode=abrd_futs_ord_ptn_code,
-                    CrcyCode="",
-                    OvrsDrvtOrdPrc=price,
-                    CndiOrdPrc=0.0,
-                    OrdQty=qty,
-                    PrdtCode="000000",
-                    DueYymm=expiry_month,
-                    ExchCode=exchange,
+                    RecCnt=1, OrdDt=request_date, IsuCodeVal=symbol,
+                    FutsOrdTpCode="1", BnsTpCode="1" if side == "sell" else "2",
+                    AbrdFutsOrdPtnCode=code, CrcyCode="", OvrsDrvtOrdPrc=price,
+                    CndiOrdPrc=0.0, OrdQty=qty, PrdtCode="000000",
+                    DueYymm=config.get("expiry_month", ""), ExchCode=exchange,
                 ),
             )
-
             response = await order_api.req_async()
-
-            # 디버그: 응답 전체 출력
-            context.log("debug", f"CIDBT00100 response: rsp_cd={response.rsp_cd}, rsp_msg={response.rsp_msg}", node_id)
-
-            if response.error_msg:
-                reject = map_reject_code(
-                    "overseas_futures", response.rsp_cd or "", response.error_msg
-                )
-                context.log(
-                    "warning",
-                    f"Order failed: {symbol} - {response.error_msg} ({reject.cause})",
-                    node_id,
-                )
-                await self._notify_order_reject(
-                    context, node_id, symbol, reject,
-                    node_type="OverseasFuturesNewOrderNode",
-                )
-                return self._order_result(
-                    False, symbol, exchange, side, qty, price,
-                    response.error_msg, reject_info=reject,
-                )
-
-            order_no = ""
-            if response.block2:
-                # 해외선물 주문번호 필드: OvrsFutsOrdNo (str, default "")
-                order_no = str(response.block2.OvrsFutsOrdNo) if hasattr(response.block2, "OvrsFutsOrdNo") and response.block2.OvrsFutsOrdNo else ""
-
-            # 주문번호가 없으면 경고 + 기록 거부
-            if not order_no:
-                msg = response.rsp_msg or "주문번호 없음"
-                context.log("warning", f"Futures order submitted but no OrderNo returned: {symbol} - {msg}", node_id)
-                # 🔴 종전에는 무조건 "장 마감 / 브로커 지연" 이라고 단정했다. 전제는
-                # "rsp_cd 는 성공인데 OrdNo 만 없다" 였는데, 2026-08-19 실계좌 실측에서
-                # LS 의 업무 거부는 **error_msg 가 비고 rsp_cd 에 오류 코드가 실린 채
-                # 접수 블록 자체가 없이** 온다는 게 확인됐다(02201 예수금 부족 등).
-                # 그래서 이 분기가 실제 거부를 삼키고 틀린 원인을 말하고 있었다.
-                reject = diagnose_missing_order_no(
-                    "overseas_futures", response.rsp_cd or "", msg
-                )
-                await self._notify_order_reject(
-                    context, node_id, symbol, reject,
-                    node_type="OverseasFuturesNewOrderNode",
-                )
-                return self._order_result(
-                    False, symbol, exchange, side, qty, price,
-                    f"Empty OrderNo: {msg}", reject_info=reject,
-                )
-
-            context.log("info", f"Futures order submitted: {symbol} {side} {qty}@{price} → order_id={order_no}", node_id)
-
-            # Record workflow order for FIFO tracking (OrderNo가 있는 경우만)
-            context.record_workflow_order(
-                order_no=order_no,
-                order_date=dt.now().strftime("%Y%m%d"),
-                symbol=symbol,
-                exchange=exchange,
-                side=side,
-                quantity=qty,
-                price=price,
-                node_id=node_id,
+        except Exception as exc:
+            output = self._order_result(
+                False, symbol, exchange, side, qty, price, str(exc),
+                reject_info=map_reject_code("overseas_futures", "", str(exc)),
             )
+            output["order_result"]["recovery_status"] = "prepared_or_uncertain"
+            return output
 
-            return self._order_result(True, symbol, exchange, side, qty, price, None, order_no)
-
-        except Exception as e:
-            context.log("warning", f"Futures order exception: {symbol} - {e}", node_id)
-            # 예외는 rsp_cd 가 없으므로 known=False 폴백으로 동봉(stock 경로와 일관).
-            reject = map_reject_code("overseas_futures", "", str(e))
-            return self._order_result(
-                False, symbol, exchange, side, qty, price, str(e), reject_info=reject,
+        # An actual order number is acceptance evidence. Preserve it even if
+        # ancillary response diagnostics or local bookkeeping subsequently fail.
+        block = getattr(response, "block2", None)
+        raw_order_id = getattr(block, "OvrsFutsOrdNo", "")
+        order_id = str(raw_order_id or "").strip()
+        valid_ack = normalize_broker_identity(raw_order_id) is not None
+        response_fields = {
+            "response_code": response.rsp_cd,
+            "response_message": response.rsp_msg,
+            "broker_order_date": metadata.broker_order_date.isoformat(),
+            "order_date_basis": metadata.order_date_basis,
+        }
+        if valid_ack:
+            output = self._order_result(True, symbol, exchange, side, qty, price, None, order_id)
+            output["order_result"].update(
+                response_fields, order_id=order_id, accepted_at=dt.now(timezone.utc).isoformat(),
             )
+            # No await and no external callback may precede this unconditional
+            # freeze. Cancellation during fill waiting will replay this ACK.
+            entry["accepted"] = copy.deepcopy(output)
+            if handler is not None:
+                try:
+                    additions = self._call_order_lifecycle(handler, "accepted", metadata, copy.deepcopy(output["order_result"]))
+                    if additions is not None:
+                        if not isinstance(additions, Mapping) or set(additions) - {
+                            "client_order_key", "order_observed_at", "recovery_status",
+                        }:
+                            raise ValueError("Lifecycle accepted returned non-additive result fields")
+                        output["order_result"].update(additions)
+                except Exception:
+                    output["order_result"]["recovery_status"] = "persistence_failed"
+            entry["accepted"] = copy.deepcopy(output)
+            # Legacy stores remain best effort; their failure cannot revoke ACK.
+            try:
+                context.record_workflow_order(
+                    order_no=order_id, order_date=request_date, symbol=symbol,
+                    exchange=exchange, side=side, quantity=qty, price=price, node_id=node_id,
+                )
+                context.record_order_submitted(
+                    node_id=node_id, order_result=output,
+                    item={"operation_key": metadata.operation_key},
+                )
+            except Exception:
+                output["order_result"]["recovery_status"] = "persistence_failed"
+                entry["accepted"] = copy.deepcopy(output)
+            return output
+
+        message = response.error_msg or response.rsp_msg or "Empty OrderNo"
+        reject = diagnose_missing_order_no("overseas_futures", response.rsp_cd or "", message)
+        error = message if response.error_msg else f"Empty OrderNo: {message}"
+        output = self._order_result(False, symbol, exchange, side, qty, price, error, reject_info=reject)
+        output["order_result"].update(response_fields)
+        # Use only the already documented rejection table. A missing ID, unknown
+        # response, accepted code, or transport exception is not a rejection proof.
+        definitive = bool(response.rsp_cd) and response.rsp_cd not in ORDER_ACCEPTED_RSP_CDS and reject.known
+        output["order_result"]["recovery_status"] = "rejected" if definitive else "prepared_or_uncertain"
+        if definitive and handler is not None:
+            try:
+                self._call_order_lifecycle(handler, "rejected", metadata, copy.deepcopy(output["order_result"]))
+            except Exception:
+                output["order_result"]["recovery_status"] = "persistence_failed"
+        await self._notify_order_reject(
+            context, node_id, symbol, reject, node_type="OverseasFuturesNewOrderNode",
+        )
+        return output
 
     def _check_exclusion_list(
         self,
@@ -16797,6 +17072,7 @@ class AIAgentToolExecutor:
         tool_name: str,
         args: Dict[str, Any],
         agent_node_id: str,
+        tool_call_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """tool 엣지로 연결된 노드를 Tool로 호출.
 
@@ -16830,6 +17106,9 @@ class AIAgentToolExecutor:
                 processed_args[k] = v
 
         # 노드의 고정 config + LLM이 넘긴 args 병합
+        if tool_node_type == "OverseasFuturesNewOrderNode":
+            for key in ("connection", "credential_id", "broker_node_id"):
+                processed_args.pop(key, None)
         tool_config.update(processed_args)
 
         # Broker connection 자동 주입 (product_scope 매칭)
@@ -16844,6 +17123,7 @@ class AIAgentToolExecutor:
             node_type=tool_node_type,
             config=tool_config,
             context=self.context,
+            order_invocation_id=f"tool:{agent_node_id}:{tool_call_id or 'unidentified'}",
         )
 
         return result
@@ -16857,6 +17137,8 @@ class AIAgentToolExecutor:
         """Tool 노드에 Broker connection 자동 주입."""
         if node.product_scope == "all":
             return config
+        if node.product_scope in FUTURES_PRODUCTS:
+            return inject_futures_connection(node, config, self.workflow, self.context)
 
         for other_id, other_node in self.workflow.nodes.items():
             if other_node.product_scope == "all":
@@ -17401,6 +17683,7 @@ class AIAgentNodeExecutor(NodeExecutorBase):
                         tool_name=tool_name,
                         args=tool_args,
                         agent_node_id=node_id,
+                        tool_call_id=tc.get("id"),
                     )
                     tool_call_count += 1
                     tool_duration = (_time.monotonic() - tool_start) * 1000
@@ -18030,6 +18313,11 @@ class WorkflowExecutor:
         # 그대로 동작한다(받는 키워드만 골라 넘긴다).
         # Left None for standalone/public usage (unchanged self-issue path).
         self.ls_token_provider = None
+        self.order_lifecycle_handler = None
+
+    def set_order_lifecycle_handler(self, handler) -> None:
+        """Set a synchronous local journal capability, independent of the DSL."""
+        self.order_lifecycle_handler = handler
 
     def set_ls_token_provider(self, provider) -> None:
         """Configure the opt-in LS token provider (Verified League §3.2.3).
@@ -18264,6 +18552,7 @@ class WorkflowExecutor:
             workflow_nodes=resolved.nodes,
             storage_dir=storage_dir,
             ls_token_provider=self.ls_token_provider,
+            order_lifecycle_handler=self.order_lifecycle_handler,
         )
         # Propagate the CodeNode gate to the context so CodeNodeExecutor can read it.
         context.allow_code_node = self.allow_code_node
@@ -18612,6 +18901,7 @@ class WorkflowExecutor:
             workflow_nodes=resolved.nodes,
             storage_dir=storage_dir,
             ls_token_provider=self.ls_token_provider,
+            order_lifecycle_handler=self.order_lifecycle_handler,
         )
 
         if listeners:
@@ -18736,6 +19026,8 @@ class WorkflowExecutor:
         plugin: Optional[Callable] = None,
         fields: Optional[Dict[str, Any]] = None,
         workflow: Optional["ResolvedWorkflow"] = None,
+        order_invocation_id: str = "main",
+        order_iteration_index: Optional[int] = None,
     ) -> Dict[str, Any]:
         """Execute single node"""
         executor = self._executors.get(node_type)
@@ -18755,6 +19047,8 @@ class WorkflowExecutor:
             fields=fields,
             workflow=workflow,
             _executors=self._executors,
+            order_invocation_id=order_invocation_id,
+            order_iteration_index=order_iteration_index,
         )
 
     def get_job(self, job_id: str) -> Optional["WorkflowJob"]:
@@ -18872,6 +19166,9 @@ class WorkflowJob:
         # sibling form so chatbot consumers get the same shape regardless of mode.
         from programgarden_core import ErrorInfo as _ErrorInfo  # type: ignore[import-not-found]
         self._node_error_infos: Dict[str, _ErrorInfo] = {}  # node_id -> structured ErrorInfo
+        # Direct main-flow order failures in this pass, separate from historical
+        # diagnostics and errors handled inside SplitNode/auto-iteration.
+        self._main_flow_order_failures: Set[str] = set()
         self._restore_mode: bool = False
         self._restore_checkpoint: Optional[Dict[str, Any]] = None
         self._workflow_json_hash: Optional[str] = None  # 워크플로우 정의 해시
@@ -19110,8 +19407,16 @@ class WorkflowJob:
                     f"persistent_tasks: {len(self.context._persistent_tasks)})"
                 )
 
-            # Phase 3: Mark completed if no failures
-            if not self.context.is_failed:
+            # Cycle continuation is intentional for scheduled/resident jobs.
+            # A one-shot run has no future cycle to recover an unhandled order
+            # rejection; successful downstream nodes do not erase that failure.
+            # Explicit stop/cancellation keeps its existing lifecycle semantics.
+            unhandled_order_failure = (
+                not has_event_sources
+                and self.context.is_running
+                and bool(self._main_flow_order_failures)
+            )
+            if not self.context.is_failed and not unhandled_order_failure:
                 self.status = "completed"
             else:
                 self.status = "failed"
@@ -19251,6 +19556,7 @@ class WorkflowJob:
             skip_nodes: 복구 모드에서 이미 완료된 노드 ID 집합 (스킵)
         """
         skip_nodes = skip_nodes or set()
+        self._main_flow_order_failures.clear()
         _safe_print(f"🔄 Executing main flow: {self.workflow.execution_order}")
 
         # === Item-based execution setup ===
@@ -19472,7 +19778,8 @@ class WorkflowJob:
                     node.node_type, input_data, config,
                 )
 
-                if should_iterate and node_id not in branch_nodes:
+                auto_iterated = should_iterate and node_id not in branch_nodes
+                if auto_iterated:
                     # 자동 iterate 실행 (SplitNode 브랜치가 아닌 경우에만)
                     outputs = await self._execute_with_auto_iterate(
                         node_id=node_id,
@@ -19545,6 +19852,8 @@ class WorkflowJob:
                 # it: FAILED node state + job stats + an error log line. no_signal
                 # ("no trading signal today") is a normal no-op and is excluded.
                 order_failure = _order_failure_from_outputs(outputs)
+                if order_failure and not auto_iterated:
+                    self._main_flow_order_failures.add(node_id)
 
                 # DEF-26/DEF-27: wire the previously-dead orders_placed /
                 # orders_filled counters. placed = orders this node actually
@@ -19947,6 +20256,7 @@ class WorkflowJob:
                     plugin=node.plugin,
                     fields=node.fields,
                     workflow=self.workflow,
+                    order_iteration_index=idx,
                 )
                 all_results.append(outputs)
             except Exception as e:
@@ -20505,6 +20815,8 @@ class WorkflowJob:
                 plugin=node.plugin,
                 fields=node.fields,
                 workflow=self.workflow,
+                order_invocation_id=f"split:{branch_scope}",
+                order_iteration_index=index,
             )
 
             # Store outputs
@@ -20561,6 +20873,13 @@ class WorkflowJob:
                         last_had_public = False
                     else:
                         result = row
+                elif node.node_type in (
+                    "OverseasStockNewOrderNode", "OverseasFuturesNewOrderNode", "KoreaStockNewOrderNode",
+                ) and isinstance(public.get("order_result"), dict):
+                    # Keep implicit Split collection backward compatible. The
+                    # new catalog result list must not nest each legacy row.
+                    # Explicit nodes.<order>.result bindings still read the list.
+                    result = public["order_result"]
                 else:
                     result = next(
                         (public[p] for p in _BRANCH_PAYLOAD_PORTS if public.get(p) is not None),
@@ -20684,6 +21003,8 @@ class WorkflowJob:
         # 1. 범용 노드(product_scope=ALL)는 connection 불필요
         if node.product_scope == "all":
             return config
+        if node.product_scope in FUTURES_PRODUCTS:
+            return inject_futures_connection(node, config, self.workflow, self.context)
 
         # 3. 매칭되는 BrokerNode의 connection 출력 검색
         #    product_scope + broker_provider 둘 다 매칭되어야 주입
@@ -21267,7 +21588,8 @@ class WorkflowJob:
         self.context.resume()
 
     async def _cleanup_broker_fill_subscriptions(self) -> None:
-        """BrokerNode의 fill subscription SDK 콜백 정리"""
+        """Stop all broker-owned work before cleaning up the remaining nodes."""
+        self.context.stop()
         try:
             broker_executor = BrokerNodeExecutor()
             await broker_executor.cleanup_fill_subscriptions(self.job_id)

--- a/src/programgarden/programgarden/futures_pnl.py
+++ b/src/programgarden/programgarden/futures_pnl.py
@@ -1,0 +1,98 @@
+"""Preserve currency-scoped estimates without inventing workflow accounting.
+
+Current positions and a native gross price-change estimate do not establish
+realized PnL, opening capital, workflow ownership, fees or account return.
+The legacy workflow/total scalars therefore remain unavailable. Estimates and
+the original broker observations remain visible as separate metadata.
+"""
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+
+GROSS_BASIS = "estimated_gross_price_change"
+WORKFLOW_SCALARS = tuple(
+    f"{scope}_{metric}"
+    for scope in ("workflow", "other", "total")
+    for metric in ("pnl_rate", "pnl_amount", "eval_amount", "buy_amount")
+)
+
+
+def unavailable_workflow_pnl() -> dict[str, Any]:
+    return dict.fromkeys(WORKFLOW_SCALARS) | {
+        "workflow_positions": [], "other_positions": [],
+        "trust_score": 0, "anomaly_count": 0,
+    }
+
+
+def unavailable_account_pnl() -> dict[str, None]:
+    return dict.fromkeys(
+        [f"account_total_{metric}" for metric in
+         ("pnl_rate", "pnl_amount", "eval_amount", "buy_amount")]
+        + [f"account_{product}_{metric}" for product in
+           ("overseas_stock", "overseas_futures", "korea_stock")
+           for metric in ("pnl_rate", "pnl_amount")]
+    )
+
+
+def _finite(value: Any) -> Decimal | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, ValueError, TypeError):
+        return None
+    return result if result.is_finite() else None
+
+
+def futures_pnl_metadata(positions: dict[str, Any] | None) -> dict[str, Any]:
+    """Group explicit same-basis estimates; never treat missing metadata as USD."""
+    buckets: dict[str, dict[str, Any]] = {}
+    details: dict[str, dict[str, Any]] = {}
+    unavailable = 0
+    for symbol, pos in (positions or {}).items():
+        currency = pos.get("pnl_currency")
+        position_currency = pos.get("currency")
+        amount = _finite(pos.get("pnl_amount"))
+        eligible = (
+            pos.get("pnl_status") == "available"
+            and pos.get("pnl_basis") == GROSS_BASIS
+            and isinstance(currency, str)
+            and len(currency) == 3 and currency.isascii() and currency.isalpha()
+            and currency == currency.upper() and amount is not None
+            and isinstance(position_currency, str)
+            and currency == position_currency.strip().upper()
+        )
+        if eligible:
+            bucket = buckets.setdefault(currency, {
+                "currency": currency, "basis": GROSS_BASIS,
+                "total_pnl_amount": Decimal(0), "position_count": 0,
+            })
+            bucket["total_pnl_amount"] += amount
+            bucket["position_count"] += 1
+        else:
+            unavailable += 1
+        # Keep only explicit financial evidence and position facts, never an
+        # arbitrary broker/context payload or an inferred workflow classification.
+        detail = {key: pos.get(key) for key in (
+            "quantity", "buy_price", "current_price", "direction",
+            "currency", "pnl_currency", "pnl_basis", "pnl_status",
+            "pnl_unavailable_reason", "broker_pnl_basis",
+        )}
+        detail["pnl_amount"] = amount if eligible else None
+        detail["broker_pnl_amount"] = _finite(pos.get("broker_pnl_amount"))
+        details[symbol] = detail
+    known_currencies = set(buckets)
+    single_currency = next(iter(known_currencies)) if len(known_currencies) == 1 and not unavailable else None
+    return {
+        "currency": single_currency,
+        "monetary_status": "estimated" if buckets and not unavailable else (
+            "partial" if buckets else "unavailable"
+        ),
+        "monetary_basis": GROSS_BASIS if buckets else None,
+        "monetary_unavailable_reason": "workflow_accounting_basis_unverified" if positions is not None
+            else "account_positions_unavailable",
+        "pnl_by_currency": buckets,
+        "monetary_positions": details,
+        "unavailable_position_count": unavailable,
+    }

--- a/src/programgarden/programgarden/order_lifecycle.py
+++ b/src/programgarden/programgarden/order_lifecycle.py
@@ -1,0 +1,117 @@
+"""Synchronous local order journaling, independent of DSL and checkpoints.
+
+Handlers must perform local disk operations only. A prepared operation whose
+outcome is unknown must raise on replay; it must never authorize another send.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+import hashlib
+import json
+from typing import Any, Mapping, Protocol
+
+
+FUTURES_PRODUCTS = frozenset({"overseas_futures", "overseas_futureoption"})
+
+
+@dataclass(frozen=True)
+class OrderLifecycleMetadata:
+    operation_key: str
+    job_id: str
+    workflow_id: str
+    node_id: str
+    cycle: int
+    iteration_index: int
+    invocation_id: str
+    broker_node_id: str
+    credential_id: str
+    product: str
+    paper_trading: bool
+    symbol: str
+    exchange: str
+    side: str
+    order_type: str
+    quantity: Decimal
+    price: Decimal
+    broker_order_date: date
+    order_date_basis: str = "CIDBT00100_request_OrdDt"
+
+
+class OrderLifecycleHandler(Protocol):
+    def prepare(self, metadata: OrderLifecycleMetadata) -> Mapping[str, Any] | None:
+        """Durably prepare, return a prior accepted inner result, or raise."""
+        ...
+
+    def accepted(self, metadata: OrderLifecycleMetadata, result: Mapping[str, Any]) -> Mapping[str, Any] | None:
+        """Durably record acceptance and return additive parent/status fields."""
+        ...
+
+    def rejected(self, metadata: OrderLifecycleMetadata, result: Mapping[str, Any]) -> None:
+        """Record only a definitive broker rejection, never transport ambiguity."""
+        ...
+
+
+def operation_key(job_id: str, node_id: str, cycle: int, iteration_index: int, invocation_id: str) -> str:
+    """Identify an invocation, not its order facts; changed facts must conflict."""
+    payload = [job_id, node_id, cycle, iteration_index, invocation_id]
+    return "order-v1:" + hashlib.sha256(json.dumps(payload, separators=(",", ":")).encode()).hexdigest()
+
+
+def exact_futures_credential(connection: Mapping[str, Any], context: Any) -> dict[str, Any]:
+    """Resolve only the declared broker and credential; never a product slot."""
+    broker_id, credential_id = connection.get("broker_node_id"), connection.get("credential_id")
+    if not isinstance(broker_id, str) or not broker_id or not isinstance(credential_id, str) or not credential_id:
+        raise ValueError("Futures connection requires broker_node_id and credential_id")
+    if connection.get("product") not in FUTURES_PRODUCTS or type(connection.get("paper_trading")) is not bool:
+        raise ValueError("Futures connection requires explicit product and paper_trading")
+    nodes = context._workflow_nodes_map
+    if nodes:
+        broker = nodes.get(broker_id)
+        if broker is None or not broker.node_type.endswith("BrokerNode") or broker.product_scope not in FUTURES_PRODUCTS:
+            raise ValueError("Futures connection does not identify a compatible workflow broker")
+        if broker.config.get("credential_id") != credential_id:
+            raise ValueError("Futures connection credential differs from its workflow broker")
+    references = [ref for ref in context._workflow_credentials if ref.get("credential_id") == credential_id]
+    if len(references) > 1:
+        raise ValueError("Futures credential reference is ambiguous")
+    if references:
+        credential_type = references[0].get("type") or references[0].get("credential_type")
+        if credential_type and credential_type != "broker_ls_overseas_futures":
+            raise ValueError("Futures connection references an incompatible credential type")
+    registered = context.get_all_outputs(broker_id).get("connection")
+    if registered:
+        fields = ("broker_node_id", "credential_id", "product", "paper_trading")
+        if any(registered.get(key) != connection.get(key) for key in fields):
+            raise ValueError("Futures connection does not match its broker output")
+    # A restored broker output can resolve its exact workflow credential without
+    # reusing a credential from another broker's most recent execution.
+    credential = context.get_workflow_credential(credential_id)
+    if not credential:
+        credential = context.get_credential(f"broker_credentials:{broker_id}:{credential_id}")
+    if not credential:
+        raise ValueError("Exact futures broker credential is unavailable")
+    if "paper_trading" in credential and credential["paper_trading"] != connection["paper_trading"]:
+        raise ValueError("Futures credential mode does not match its connection")
+    return credential
+
+
+def inject_futures_connection(node: Any, config: dict[str, Any], workflow: Any, context: Any) -> dict[str, Any]:
+    """Preserve an explicit route, or require exactly one compatible broker."""
+    if config.get("connection") is not None:
+        return config
+    candidates = []
+    for broker_id, broker in workflow.nodes.items():
+        if broker.product_scope != node.product_scope:
+            continue
+        if node.broker_provider != "all" and broker.broker_provider != "all" and node.broker_provider != broker.broker_provider:
+            continue
+        outputs = context.get_all_outputs(broker_id)
+        if "connection" in outputs or getattr(broker, "node_type", "").endswith("BrokerNode"):
+            candidates.append(outputs.get("connection"))
+    if len(candidates) > 1:
+        raise ValueError("Multiple compatible futures brokers require an explicit connection")
+    if len(candidates) == 1 and candidates[0] is not None:
+        return {**config, "connection": candidates[0]}
+    return config

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.33.4"
+version = "1.33.5"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
@@ -29,8 +29,8 @@ lxml = "^6.0.2"
 pytickersymbols = {version = ">=1.17.5", python = ">=3.12,<4.0"}
 aiosqlite = "^0.20.0"
 litellm = ">=1.40.0"
-programgarden-core = "^1.25.0"
-programgarden-finance = "^1.9.3"
+programgarden-core = "^1.25.3"
+programgarden-finance = "^1.9.4"
 programgarden-community = "^1.15.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/programgarden/tests/test_account_pnl_listener.py
+++ b/src/programgarden/tests/test_account_pnl_listener.py
@@ -228,13 +228,8 @@ class TestBrokerNodeExecutor:
         assert callable(getattr(active, 'on_workflow_pnl_update'))
 
 
-class TestFuturesPnlAmountPreferred:
-    """D1: 선물 평가손익 승수 누락 — 포지션에 pnl_amount 가 있으면 우선 합산한다.
-
-    자체 산술 qty×(현재가-평단) 은 승수를 무시해 1/N 로 축소되므로,
-    브로커/트래커가 실은 pnl_amount(승수 반영)를 우선 써야 한다. pnl_rate 는
-    승수가 소거되는 eval/buy 비율이라 금액과 무관하게 정확하다.
-    """
+class TestFuturesPnlEvidenceBoundary:
+    """Unqualified position amounts cannot establish futures account accounting."""
 
     def _ctx(self):
         from programgarden.context import ExecutionContext
@@ -256,36 +251,26 @@ class TestFuturesPnlAmountPreferred:
         }
     }
 
-    def test_account_pnl_prefers_broker_pnl_amount(self):
-        ctx = self._ctx()
-        result = ctx._calculate_account_pnl(self._POS)
-        # 자체 산술이면 ≈160 이지만 pnl_amount 우선 → 1600
-        assert result["account_overseas_futures_pnl_amount"] == pytest.approx(1600.0)
-        assert result["account_total_pnl_amount"] == pytest.approx(1600.0)
-        # pnl_rate 는 승수 무관 eval/buy 비율 — 여전히 정확
-        expected_rate = (8601.0 - 8547.67) / 8547.67 * 100
-        assert result["account_overseas_futures_pnl_rate"] == pytest.approx(expected_rate)
+    def test_account_pnl_withholds_unqualified_broker_amount(self):
+        result = self._ctx()._calculate_account_pnl(self._POS)
+        assert result["account_overseas_futures_pnl_amount"] is None
+        assert result["account_total_pnl_amount"] is None
+        assert result["account_overseas_futures_pnl_rate"] is None
 
-    def test_account_pnl_falls_back_to_arithmetic_when_absent(self):
-        ctx = self._ctx()
+    def test_account_pnl_does_not_invent_missing_multiplier_or_currency(self):
         pos = {"HSIQ26": {**self._POS["HSIQ26"]}}
         del pos["HSIQ26"]["pnl_amount"]
-        result = ctx._calculate_account_pnl(pos)
-        # 폴백: qty×(현재가-평단) = 3×53.33 ≈ 159.99
-        assert result["account_overseas_futures_pnl_amount"] == pytest.approx(3 * (8601.0 - 8547.67))
+        result = self._ctx()._calculate_account_pnl(pos)
+        assert result["account_overseas_futures_pnl_amount"] is None
 
-    def test_workflow_fallback_prefers_broker_pnl_amount(self):
-        ctx = self._ctx()
-        result = ctx._calculate_workflow_pnl(
-            current_prices={"HSIQ26": 8601.0},
-            all_positions=self._POS,
+    def test_workflow_does_not_adopt_unattributed_account_positions(self):
+        result = self._ctx()._calculate_workflow_pnl(
+            current_prices={"HSIQ26": 8601.0}, all_positions=self._POS,
             product="overseas_futures",
         )
-        # no-tracker fallback: 모든 포지션이 "other"
-        assert result["other_pnl_amount"] == pytest.approx(1600.0)
-        assert result["total_pnl_amount"] == pytest.approx(1600.0)
-        # PositionDetail 에도 승수 반영된 금액
-        assert float(result["other_positions"][0].pnl_amount) == pytest.approx(1600.0)
+        assert result["other_pnl_amount"] is None
+        assert result["total_pnl_amount"] is None
+        assert result["other_positions"] == []
 
     def test_placeholder_zero_pnl_amount_falls_back_to_arithmetic(self):
         # MINOR1: 여러 빌더가 pnl_amount 를 기본 0.0 placeholder 로 넣는다.

--- a/src/programgarden/tests/test_broker_tracker_lifecycle.py
+++ b/src/programgarden/tests/test_broker_tracker_lifecycle.py
@@ -1,0 +1,285 @@
+"""Broker-owned trackers stop with the workflow, without any network access."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import BrokerNodeExecutor, WorkflowJob
+from programgarden.resolver import ResolvedWorkflow
+from programgarden_core.bases.listener import BaseExecutionListener
+from programgarden_finance.ls.overseas_futureoption.extension.tracker import FuturesAccountTracker
+
+
+POLL_INTERVAL = 0.01
+
+
+@pytest.fixture(autouse=True)
+def isolate_broker_registries(monkeypatch):
+    monkeypatch.setattr(BrokerNodeExecutor, "_active_trackers", {})
+    monkeypatch.setattr(BrokerNodeExecutor, "_background_tasks", {})
+    monkeypatch.setattr(BrokerNodeExecutor, "_notification_tasks", {})
+
+
+def make_job(job_id="broker-lifecycle"):
+    context = ExecutionContext(job_id=job_id, workflow_id="offline-workflow")
+    workflow = ResolvedWorkflow("offline-workflow", "1.0.0", {}, [], [])
+    return WorkflowJob(job_id, workflow, context, MagicMock())
+
+
+def make_futures_fixture():
+    real = SimpleNamespace(connect=AsyncMock(), is_connected=AsyncMock(return_value=True), close=AsyncMock())
+    tracker = FuturesAccountTracker(MagicMock(), MagicMock(), real, refresh_interval=POLL_INTERVAL)
+    tracker._spec_manager = SimpleNamespace(initialize=AsyncMock(), stop=AsyncMock())
+    tracker._fetch_all_data = AsyncMock()
+    tracker._setup_subscriptions = AsyncMock()
+    tracker._cleanup_subscriptions = AsyncMock()
+    api = SimpleNamespace(
+        real=lambda: real,
+        accno=lambda: SimpleNamespace(account_tracker=lambda **kwargs: tracker),
+        market=MagicMock(),
+    )
+    return SimpleNamespace(overseas_futureoption=lambda: api), tracker, real
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("termination", ["complete", "stop", "cancel", "force_stop"])
+async def test_sdk_periodic_polling_stops_after_job_termination(termination):
+    """Use the SDK's actual start/periodic-refresh/stop loop, with read calls mocked."""
+    job = make_job()
+    broker = BrokerNodeExecutor()
+    ls, tracker, real = make_futures_fixture()
+
+    async def main_flow():
+        await broker._start_overseas_futures_tracker(
+            ls, "broker", "overseas_futures", "ls", job.context,
+        )
+        # Prove the periodic loop is active before terminating the job.
+        await asyncio.sleep(POLL_INTERVAL * 3)
+        assert tracker._fetch_all_data.await_count >= 2
+
+    job._execute_main_flow = AsyncMock(side_effect=main_flow)
+    try:
+        if termination == "complete":
+            await job._run()
+            assert job.status == "completed"
+        else:
+            await main_flow()
+            await getattr(job, termination)()
+            assert job.status == {"stop": "stopped", "cancel": "cancelled", "force_stop": "force_stopped"}[termination]
+
+        reads_at_termination = tracker._fetch_all_data.await_count
+        await asyncio.sleep(POLL_INTERVAL * 8)
+        assert tracker._fetch_all_data.await_count == reads_at_termination
+        assert tracker._refresh_task is None
+        assert tracker._is_running is False
+        real.close.assert_awaited_once()
+        assert f"{job.job_id}_broker" not in broker._active_trackers
+
+        # Explicit stop after normal completion is safe and idempotent.
+        await job.stop()
+        real.close.assert_awaited_once()
+    finally:
+        await tracker.stop()
+        broker._active_trackers.pop(f"{job.job_id}_broker", None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("termination", ["complete", "stop", "cancel"])
+@pytest.mark.parametrize("blocked_stage", ["connect", "start"])
+@pytest.mark.parametrize("product", ["overseas_stock", "overseas_futures", "korea_stock"])
+async def test_termination_cancels_partial_tracker_startup(termination, blocked_stage, product):
+    """A slow connect/initial read must not install a tracker after job cleanup."""
+    job = make_job()
+    broker = BrokerNodeExecutor()
+    entered = asyncio.Event()
+    released = asyncio.Event()
+
+    async def blocked():
+        entered.set()
+        await released.wait()
+
+    real = SimpleNamespace(connect=AsyncMock(), close=AsyncMock())
+    tracker = SimpleNamespace(start=AsyncMock(), stop=AsyncMock(), on_account_pnl_change=MagicMock())
+    setattr(real if blocked_stage == "connect" else tracker, blocked_stage, AsyncMock(side_effect=blocked))
+    api = SimpleNamespace(
+        real=lambda: real, market=MagicMock(),
+        accno=lambda: SimpleNamespace(account_tracker=lambda **kwargs: tracker),
+    )
+    api_name = "overseas_futureoption" if product == "overseas_futures" else product
+    ls = SimpleNamespace(**{api_name: lambda: api})
+    startup = broker._start_background_task(
+        job.context,
+        getattr(broker, f"_start_{product}_tracker")(ls, "broker", product, "ls", job.context),
+    )
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        if termination == "complete":
+            job._execute_main_flow = AsyncMock()
+            await job._run()
+        elif termination == "stop":
+            await job.stop()
+        else:
+            async def running_flow():
+                await asyncio.Event().wait()
+
+            job._execute_main_flow = AsyncMock(side_effect=running_flow)
+            job._task = asyncio.create_task(job._run())
+            await asyncio.sleep(0)
+            await job.cancel()
+        released.set()
+        await asyncio.sleep(POLL_INTERVAL * 2)
+        assert startup.cancelled()
+        tracker.stop.assert_awaited_once()
+        real.close.assert_awaited_once()
+        assert not broker._active_trackers
+        assert not broker._background_tasks
+    finally:
+        startup.cancel()
+        await asyncio.gather(startup, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("product", ["overseas_stock", "overseas_futures", "korea_stock"])
+async def test_late_pnl_callback_cannot_restart_job_work(product):
+    job = make_job()
+    job.context.notify_workflow_pnl = AsyncMock()
+    broker = BrokerNodeExecutor()
+    real = SimpleNamespace(connect=AsyncMock(), close=AsyncMock())
+    tracker = SimpleNamespace(
+        start=AsyncMock(), stop=AsyncMock(), get_positions=lambda: {},
+        on_account_pnl_change=MagicMock(),
+    )
+    api = SimpleNamespace(
+        real=lambda: real, market=MagicMock(),
+        accno=lambda: SimpleNamespace(account_tracker=lambda **kwargs: tracker),
+    )
+    api_name = "overseas_futureoption" if product == "overseas_futures" else product
+    ls = SimpleNamespace(**{api_name: lambda: api})
+    await getattr(broker, f"_start_{product}_tracker")(ls, "broker", product, "ls", job.context)
+    callback = tracker.on_account_pnl_change.call_args.args[0]
+    callback(SimpleNamespace())
+    await asyncio.sleep(0)
+    assert job.context.notify_workflow_pnl.await_count == 1
+    await job.stop()
+    callback(SimpleNamespace())
+    await asyncio.sleep(0)
+    assert job.context.notify_workflow_pnl.await_count == 1
+    assert not broker._background_tasks
+
+
+@pytest.mark.asyncio
+async def test_cleanup_preserves_another_job_with_a_similar_id():
+    broker = BrokerNodeExecutor()
+    job = make_job("job-1")
+    other = make_job("job-10")
+    entered = asyncio.Event()
+
+    async def background_read():
+        entered.set()
+        await asyncio.Event().wait()
+
+    task = broker._start_background_task(other.context, background_read())
+    tracker = SimpleNamespace(stop=AsyncMock())
+    real = SimpleNamespace(close=AsyncMock())
+    broker._active_trackers["job-10_broker"] = {"tracker": tracker, "real": real}
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        await job.stop()
+        assert not task.done()
+        tracker.stop.assert_not_awaited()
+        real.close.assert_not_awaited()
+        await other.stop()
+        assert task.cancelled()
+        tracker.stop.assert_awaited_once()
+        real.close.assert_awaited_once()
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("termination", ["complete", "stop", "cancel", "force_stop"])
+@pytest.mark.parametrize("already_started", [False, True])
+async def test_termination_preserves_pending_actual_pnl_listener_delivery(termination, already_started):
+    """Real context dispatch must finish before listener cleanup closes its sink."""
+    job = make_job()
+    broker = BrokerNodeExecutor()
+    ls, tracker, real = make_futures_fixture()
+    entered, release, connection_closed = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    delivered = []
+
+    class Listener(BaseExecutionListener):
+        async def on_workflow_pnl_update(self, event):
+            entered.set()
+            await release.wait()
+            assert connection_closed.is_set()
+            delivered.append(True)
+
+    job.context.add_listener(Listener())
+    await broker._start_overseas_futures_tracker(ls, "broker", "overseas_futures", "ls", job.context)
+    real.close.side_effect = connection_closed.set
+    tracker._on_account_pnl_change_callbacks[0](SimpleNamespace(currency="USD"))
+    if already_started:
+        await asyncio.wait_for(entered.wait(), timeout=1)
+    job._execute_main_flow = AsyncMock()
+    ending = asyncio.create_task(job._run() if termination == "complete" else getattr(job, termination)())
+    try:
+        await asyncio.wait_for(connection_closed.wait(), timeout=1)
+        assert not tracker._is_running
+        assert not ending.done()
+        release.set()
+        await asyncio.wait_for(ending, timeout=1)
+        assert delivered == [True]
+        assert not broker._notification_tasks
+        assert not job.context._listeners
+    finally:
+        release.set()
+        await asyncio.gather(ending, return_exceptions=True)
+        await tracker.stop()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resists_cancellation", [False, True])
+async def test_wedged_pnl_listener_has_bounded_observable_stop(monkeypatch, caplog, resists_cancellation):
+    job = make_job()
+    broker = BrokerNodeExecutor()
+    ls, tracker, real = make_futures_fixture()
+    entered, release, cancelled = asyncio.Event(), asyncio.Event(), asyncio.Event()
+    monkeypatch.setattr(BrokerNodeExecutor, "_PNL_DRAIN_TIMEOUT_SECONDS", 0.02)
+    monkeypatch.setattr(BrokerNodeExecutor, "_PNL_CANCEL_TIMEOUT_SECONDS", 0.02)
+
+    class Listener(BaseExecutionListener):
+        async def on_workflow_pnl_update(self, event):
+            entered.set()
+            try:
+                await release.wait()
+            except asyncio.CancelledError:
+                cancelled.set()
+                if not resists_cancellation:
+                    raise
+                await release.wait()
+
+    job.context.add_listener(Listener())
+    await broker._start_overseas_futures_tracker(ls, "broker", "overseas_futures", "ls", job.context)
+    tracker._on_account_pnl_change_callbacks[0](SimpleNamespace(currency="USD"))
+    notification = next(iter(broker._notification_tasks[job.job_id]))
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        await asyncio.wait_for(job.stop(), timeout=0.5)
+        assert cancelled.is_set()
+        assert "PnL notification drain timed out" in caplog.text
+        assert not tracker._is_running
+        real.close.assert_awaited_once()
+        if resists_cancellation:
+            assert "notification cancellation did not finish" in caplog.text
+            assert notification in broker._notification_tasks[job.job_id]
+        else:
+            assert notification.cancelled()
+            assert not broker._notification_tasks
+    finally:
+        release.set()
+        await asyncio.gather(notification, return_exceptions=True)
+        await tracker.stop()

--- a/src/programgarden/tests/test_execution_identity_ledger.py
+++ b/src/programgarden/tests/test_execution_identity_ledger.py
@@ -1,0 +1,283 @@
+"""Real SQLite guards for explicit execution replay and early partial fills."""
+
+import asyncio
+import json
+import sqlite3
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+
+import pytest
+
+from programgarden.database.workflow_position_tracker import (
+    ExecutionIdentityConflictError,
+    WorkflowPositionTracker,
+)
+
+
+def tracker(tmp_path, **kwargs):
+    return WorkflowPositionTracker(str(tmp_path / "ledger.db"), "job", "broker", **kwargs)
+
+
+def fill(**kwargs):
+    return {
+        "order_no": "000123", "order_date": "20260909", "symbol": "SYNTH", "exchange": "TEST",
+        "side": "buy", "quantity": 2, "price": 100.0, "fill_time": "100000001", "commda_code": "40",
+        **kwargs,
+    }
+
+
+def order(target, number="000123", date="20260909"):
+    target.record_order(number, date, "SYNTH", "TEST", "buy", 10, 100, "job", "node")
+
+
+def rows(target, table):
+    assert table in {"trade_history", "workflow_position_lots", "workflow_orders"}
+    with sqlite3.connect(target.db_path) as conn:
+        return conn.execute(f"SELECT * FROM {table} ORDER BY id").fetchall()
+
+
+def remaining(target):
+    with sqlite3.connect(target.db_path) as conn:
+        return conn.execute("SELECT COALESCE(SUM(remaining_qty), 0) FROM workflow_position_lots").fetchone()[0]
+
+
+@pytest.mark.asyncio
+async def test_replay_and_reopen_preserve_buy_and_sell_fifo(tmp_path):
+    target = tracker(tmp_path)
+    order(target)
+    assert await target.record_fill(**fill(), execution_id="001") == "workflow"
+    before = rows(target, "trade_history"), rows(target, "workflow_position_lots")
+    assert await target.record_fill(**fill(), execution_id=1) == "workflow"
+    reopened = tracker(tmp_path)
+    assert await reopened.record_fill(**fill(), execution_id="1") == "workflow"
+    assert (rows(target, "trade_history"), rows(target, "workflow_position_lots")) == before
+
+    order(target, "sell")
+    sale = fill(order_no="sell", side="sell", quantity=1, price=110, fill_time="110000000")
+    assert await target.record_fill(**sale, execution_id="sell-fill") == "workflow"
+    before = rows(target, "trade_history"), rows(target, "workflow_position_lots")
+    assert await reopened.record_fill(**sale, execution_id="sell-fill") == "workflow"
+    assert (rows(target, "trade_history"), rows(target, "workflow_position_lots")) == before
+    assert remaining(target) == 1
+    with sqlite3.connect(target.db_path) as conn:
+        assert conn.execute("SELECT SUM(realized_pnl) FROM trade_history").fetchone()[0] == 10
+
+
+@pytest.mark.asyncio
+async def test_padded_order_and_execution_replay_keeps_original_evidence(tmp_path):
+    target = tracker(tmp_path)
+    order(target, "123")
+    assert await target.record_fill(**fill(), execution_id=" 000456 ") == "workflow"
+    assert await target.record_fill(**fill(order_no="123", quantity=2.0, price=100), execution_id=456) == "workflow"
+    with sqlite3.connect(target.db_path) as conn:
+        row = conn.execute("SELECT order_no, normalized_order_no, execution_id, execution_payload FROM trade_history").fetchone()
+    assert row[:3] == ("000123", "123", "456")
+    assert json.loads(row[3])["reported_execution_id"] == " 000456 "
+    assert len(rows(target, "trade_history")) == 1
+
+
+@pytest.mark.asyncio
+async def test_distinct_opaque_ids_do_not_collapse_identical_fill_facts(tmp_path):
+    target = tracker(tmp_path)
+    args = fill(commda_code="10")
+    for identity in (" 000A ", "A", "a"):
+        assert await target.record_fill(**args, execution_id=identity) == "manual"
+    assert await target.record_fill(**args, execution_id="000A") == "manual"
+    assert len(rows(target, "trade_history")) == 3
+    assert remaining(target) == 6
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("changed", [
+    {"symbol": "OTHER"}, {"exchange": "OTHER"}, {"side": "sell"},
+    {"quantity": 3}, {"price": 101}, {"fill_time": "100000002"}, {"commda_code": "10"},
+])
+async def test_conflicting_committed_identity_never_mutates_facts(tmp_path, changed):
+    target = tracker(tmp_path)
+    order(target)
+    await target.record_fill(**fill(), execution_id="same")
+    before = rows(target, "trade_history"), rows(target, "workflow_position_lots")
+    with pytest.raises(ExecutionIdentityConflictError, match="Conflicting fill facts"):
+        await target.record_fill(**fill(**changed), execution_id="same")
+    assert (rows(target, "trade_history"), rows(target, "workflow_position_lots")) == before
+
+
+@pytest.mark.asyncio
+async def test_distinct_early_partials_survive_ack_and_buffer_replays(tmp_path):
+    target = tracker(tmp_path)
+    target.FILL_BUFFER_TIMEOUT = 0
+    assert await target.record_fill(**fill(), execution_id="0001") == "pending"
+    assert await target.record_fill(**fill(order_no="123"), execution_id=1) == "pending"
+    assert await target.record_fill(**fill(quantity=3, price=101, fill_time="100000002"), execution_id="2") == "pending"
+    with pytest.raises(ExecutionIdentityConflictError):
+        await target.record_fill(**fill(quantity=20), execution_id="1")
+    assert len(target._pending_fills) == 2
+    order(target, "123")
+    await target._process_buffered_fill("123", "20260909")
+    await asyncio.sleep(0)
+    assert remaining(target) == 5
+    assert len(rows(target, "trade_history")) == 2
+    assert target._pending_fills == {}
+
+
+@pytest.mark.asyncio
+async def test_early_partials_all_timeout_without_order(tmp_path):
+    target = tracker(tmp_path)
+    target.FILL_BUFFER_TIMEOUT = 0
+    await target.record_fill(**fill(), execution_id="1")
+    await target.record_fill(**fill(quantity=3, fill_time="100000002"), execution_id="2")
+    for key in list(target._pending_fills):
+        await target._process_timeout_fill(key)
+    assert remaining(target) == 5
+    with sqlite3.connect(target.db_path) as conn:
+        assert conn.execute("SELECT classification FROM trade_history").fetchall() == [("unknown_api",), ("unknown_api",)]
+    order(target)
+    assert await target.record_fill(**fill(), execution_id="1") == "unknown_api"
+    assert len(rows(target, "trade_history")) == 2
+
+
+@pytest.mark.asyncio
+async def test_timeout_belongs_to_one_arrival_not_later_partial(tmp_path):
+    target = tracker(tmp_path)
+    target.FILL_BUFFER_TIMEOUT = 0
+    previous_tasks = asyncio.all_tasks()
+    await target.record_fill(**fill(), execution_id="1")
+    first = next(iter(target._pending_fills))
+    await target.record_fill(**fill(quantity=3, fill_time="100000002"), execution_id="2")
+    # Drive the real expiry method one arrival at a time, with no wall-clock race.
+    timers = asyncio.all_tasks() - previous_tasks
+    for timer in timers:
+        timer.cancel()
+    await asyncio.gather(*timers, return_exceptions=True)
+    await target._process_timeout_fill(first)
+    assert len(rows(target, "trade_history")) == 1
+    assert len(target._pending_fills) == 1
+    for key in list(target._pending_fills):
+        await target._process_timeout_fill(key)
+    assert remaining(target) == 5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("identity", [None, "", "   ", 0, "0000"])
+async def test_missing_identity_retains_legacy_arrivals_without_partial_loss(tmp_path, identity):
+    target = tracker(tmp_path)
+    target.FILL_BUFFER_TIMEOUT = 0
+    await target.record_fill(**fill(), execution_id=identity)
+    await target.record_fill(**fill(), execution_id=identity)
+    order(target)
+    await target._process_buffered_fill("000123", "20260909")
+    assert remaining(target) == 4
+    assert len(rows(target, "trade_history")) == 2
+    with sqlite3.connect(target.db_path) as conn:
+        assert conn.execute("SELECT execution_id FROM trade_history").fetchall() == [(None,), (None,)]
+    await target.record_fill(**fill(), execution_id=identity)
+    assert remaining(target) == 6
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("identity", [-1, "-001", 1.0, "1.0", True])
+async def test_invalid_numeric_id_does_not_write_or_buffer(tmp_path, identity):
+    target = tracker(tmp_path)
+    with pytest.raises(ValueError):
+        await target.record_fill(**fill(), execution_id=identity)
+    assert target._pending_fills == {}
+    assert rows(target, "trade_history") == []
+
+
+@pytest.mark.asyncio
+async def test_identity_domain_separates_dates_orders_modes_products_and_providers(tmp_path):
+    targets = [
+        tracker(tmp_path), tracker(tmp_path, trading_mode="paper"),
+        tracker(tmp_path, product="overseas_futures"), tracker(tmp_path, provider="other-provider"),
+    ]
+    for target in targets:
+        for date, number in [("20260909", "123"), ("20260910", "123"), ("20260909", "124")]:
+            args = fill(order_date=date, order_no=number, commda_code="10")
+            assert await target.record_fill(**args, execution_id="same") == "manual"
+            assert await target.record_fill(**args, execution_id="same") == "manual"
+    assert len(rows(targets[0], "trade_history")) == 12
+
+
+def test_concurrent_connections_gate_before_fifo_mutation(tmp_path):
+    first, second = tracker(tmp_path), tracker(tmp_path)
+    barrier = Barrier(2)
+
+    def write(target):
+        barrier.wait(timeout=5)
+        return asyncio.run(target.record_fill(**fill(commda_code="10"), execution_id="race"))
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(write, target) for target in (first, second)]
+        assert [future.result(timeout=10) for future in futures] == ["manual", "manual"]
+    assert len(rows(first, "trade_history")) == 1
+    assert remaining(first) == 2
+
+
+def test_concurrent_conflicting_identity_accepts_only_one_payload(tmp_path):
+    first, second = tracker(tmp_path), tracker(tmp_path)
+    barrier = Barrier(2)
+
+    def write(target, quantity):
+        barrier.wait(timeout=5)
+        try:
+            return asyncio.run(target.record_fill(**fill(commda_code="10", quantity=quantity), execution_id="race"))
+        except ExecutionIdentityConflictError:
+            return "conflict"
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(write, first, 2), pool.submit(write, second, 3)]
+        assert sorted(future.result(timeout=10) for future in futures) == ["conflict", "manual"]
+    with sqlite3.connect(first.db_path) as conn:
+        quantities = conn.execute("SELECT quantity FROM trade_history").fetchall()
+    assert len(quantities) == 1
+    assert remaining(first) == quantities[0][0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("side", ["buy", "sell"])
+async def test_history_write_failure_rolls_back_fifo_and_identity(tmp_path, side):
+    target = tracker(tmp_path)
+    if side == "sell":
+        await target.record_fill(**fill(commda_code="10"), execution_id="opening")
+    args = fill(commda_code="10", side=side, quantity=1 if side == "sell" else 2)
+    before = rows(target, "trade_history"), rows(target, "workflow_position_lots")
+    with sqlite3.connect(target.db_path) as conn:
+        conn.execute("CREATE TRIGGER reject_history BEFORE INSERT ON trade_history BEGIN SELECT RAISE(ABORT, 'synthetic failure'); END")
+    with pytest.raises(sqlite3.IntegrityError, match="synthetic failure"):
+        await target.record_fill(**args, execution_id="atomic")
+    assert (rows(target, "trade_history"), rows(target, "workflow_position_lots")) == before
+    with sqlite3.connect(target.db_path) as conn:
+        conn.execute("DROP TRIGGER reject_history")
+    assert await target.record_fill(**args, execution_id="atomic") == "manual"
+    assert remaining(target) == (1 if side == "sell" else 2)
+
+
+@pytest.mark.asyncio
+async def test_existing_schema_rows_are_preserved_without_inferred_identity(tmp_path):
+    path = tmp_path / "ledger.db"
+    with sqlite3.connect(path) as conn:
+        conn.execute("""
+            CREATE TABLE trade_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT, product TEXT NOT NULL,
+                provider TEXT NOT NULL, order_no TEXT, order_date TEXT, symbol TEXT,
+                exchange TEXT, side TEXT, quantity INTEGER, price REAL,
+                fill_datetime TEXT, classification TEXT, commda_code TEXT,
+                realized_pnl REAL, trading_mode TEXT NOT NULL DEFAULT 'live', created_at TEXT
+            )
+        """)
+        conn.execute("""
+            INSERT INTO trade_history(product, provider, order_no, order_date, symbol,
+                exchange, side, quantity, price, fill_datetime, classification, commda_code,
+                realized_pnl, trading_mode, created_at)
+            VALUES ('overseas_stock', 'ls', '000123', '20260909', 'SYNTH', 'TEST',
+                'buy', 2, 100, '20260909_100000001', 'manual', '10', 0, 'live', 'original')
+        """)
+        old = conn.execute("SELECT * FROM trade_history").fetchone()
+    target = tracker(tmp_path)
+    migrated = rows(target, "trade_history")[0]
+    assert migrated[:len(old)] == old
+    assert migrated[len(old):] == (None, None, None)
+    await target.record_fill(**fill(commda_code="10"), execution_id="new-evidence")
+    assert len(rows(target, "trade_history")) == 2
+    assert rows(target, "trade_history")[0] == migrated
+    assert len(rows(tracker(tmp_path), "trade_history")) == 2

--- a/src/programgarden/tests/test_futures_account_monetary_serialization.py
+++ b/src/programgarden/tests/test_futures_account_monetary_serialization.py
@@ -1,0 +1,179 @@
+"""Actual SDK models through initial and tick account outputs; synthetic, offline only."""
+
+import asyncio
+from decimal import Decimal
+import logging
+import socket
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import AccountNodeExecutor, RealAccountNodeExecutor
+from programgarden_finance.ls.overseas_futureoption.accno.CIDBQ01500.blocks import CIDBQ01500OutBlock2
+from programgarden_finance.ls.overseas_futureoption.extension.models import FuturesPositionItem
+from programgarden_finance.ls.overseas_futureoption.extension.symbol_spec_manager import SymbolSpec
+from programgarden_finance.ls.overseas_futureoption.extension.tracker import FuturesAccountTracker
+
+
+@pytest.fixture(autouse=True)
+def deny_network(monkeypatch):
+    def denied(*args, **kwargs):
+        raise AssertionError("Account serialization tests must remain offline")
+    monkeypatch.setattr(socket.socket, "connect", denied)
+    monkeypatch.setattr(socket.socket, "connect_ex", denied)
+    monkeypatch.setattr(socket.socket, "sendto", denied)
+
+
+def response(rows):
+    return SimpleNamespace(rsp_cd="00000", rsp_msg="Synthetic fixture", block2=rows)
+
+
+def sdk_tracker(currency="HKD", current=25010, with_spec=True):
+    row = CIDBQ01500OutBlock2(
+        IsuCodeVal="HMH_SYNTHETIC", CrcyCodeVal=currency, BnsTpCode="2",
+        PchsPrc=25000, OvrsDrvtNowPrc=current, AbrdFutsEvalPnlAmt=777, BalQty=1,
+    )
+    account = SimpleNamespace(CIDBQ01500=lambda **kwargs: SimpleNamespace(
+        req_async=AsyncMock(return_value=response([row])),
+    ))
+    tracker = FuturesAccountTracker(account, market_client=None)
+    if with_spec:
+        tracker._spec_manager._specs[row.IsuCodeVal] = SymbolSpec(
+            symbol=row.IsuCodeVal, currency=currency, tick_size=Decimal("1"),
+            tick_value=Decimal("10"), exchange_code="SYNTHETIC", decimal_places=0,
+        )
+    # Keep actual fetch/model/calculator/callback behavior; replace only transport
+    # startup so no WebSocket, periodic task, or master request is started.
+    tracker.start = tracker._fetch_positions
+    return tracker
+
+
+async def start_account_node(tracker):
+    real = SimpleNamespace(is_connected=AsyncMock(return_value=True), connect=AsyncMock())
+    account = SimpleNamespace(account_tracker=lambda **kwargs: tracker)
+    ls = SimpleNamespace(overseas_futureoption=lambda: SimpleNamespace(
+        accno=lambda: account, market=lambda: None, real=lambda: real,
+    ))
+    context = ExecutionContext(job_id="synthetic-account", workflow_id="synthetic-account")
+    context.notify_output_update = AsyncMock()
+    context.emit_event = AsyncMock()
+    context.register_cleanup_on_flow_end = Mock()
+    result = await RealAccountNodeExecutor()._ls_futureoption_with_tracker(
+        ls, "account", {"_trigger_on_update_nodes": ["synthetic-display"]}, context,
+        sync_interval_sec=60, stay_connected=False,
+    )
+    # Drain only finite local callback scheduling, without wall-clock sleeps.
+    for _ in range(4):
+        await asyncio.sleep(0)
+    return result, context
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("current", [25010, 25000, 24990])
+async def test_actual_sdk_initial_and_tick_keep_native_money_and_broker_raw(current, caplog):
+    caplog.set_level(logging.DEBUG, logger="programgarden.executor")
+    tracker = sdk_tracker(current=current)
+    result, context = await start_account_node(tracker)
+    initial = result["positions"][0]
+    assert initial["pnl_amount"] == (current - 25000) * 10
+    assert initial["pnl_currency"] == initial["currency"] == "HKD"
+    assert initial["pnl_basis"] == "estimated_gross_price_change"
+    assert initial["pnl_status"] == "available"
+    assert initial["broker_pnl_amount"] == 777
+    assert initial["broker_pnl_basis"] == "broker_reported_unconfirmed"
+
+    for price, expected in [(current, initial["pnl_amount"]), (25000, 0), (24999, -10)]:
+        context.emit_event.reset_mock()
+        context.notify_output_update.reset_mock()
+        tracker._on_tick_received(SimpleNamespace(body=SimpleNamespace(
+            symbol="HMH_SYNTHETIC", curpr=price,
+        )))
+        for _ in range(4):
+            await asyncio.sleep(0)
+        context.emit_event.assert_awaited_once()
+        emitted = context.emit_event.await_args.kwargs
+        assert emitted["trigger_nodes"] == ["synthetic-display"]
+        position = emitted["data"]["positions"][0]
+        assert position["pnl_amount"] == expected
+        assert position["pnl_currency"] == "HKD"
+        assert position["pnl_basis"] == initial["pnl_basis"]
+        assert position["broker_pnl_amount"] == 777
+        assert position == RealAccountNodeExecutor()._get_overseas_futures_tracker_data(tracker)["positions"][0]
+        assert context.notify_output_update.await_args.kwargs["outputs"]["positions"] == [position]
+    messages = [r.getMessage() for r in caplog.records if r.getMessage().startswith("Futures position ")]
+    assert messages and all("$" not in message for message in messages)
+    assert any("pnl_currency=HKD" in message for message in messages)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("currency", ["HKD", ""])
+async def test_missing_spec_initial_and_tick_publish_null_without_format_exception(currency, caplog):
+    caplog.set_level(logging.DEBUG, logger="programgarden.executor")
+    tracker = sdk_tracker(currency=currency, with_spec=False)
+    result, context = await start_account_node(tracker)
+    initial = result["positions"][0]
+    assert initial["pnl_amount"] is None
+    assert initial["pnl_currency"] is None and initial["pnl_basis"] is None
+    assert initial["pnl_status"] == "unavailable"
+    assert initial["pnl_unavailable_reason"]
+    assert initial["currency"] == currency
+    assert initial["broker_pnl_amount"] == 777
+    context.emit_event.reset_mock()
+    tracker._on_tick_received(SimpleNamespace(body=SimpleNamespace(symbol="HMH_SYNTHETIC", curpr=25011)))
+    for _ in range(4):
+        await asyncio.sleep(0)
+    context.emit_event.assert_awaited_once()  # The old None formatting swallowed this callback.
+    updated = context.emit_event.await_args.kwargs["data"]["positions"][0]
+    assert updated["pnl_amount"] is None and updated["current_price"] == 25011
+    assert updated["broker_pnl_amount"] == 777
+    assert any("pnl_amount=None" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.parametrize("amount", [None, Decimal("0"), Decimal("-12.5")])
+def test_actual_model_preserves_nullable_broker_amount(amount):
+    pos = FuturesPositionItem(symbol="SYNTHETIC", broker_pnl_amount=amount)
+    tracker = SimpleNamespace(get_positions=lambda: {pos.symbol: pos}, get_balance=lambda: {})
+    output = RealAccountNodeExecutor()._get_overseas_futures_tracker_data(tracker)["positions"][0]
+    assert output["broker_pnl_amount"] == amount
+    assert output["pnl_amount"] is None and output["currency"] == ""
+
+
+@pytest.mark.asyncio
+async def test_registered_callback_does_not_raise_for_unavailable_amount():
+    tracker = sdk_tracker(with_spec=False)
+    _, context = await start_account_node(tracker)
+    context.emit_event.reset_mock()
+    # Invoke the actual registered callback directly so the SDK's exception
+    # swallowing cannot hide a nullable debug-formatting failure.
+    callback, = tracker._on_position_change_callbacks
+    callback(tracker.get_positions())
+    for _ in range(4):
+        await asyncio.sleep(0)
+    context.emit_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("amount", [None, 0, -12.5, 100])
+@pytest.mark.parametrize("currency", ["HKD", ""])
+async def test_direct_rest_preserves_supplied_raw_amount_without_inventing_estimate(amount, currency):
+    fields = dict(IsuCodeVal="SYNTHETIC", CrcyCodeVal=currency, BnsTpCode="2",
+                  PchsPrc=25000, OvrsDrvtNowPrc=25010, BalQty=1)
+    if amount is not None:
+        fields["AbrdFutsEvalPnlAmt"] = amount
+    row = CIDBQ01500OutBlock2(**fields)
+    account = SimpleNamespace(
+        CIDBQ01500=lambda **kwargs: SimpleNamespace(req_async=AsyncMock(return_value=response([row]))),
+        CIDBQ05300=lambda **kwargs: SimpleNamespace(req_async=AsyncMock(return_value=SimpleNamespace(block2=[], block3=None))),
+    )
+    ls = SimpleNamespace(overseas_futureoption=lambda: SimpleNamespace(accno=lambda: account))
+    result = await AccountNodeExecutor()._ls_overseas_futureoption(ls, "account", SimpleNamespace(log=Mock()))
+    position = result["positions"][0]
+    assert position["broker_pnl_amount"] == amount
+    assert position["broker_pnl_basis"] == "broker_reported_unconfirmed"
+    assert position["pnl_amount"] is None and position["pnl_currency"] is None
+    assert position["pnl_basis"] is None and position["pnl_status"] == "unavailable"
+    assert position["pnl_unavailable_reason"] == "native_estimate_requires_contract_metadata"
+    assert position["currency"] == currency
+    assert position["pnl_rate"] == 0.04

--- a/src/programgarden/tests/test_futures_contract_node.py
+++ b/src/programgarden/tests/test_futures_contract_node.py
@@ -271,21 +271,18 @@ async def test_next_unavailable_raises_instead_of_dropping_symbol():
 
 @pytest.mark.asyncio
 async def test_empty_master_surfaces_ls_rsp_cd_not_a_guess():
-    """o3101 이 빈 블록 + 업무거부 rsp_cd 를 주면(HTTP 200, error_msg 빈 문자열), 최종 에러가
-    LS 원문(rsp_cd/rsp_msg)을 그대로 실어야 한다 — '앱키가 몰렸을 것' 같은 추측이 아니라.
-    이 한 줄이 '토큰 무효화 vs 시세 권한 문제'를 라이브 프로브 없이 판별해 준다."""
+    """An empty master retains original response fields without inferring a cause."""
     ex = FuturesContractNodeExecutor()
-    with _patched_master_raw([], rsp_cd="IGW00121", rsp_msg="해외선물 시세 권한이 없습니다"), \
+    with _patched_master_raw([], rsp_cd="SYNTHETIC_UNKNOWN", rsp_msg="Original broker message"), \
             patch("programgarden.executor.asyncio.sleep", new=_async_noop):
         with pytest.raises(RuntimeError) as e:
             await ex.execute(
                 "contract", "FuturesContractNode", {"base_products": ["HMH"]}, _make_context()
             )
     msg = str(e.value)
-    assert "IGW00121" in msg
-    assert "해외선물 시세 권한이 없습니다" in msg
-    # rsp_cd 가 성공이 아니므로 '일시적 경합' 이 아니라 '권한/토큰' 으로 진단해야 한다.
-    assert "entitlement" in msg or "token" in msg
+    assert "rsp_cd=SYNTHETIC_UNKNOWN" in msg
+    assert "rsp_msg=Original broker message" in msg
+    assert "entitlement" not in msg and "token" not in msg and "collision" not in msg
 
 
 @pytest.mark.asyncio
@@ -408,6 +405,8 @@ async def test_symbol_query_unavailable_exchange_raises_not_empty():
     msg = str(e.value)
     assert "CME" in msg
     assert "HKEX" in msg and "LME" in msg  # 무엇을 쓸 수 있는지 알려준다
+    assert "entitlement" not in msg
+    assert "rsp_cd=" in msg and "rsp_msg=" in msg
 
 
 @pytest.mark.asyncio
@@ -448,6 +447,7 @@ async def test_symbol_query_empty_master_raises_with_ls_reason():
     msg = str(e.value)
     assert "IGW00121" in msg
     assert "권한이 없습니다" in msg
+    assert "entitlement" not in msg and "token" not in msg and "app key" not in msg
 
 
 @pytest.mark.asyncio

--- a/src/programgarden/tests/test_futures_order_lifecycle.py
+++ b/src/programgarden/tests/test_futures_order_lifecycle.py
@@ -1,0 +1,520 @@
+"""Actual futures executor with in-memory SDK transport and local-only hooks."""
+from copy import deepcopy
+from datetime import date, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import asyncio
+import socket
+
+import pytest
+
+from programgarden.context import ExecutionContext
+import programgarden.executor as engine
+from programgarden.order_lifecycle import OrderLifecycleMetadata
+from programgarden_finance.ls.overseas_futureoption.order.CIDBT00100.blocks import CIDBT00100OutBlock2
+
+
+ORDER = {"symbol": "SYNTHETIC", "exchange": "HKEX", "quantity": 1, "price": 25000}
+CONNECTION = {"broker_node_id": "broker-a", "credential_id": "cred-a", "product": "overseas_futures", "paper_trading": True}
+CONFIG = {"connection": CONNECTION, "order": ORDER, "side": "buy", "order_type": "limit"}
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    def denied(*args, **kwargs):
+        raise AssertionError("Lifecycle tests cannot access a network socket")
+    for name in ("connect", "connect_ex", "sendto"):
+        monkeypatch.setattr(socket.socket, name, denied)
+
+
+class Journal:
+    def __init__(self):
+        self.prepared = []
+        self.accepted_rows = []
+        self.rejected_rows = []
+        self.fail_prepare = False
+        self.fail_accept = False
+        self.replay = None
+
+    def prepare(self, metadata):
+        self.prepared.append(metadata)
+        if self.fail_prepare:
+            raise OSError("Synthetic disk failure")
+        return deepcopy(self.replay)
+
+    def accepted(self, metadata, result):
+        self.accepted_rows.append((metadata, deepcopy(result)))
+        if self.fail_accept:
+            raise OSError("Synthetic disk failure after ACK")
+        return {"client_order_key": "synthetic-parent", "order_observed_at": result["accepted_at"], "recovery_status": "accepted"}
+
+    def rejected(self, metadata, result):
+        self.rejected_rows.append((metadata, deepcopy(result)))
+
+
+def context(tmp_path, handler=None, job_id="fixture-job"):
+    ctx = ExecutionContext(
+        job_id=job_id, workflow_id="fixture-workflow", storage_dir=str(tmp_path),
+        workflow_credentials=[{"credential_id": "cred-a", "data": {"appkey": "key-a", "appsecret": "secret-a", "paper_trading": True}},
+                              {"credential_id": "cred-b", "data": {"appkey": "key-b", "appsecret": "secret-b", "paper_trading": True}}],
+        order_lifecycle_handler=handler,
+    )
+    ctx.set_secret("credential_id", {"appkey": "wrong-legacy-key", "appsecret": "wrong-legacy-secret"})
+    ctx.set_output("broker-a", "connection", CONNECTION)
+    ctx.set_output("broker-b", "connection", {**CONNECTION, "broker_node_id": "broker-b", "credential_id": "cred-b"})
+    return ctx
+
+
+def sdk(monkeypatch, *, response=None, request_error=None):
+    requests, logins = [], []
+    if response is None:
+        response = SimpleNamespace(error_msg=None, rsp_cd="00000", rsp_msg="Synthetic accepted fixture", block2=CIDBT00100OutBlock2(OvrsFutsOrdNo="000000001"))
+    def factory(body):
+        async def req_async():
+            requests.append(body)
+            if request_error:
+                raise request_error
+            return response
+        return SimpleNamespace(req_async=req_async)
+    ls = SimpleNamespace(overseas_futureoption=lambda: SimpleNamespace(order=lambda: SimpleNamespace(CIDBT00100=factory)))
+    def login(*args, **kwargs):
+        logins.append((args, kwargs))
+        return ls, True, None
+    monkeypatch.setattr(engine, "ensure_ls_login", login)
+    return requests, logins
+
+
+async def execute(executor, ctx, config=None, **kwargs):
+    return await executor.execute("order", "OverseasFuturesNewOrderNode", deepcopy(config or CONFIG), ctx, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_ack_frozen_before_fill_wait_cancellation_then_retry_sends_once(tmp_path, monkeypatch):
+    ctx = context(tmp_path)
+    requests, logins = sdk(monkeypatch)
+    executor = engine.NewOrderNodeExecutor()
+    legacy = []
+    ctx.record_order_submitted = lambda **row: legacy.append(deepcopy(row))
+    async def cancelled(*args, **kwargs):
+        assert len(legacy) == 1
+        assert next(iter(ctx._order_lifecycle_operations.values()))["accepted"]["order_id"] == "000000001"
+        raise asyncio.CancelledError()
+    monkeypatch.setattr(executor, "_confirm_order_fill", cancelled)
+    with pytest.raises(asyncio.CancelledError):
+        await execute(executor, ctx)
+    replay = await execute(executor, ctx)
+    assert len(requests) == len(logins) == 1
+    assert replay["order_result"]["success"] is True
+    assert replay["result"][0]["idempotent_replay"] is True
+    entry = next(iter(ctx._order_lifecycle_operations.values()))
+    metadata, accepted = entry["metadata"], entry["accepted"]["order_result"]
+    assert isinstance(metadata, OrderLifecycleMetadata)
+    assert requests[0].OrdDt == metadata.broker_order_date.strftime("%Y%m%d")
+    assert accepted["broker_order_date"] == metadata.broker_order_date.isoformat()
+    assert accepted["order_date_basis"] == "CIDBT00100_request_OrdDt"
+    assert datetime.fromisoformat(accepted["accepted_at"]).tzinfo is not None
+    assert accepted["response_code"] == "00000"
+    assert accepted["response_message"] == "Synthetic accepted fixture"
+
+
+@pytest.mark.asyncio
+async def test_post_ack_disk_failure_preserves_success_and_replay(tmp_path, monkeypatch):
+    journal = Journal(); journal.fail_accept = True
+    ctx = context(tmp_path, journal)
+    requests, _ = sdk(monkeypatch)
+    executor = engine.NewOrderNodeExecutor()
+    monkeypatch.setattr(executor, "_confirm_order_fill", AsyncMock(side_effect=OSError("Synthetic confirmation error")))
+    output = await execute(executor, ctx)
+    replay = await execute(executor, ctx)
+    assert len(requests) == 1
+    for row in (output, replay):
+        assert row["order_result"]["success"] is True
+        assert row["order_id"] == "000000001"
+        assert row["result"][0]["recovery_status"] == "persistence_failed"
+    assert not journal.rejected_rows
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["prepare", "transport", "cancel"])
+async def test_prepared_uncertain_operation_blocks_retry(tmp_path, monkeypatch, failure):
+    journal = Journal(); journal.fail_prepare = failure == "prepare"
+    ctx = context(tmp_path, journal)
+    error = {"prepare": None, "transport": TimeoutError("Synthetic transport timeout"), "cancel": asyncio.CancelledError()}[failure]
+    requests, _ = sdk(monkeypatch, request_error=error)
+    executor = engine.NewOrderNodeExecutor()
+    if failure == "cancel":
+        with pytest.raises(asyncio.CancelledError):
+            await execute(executor, ctx)
+    else:
+        first = await execute(executor, ctx)
+        assert first["result"][0]["success"] is False
+    replay = await execute(executor, ctx)
+    assert len(requests) == (0 if failure == "prepare" else 1)
+    assert len(journal.prepared) == 1 and not journal.rejected_rows
+    assert replay["result"][0]["recovery_status"] == "prepared_or_uncertain"
+
+
+@pytest.mark.asyncio
+async def test_without_handler_paper_ack_guard_is_unconditional(tmp_path, monkeypatch):
+    ctx = context(tmp_path)
+    requests, _ = sdk(monkeypatch)
+    executor = engine.NewOrderNodeExecutor()
+    monkeypatch.setattr(executor, "_confirm_order_fill", AsyncMock(side_effect=asyncio.CancelledError()))
+    with pytest.raises(asyncio.CancelledError):
+        await execute(executor, ctx)
+    assert (await execute(executor, ctx))["result"][0]["success"]
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+async def test_prior_durable_acceptance_replays_without_transport(tmp_path, monkeypatch):
+    journal = Journal()
+    journal.replay = {"success": True, "order_id": "known", "client_order_key": "known-parent", "status": "submitted"}
+    requests, _ = sdk(monkeypatch)
+    output = await execute(engine.NewOrderNodeExecutor(), context(tmp_path, journal))
+    assert not requests and not journal.accepted_rows
+    assert output["result"][0]["order_id"] == "known"
+    assert output["result"][0]["idempotent_replay"]
+
+
+@pytest.mark.asyncio
+async def test_iteration_cycle_tool_call_and_fresh_job_are_distinct_operations(tmp_path, monkeypatch):
+    journal = Journal()
+    ctx = context(tmp_path, journal)
+    ctx._workflow_job = SimpleNamespace(_order_cycle=0)
+    requests, _ = sdk(monkeypatch)
+    executor = engine.NewOrderNodeExecutor()
+    monkeypatch.setattr(executor, "_confirm_order_fill", AsyncMock())
+    for index in (0, 1):
+        ctx.set_iteration_context(ORDER, index, 2)
+        assert (await execute(executor, ctx))["result"][0]["success"]
+    assert (await execute(executor, ctx))["result"][0]["idempotent_replay"]
+    ctx._workflow_job._order_cycle = 1
+    await execute(executor, ctx)
+    for call_id in ("tool:agent:call-1", "tool:agent:call-2"):
+        await execute(executor, ctx, order_invocation_id=call_id)
+    await execute(executor, context(tmp_path, journal, job_id="fresh-job"))
+    assert len(requests) == 6
+    assert len({m.operation_key for m in journal.prepared}) == 6
+
+
+@pytest.mark.asyncio
+async def test_changed_facts_do_not_create_a_new_retry_key(tmp_path, monkeypatch):
+    requests, _ = sdk(monkeypatch)
+    executor = engine.NewOrderNodeExecutor()
+    monkeypatch.setattr(executor, "_confirm_order_fill", AsyncMock())
+    ctx = context(tmp_path, Journal())
+    await execute(executor, ctx)
+    conflict = await execute(executor, ctx, {**CONFIG, "order": {**ORDER, "quantity": 2}})
+    assert len(requests) == 1 and conflict["result"][0]["success"] is False
+    assert "facts conflict" in conflict["result"][0]["error"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("connection", [
+    {"product": "overseas_futures", "paper_trading": True},
+    {**CONNECTION, "credential_id": "cred-b"},
+    {**CONNECTION, "credential_id": "missing"},
+    {**CONNECTION, "product": "overseas_stock"},
+    {**CONNECTION, "paper_trading": False},
+])
+async def test_invalid_route_fails_before_login_and_prepare(tmp_path, monkeypatch, connection):
+    requests, logins = sdk(monkeypatch)
+    journal = Journal()
+    output = await execute(engine.NewOrderNodeExecutor(), context(tmp_path, journal), {**CONFIG, "connection": connection})
+    assert output["result"][0]["success"] is False
+    assert not requests and not logins and not journal.prepared
+
+
+@pytest.mark.asyncio
+async def test_two_brokers_exact_second_credential_is_used(tmp_path, monkeypatch):
+    requests, logins = sdk(monkeypatch)
+    ctx = context(tmp_path, Journal())
+    executor = engine.NewOrderNodeExecutor()
+    monkeypatch.setattr(executor, "_confirm_order_fill", AsyncMock())
+    output = await execute(executor, ctx, {**CONFIG, "connection": ctx.get_all_outputs("broker-b")["connection"]})
+    assert output["result"][0]["success"]
+    assert logins[0][0][:3] == ("key-b", "secret-b", True)
+    assert ctx.order_lifecycle_handler.prepared[0].credential_id == "cred-b"
+
+
+@pytest.mark.parametrize("owner", [engine.WorkflowJob, engine.AIAgentToolExecutor])
+def test_both_injection_paths_preserve_explicit_and_reject_ambiguity(tmp_path, owner):
+    ctx = context(tmp_path)
+    broker = SimpleNamespace(product_scope="overseas_futures", broker_provider="ls", node_type="OverseasFuturesBrokerNode")
+    target = SimpleNamespace(product_scope="overseas_futures", broker_provider="ls")
+    host = SimpleNamespace(context=ctx, workflow=SimpleNamespace(nodes={"broker-a": broker, "broker-b": broker}))
+    explicit = {"connection": ctx.get_all_outputs("broker-b")["connection"]}
+    assert owner._auto_inject_connection(host, "order", target, explicit) is explicit
+    with pytest.raises(ValueError, match="Multiple compatible"):
+        owner._auto_inject_connection(host, "order", target, {})
+    host.workflow.nodes.pop("broker-b")
+    assert owner._auto_inject_connection(host, "order", target, {})["connection"]["broker_node_id"] == "broker-a"
+
+
+@pytest.mark.asyncio
+async def test_stock_legacy_login_and_dry_run_skip_lifecycle(tmp_path, monkeypatch):
+    requests, logins = sdk(monkeypatch)
+    journal = Journal(); ctx = context(tmp_path, journal)
+    executor = engine.NewOrderNodeExecutor()
+    stock = executor._order_result(True, "SYNTHETIC", "NASDAQ", "buy", 1, 5, None, "stock-fixture")
+    monkeypatch.setattr(executor, "_execute_overseas_stock", AsyncMock(return_value=stock))
+    monkeypatch.setattr(executor, "_confirm_order_fill", AsyncMock())
+    output = await executor.execute("stock", "OverseasStockNewOrderNode", {**CONFIG, "connection": {"product": "overseas_stock"}}, ctx)
+    assert output["order_id"] == "stock-fixture"
+    assert logins[0][0][:2] == ("wrong-legacy-key", "wrong-legacy-secret")
+    ctx.context_params["dry_run"] = True
+    dry = await execute(executor, ctx)
+    assert dry["dry_run"] is True and len(logins) == 1
+    assert not journal.prepared and not requests
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code,order_id,expected_rejected", [("FIXTURE_REJECT", "", True), ("UNMAPPED", "", False), ("00000", "", False), ("00000", "0", False), ("02201", "000000001", False)])
+async def test_rejected_hook_requires_known_rejection_without_ack(tmp_path, monkeypatch, code, order_id, expected_rejected):
+    journal = Journal()
+    from programgarden_core.models.order_diagnostics import OVERSEAS_FUTURES_REJECT_CODES
+    monkeypatch.setitem(OVERSEAS_FUTURES_REJECT_CODES, "FIXTURE_REJECT", {"cause": "Synthetic definitive rejection", "retry": "do_not_retry"})
+    response = SimpleNamespace(error_msg=None, rsp_cd=code, rsp_msg="Synthetic response fixture", block2=CIDBT00100OutBlock2(OvrsFutsOrdNo=order_id))
+    sdk(monkeypatch, response=response)
+    executor = engine.NewOrderNodeExecutor()
+    monkeypatch.setattr(executor, "_confirm_order_fill", AsyncMock())
+    monkeypatch.setattr(executor, "_notify_order_reject", AsyncMock())
+    output = await execute(executor, context(tmp_path, journal))
+    assert bool(journal.rejected_rows) == expected_rejected
+    assert output["result"][0]["success"] == (order_id == "000000001")
+    assert output["result"][0]["response_code"] == code
+
+
+@pytest.mark.asyncio
+async def test_managed_futures_ack_skips_legacy_history_and_retains_parent(tmp_path, monkeypatch):
+    journal = Journal(); ctx = context(tmp_path, journal)
+    requests, _ = sdk(monkeypatch)
+    executor = engine.NewOrderNodeExecutor()
+    history = AsyncMock(side_effect=AssertionError("Managed futures must not read legacy history"))
+    monkeypatch.setattr(executor, "_confirm_order_fill", history)
+    result = await execute(executor, ctx)
+    history.assert_not_awaited()
+    assert len(requests) == 1 and len(journal.accepted_rows) == 1
+    assert result["result"][0]["status"] == "submitted"
+    assert result["result"][0]["client_order_key"] == "synthetic-parent"
+    assert result["result"][0]["order_observed_at"] == result["result"][0]["accepted_at"]
+    assert "filled_quantity" not in result["result"][0]
+
+
+def workflow_definition():
+    return {
+        "id": "lifecycle-fixture", "name": "Lifecycle fixture", "version": "1.0.0",
+        "nodes": [{"id": "start", "type": "StartNode"},
+                  {"id": "broker-a", "type": "OverseasFuturesBrokerNode", "credential_id": "cred-a", "paper_trading": True},
+                  {"id": "order", "type": "OverseasFuturesNewOrderNode", "order": ORDER}],
+        "edges": [{"from": "start", "to": "broker-a"}, {"from": "broker-a", "to": "order"}],
+        "credentials": [{"credential_id": "cred-a", "type": "broker_ls_overseas_futures", "data": []}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_actual_split_children_and_retries_keep_separate_operations(tmp_path, monkeypatch):
+    executor = engine.WorkflowExecutor()
+    resolved, validation = executor.compile(workflow_definition())
+    assert validation.is_valid, validation.errors
+    journal = Journal(); ctx = context(tmp_path, journal)
+    job = engine.WorkflowJob("fixture-job", resolved, ctx, executor)
+    ctx.set_workflow_job(job)
+    requests, _ = sdk(monkeypatch)
+    for index in (0, 1, 0, 1):
+        await job._execute_branch_for_item("split", ["order"], ORDER, index, 2)
+    assert len(requests) == 2
+    assert {m.invocation_id for m in journal.prepared} == {"split:split#0", "split:split#1"}
+    assert {m.iteration_index for m in journal.prepared} == {0, 1}
+
+
+@pytest.mark.asyncio
+async def test_actual_auto_iteration_keeps_identical_items_distinct_with_legacy_registry(tmp_path, monkeypatch):
+    executor = engine.WorkflowExecutor()
+    resolved, validation = executor.compile(workflow_definition())
+    assert validation.is_valid
+    ctx = context(tmp_path, Journal())
+    ctx.context_params["enable_order_idempotency"] = True
+    job = engine.WorkflowJob("fixture-job", resolved, ctx, executor)
+    ctx.set_workflow_job(job)
+    requests, _ = sdk(monkeypatch)
+    monkeypatch.setattr(job, "_auto_iterate_pacing_sleep", AsyncMock())
+    config = {"connection": CONNECTION, "order": "{{ item }}"}
+    output = await job._execute_with_auto_iterate("order", resolved.nodes["order"], config, [ORDER, ORDER], "order")
+    assert len(requests) == 2
+    assert len(output["result"]) == 2 and all(row["success"] for row in output["result"])
+    # Restore a fresh runtime context with the same job and durable legacy store.
+    restored = context(tmp_path, Journal())
+    restored.context_params["enable_order_idempotency"] = True
+    restored_job = engine.WorkflowJob("fixture-job", resolved, restored, executor)
+    restored.set_workflow_job(restored_job)
+    monkeypatch.setattr(restored_job, "_auto_iterate_pacing_sleep", AsyncMock())
+    replay = await restored_job._execute_with_auto_iterate("order", resolved.nodes["order"], config, [ORDER, ORDER], "order")
+    assert len(requests) == 2 and all(row["idempotent_replay"] for row in replay["result"])
+
+
+@pytest.mark.asyncio
+async def test_actual_tool_calls_route_exactly_and_use_call_identity(tmp_path, monkeypatch):
+    executor = engine.WorkflowExecutor()
+    resolved, validation = executor.compile(workflow_definition())
+    assert validation.is_valid
+    journal = Journal(); ctx = context(tmp_path, journal)
+    tool = engine.AIAgentToolExecutor(ctx, resolved, engine.GenericNodeExecutor(), executor._executors)
+    tool._tool_configs["submit"] = {"node_id": "order", "node_type": "OverseasFuturesNewOrderNode", "config": deepcopy(CONFIG)}
+    requests, logins = sdk(monkeypatch)
+    for call_id in ("call-1", "call-2", "call-1"):
+        result = await tool.call_tool("submit", {"connection": ctx.get_all_outputs("broker-b")["connection"], "credential_id": "cred-b"}, "agent", tool_call_id=call_id)
+        assert result["result"][0]["success"]
+    assert len(requests) == 2 and all(args[0] == "key-a" for args, _ in logins)
+    assert len({m.operation_key for m in journal.prepared}) == 2
+
+
+@pytest.mark.asyncio
+async def test_broker_output_carries_exact_identity_without_secret(tmp_path):
+    ctx = context(tmp_path)
+    ctx.context_params["dry_run"] = True
+    output = await engine.BrokerNodeExecutor().execute(
+        "broker-b", "OverseasFuturesBrokerNode", {"credential_id": "cred-b", "paper_trading": True}, ctx,
+    )
+    assert output["connection"] == {"provider": "ls-sec.co.kr", "product": "overseas_futures", "paper_trading": True, "broker_node_id": "broker-b", "credential_id": "cred-b"}
+    assert ctx.get_credential("broker_credentials:broker-b:cred-b")["appkey"] == "key-b"
+    assert "appkey" not in output["connection"] and "appsecret" not in output["connection"]
+
+
+@pytest.mark.asyncio
+async def test_executor_injects_runtime_handler_separately_from_dsl(tmp_path, monkeypatch):
+    executor = engine.WorkflowExecutor(); journal = Journal()
+    executor.set_order_lifecycle_handler(journal)
+    monkeypatch.setattr(engine.WorkflowJob, "start", AsyncMock())
+    job = await executor.execute({"id": "handler-fixture", "name": "Handler fixture", "nodes": [{"id": "start", "type": "StartNode"}], "edges": []}, storage_dir=str(tmp_path))
+    assert job.context.order_lifecycle_handler is journal
+    assert "order_lifecycle_handler" not in job.context.context_params
+    assert "order_lifecycle_handler" not in job.context._secrets
+    await job._save_checkpoint()
+    checkpoint = job._get_checkpoint_mgr().load_checkpoint(job.job_id)
+    assert "order_lifecycle_handler" not in (checkpoint["context_params"] or {})
+    fresh_executor = engine.WorkflowExecutor(); fresh_handler = Journal()
+    fresh_executor.set_order_lifecycle_handler(fresh_handler)
+    restored = await fresh_executor.restore(
+        {"id": "handler-fixture", "name": "Handler fixture", "nodes": [{"id": "start", "type": "StartNode"}], "edges": []},
+        job.job_id, storage_dir=str(tmp_path),
+    )
+    assert restored.context.order_lifecycle_handler is fresh_handler
+    assert not restored.context._order_lifecycle_operations
+    if restored.context._resource_context:
+        await restored.context._resource_context.stop()
+    if job.context._resource_context:
+        await job.context._resource_context.stop()
+
+
+@pytest.mark.asyncio
+async def test_managed_futures_broker_does_not_schedule_legacy_history(tmp_path, monkeypatch):
+    executor = engine.BrokerNodeExecutor(); ctx = context(tmp_path, Journal())
+    calls = []
+    monkeypatch.setattr(executor, "_start_background_task", lambda *args: calls.append(args))
+    monkeypatch.setattr(ctx, "init_workflow_position_tracker", lambda **kwargs: None)
+    await executor.execute("broker-a", "OverseasFuturesBrokerNode", {"credential_id": "cred-a", "paper_trading": True}, ctx)
+    assert calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("phase", ["prepare", "accepted"])
+async def test_async_handlers_are_rejected_without_awaiting(tmp_path, monkeypatch, phase):
+    journal = Journal()
+    async def invalid_hook(*args):
+        raise AssertionError("Async lifecycle hook body must never run")
+    setattr(journal, phase, invalid_hook)
+    requests, _ = sdk(monkeypatch)
+    output = await execute(engine.NewOrderNodeExecutor(), context(tmp_path, journal))
+    assert len(requests) == (1 if phase == "accepted" else 0)
+    assert output["result"][0]["success"] is (phase == "accepted")
+    assert output["result"][0]["recovery_status"] == ("persistence_failed" if phase == "accepted" else "prepared_or_uncertain")
+
+
+@pytest.mark.asyncio
+async def test_accepted_hook_cannot_override_broker_success_or_order_id(tmp_path, monkeypatch):
+    journal = Journal()
+    journal.accepted = lambda *args: {"success": False, "order_id": "replacement"}
+    sdk(monkeypatch)
+    output = await execute(engine.NewOrderNodeExecutor(), context(tmp_path, journal))
+    assert output["order_id"] == "000000001" and output["result"][0]["success"]
+    assert output["result"][0]["recovery_status"] == "persistence_failed"
+
+
+@pytest.mark.asyncio
+async def test_ack_date_is_actual_request_date_across_midnight(tmp_path, monkeypatch):
+    import datetime as datetime_module
+    class BeforeMidnight(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 9, 9)
+    class AfterMidnight(date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 9, 10)
+    monkeypatch.setattr(datetime_module, "date", BeforeMidnight)
+    requests, _ = sdk(monkeypatch)
+    journal = Journal(); ctx = context(tmp_path, journal)
+    original = journal.accepted
+    def accepted(metadata, result):
+        monkeypatch.setattr(datetime_module, "date", AfterMidnight)
+        return original(metadata, result)
+    journal.accepted = accepted
+    executor = engine.NewOrderNodeExecutor()
+    output = await execute(executor, ctx)
+    replay = await execute(executor, ctx)
+    assert len(requests) == 1 and requests[0].OrdDt == "20260909"
+    assert output["result"][0]["broker_order_date"] == "2026-09-09"
+    assert replay["result"][0]["broker_order_date"] == "2026-09-09"
+
+
+@pytest.mark.asyncio
+async def test_standalone_post_ack_wait_exception_preserves_success(tmp_path, monkeypatch):
+    requests, _ = sdk(monkeypatch)
+    executor = engine.NewOrderNodeExecutor()
+    history = AsyncMock(side_effect=OSError("Synthetic confirmation failure"))
+    monkeypatch.setattr(executor, "_confirm_order_fill", history)
+    result = await execute(executor, context(tmp_path))
+    history.assert_awaited_once()
+    assert len(requests) == 1 and result["result"][0]["success"]
+    assert result["order_id"] == "000000001"
+
+
+@pytest.mark.asyncio
+async def test_prepared_disk_marker_blocks_retry_in_fresh_runtime_context(tmp_path, monkeypatch):
+    import sqlite3
+    path = tmp_path / "prepared.sqlite"
+    with sqlite3.connect(path) as db:
+        db.execute("CREATE TABLE operations (operation_key TEXT PRIMARY KEY)")
+    class DiskJournal(Journal):
+        def prepare(self, metadata):
+            self.prepared.append(metadata)
+            try:
+                with sqlite3.connect(path) as db:
+                    db.execute("INSERT INTO operations VALUES (?)", (metadata.operation_key,))
+            except sqlite3.IntegrityError as exc:
+                raise RuntimeError("Existing prepared operation requires reconciliation") from exc
+    journal = DiskJournal()
+    requests, _ = sdk(monkeypatch, request_error=TimeoutError("Synthetic uncertain transport"))
+    for _ in range(2):
+        output = await execute(engine.NewOrderNodeExecutor(), context(tmp_path, journal))
+        assert output["result"][0]["recovery_status"] == "prepared_or_uncertain"
+    assert len(requests) == 1 and len(journal.prepared) == 2
+    assert journal.prepared[0].operation_key == journal.prepared[1].operation_key
+    with sqlite3.connect(path) as db:
+        assert db.execute("SELECT count(*) FROM operations").fetchone()[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_bound_tool_connection_reaches_exact_second_broker(tmp_path, monkeypatch):
+    executor = engine.WorkflowExecutor()
+    resolved, validation = executor.compile(workflow_definition())
+    assert validation.is_valid
+    ctx = context(tmp_path, Journal())
+    tool = engine.AIAgentToolExecutor(ctx, resolved, engine.GenericNodeExecutor(), executor._executors)
+    tool._tool_configs["submit"] = {"node_id": "order", "node_type": "OverseasFuturesNewOrderNode", "config": {**CONFIG, "connection": "{{ nodes['broker-b'].connection }}"}}
+    requests, logins = sdk(monkeypatch)
+    output = await tool.call_tool("submit", {}, "agent", tool_call_id="bound-call")
+    assert len(requests) == 1 and output["result"][0]["success"], output
+    assert logins[0][0][:2] == ("key-b", "secret-b")

--- a/src/programgarden/tests/test_futures_pnl_currency_forwarding.py
+++ b/src/programgarden/tests/test_futures_pnl_currency_forwarding.py
@@ -1,0 +1,216 @@
+"""Exercise the real broker callback and listeners without network access."""
+
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import BrokerNodeExecutor
+from programgarden.futures_pnl import GROSS_BASIS, futures_pnl_metadata
+
+
+@pytest.fixture(autouse=True)
+def deny_network(monkeypatch):
+    import socket
+
+    def denied(*args, **kwargs):
+        raise AssertionError("Currency integration tests must remain offline")
+
+    monkeypatch.setattr(socket.socket, "connect", denied)
+    monkeypatch.setattr(socket.socket, "connect_ex", denied)
+    monkeypatch.setattr(socket.socket, "sendto", denied)
+
+
+def position(currency="HKD", amount=Decimal("100"), **changes):
+    values = dict(
+        quantity=1, entry_price=25000, current_price=25010, pnl_rate=0.04,
+        pnl_amount=amount, currency=currency, pnl_currency=currency,
+        pnl_basis=GROSS_BASIS, pnl_status="available",
+        pnl_unavailable_reason=None, broker_pnl_amount=Decimal("97"),
+        broker_pnl_basis="broker_reported_unconfirmed", is_long=True,
+    )
+    return SimpleNamespace(**(values | changes))
+
+
+async def callback_event(positions):
+    events = []
+
+    async def observe(event):
+        events.append(event)
+
+    context = ExecutionContext(job_id="currency-test", workflow_id="currency-workflow")
+    context.add_listener(SimpleNamespace(on_workflow_pnl_update=observe))
+    context.add_listener(SimpleNamespace(on_workflow_pnl_update=observe, pnl_start_date="20260909"))
+    callback = None
+
+    def register(value):
+        nonlocal callback
+        callback = value
+
+    tracker = SimpleNamespace(
+        start=AsyncMock(), stop=AsyncMock(), get_positions=lambda: positions,
+        on_account_pnl_change=register,
+    )
+    real = SimpleNamespace(connect=AsyncMock(), close=AsyncMock())
+    account = SimpleNamespace(account_tracker=lambda **kwargs: tracker)
+    ls = SimpleNamespace(overseas_futureoption=lambda: SimpleNamespace(
+        accno=lambda: account, real=lambda: real, market=lambda: object(),
+    ))
+    executor = BrokerNodeExecutor()
+    await executor._start_overseas_futures_tracker(ls, "broker", "overseas_futures", "ls", context)
+    callback(SimpleNamespace(currency="USD"))  # A stale aggregate label must not win.
+    await executor.cleanup_fill_subscriptions(context.job_id)
+    assert len(events) == 2
+    assert events[1].competition_start_date == "20260909"
+    return events
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("amount", [Decimal("100"), Decimal("0"), Decimal("-25")])
+async def test_native_estimate_reaches_actual_listener_without_workflow_money(amount):
+    events = await callback_event({"HMH_SYNTHETIC": position(amount=amount)})
+    for event in events:
+        assert event.currency == "HKD"
+        assert event.monetary_status == "estimated"
+        assert event.pnl_by_currency["HKD"]["total_pnl_amount"] == amount
+        assert event.monetary_positions["HMH_SYNTHETIC"]["broker_pnl_amount"] == 97
+        assert event.workflow_pnl_amount is None and event.total_pnl_amount is None
+        assert event.workflow_pnl_rate is None and event.account_total_pnl_rate is None
+        assert event.account_total_pnl_amount is None
+        assert event.competition_workflow_pnl_amount is None
+        assert event.workflow_positions == [] and event.other_positions == []
+
+
+@pytest.mark.asyncio
+async def test_mixed_currencies_remain_separate_through_callback():
+    events = await callback_event({
+        "HMH_SYNTHETIC": position(),
+        "USD_SYNTHETIC": position("USD", Decimal("10")),
+    })
+    for event in events:
+        assert event.currency is None
+        assert event.pnl_by_currency["HKD"]["total_pnl_amount"] == 100
+        assert event.pnl_by_currency["USD"]["total_pnl_amount"] == 10
+        assert event.total_pnl_amount is None
+
+
+@pytest.mark.asyncio
+async def test_missing_or_incompatible_evidence_never_uses_price_fallback():
+    events = await callback_event({"HMH_SYNTHETIC": position(
+        pnl_amount=None, pnl_currency=None, pnl_basis=None, pnl_status="unavailable",
+    )})
+    for event in events:
+        assert event.currency is None and event.monetary_status == "unavailable"
+        assert event.pnl_by_currency == {}
+        assert event.unavailable_position_count == 1
+        assert event.total_pnl_amount is None and event.account_total_pnl_amount is None
+
+
+@pytest.mark.parametrize("bad_amount", [None, True, "NaN", "Infinity", "not-a-number"])
+def test_unavailable_scalar_cannot_become_a_currency_bucket(bad_amount):
+    evidence = vars(position(amount=bad_amount))
+    result = futures_pnl_metadata({"synthetic": evidence})
+    assert result["pnl_by_currency"] == {}
+    assert result["currency"] is None
+
+
+@pytest.mark.parametrize("position_currency", [None, "", "USD"])
+def test_estimate_currency_must_match_reported_position_currency(position_currency):
+    evidence = vars(position(currency=position_currency, pnl_currency="HKD"))
+    result = futures_pnl_metadata({"synthetic": evidence})
+    assert result["pnl_by_currency"] == {}
+    assert result["unavailable_position_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_fill_notification_without_account_currency_stays_unavailable():
+    events = []
+
+    async def observe(event):
+        events.append(event)
+
+    context = ExecutionContext(job_id="fill-test", workflow_id="fill-workflow")
+    context.add_listener(SimpleNamespace(on_workflow_pnl_update=observe))
+    context._workflow_position_tracker = SimpleNamespace(record_fill=AsyncMock(return_value="workflow"))
+    context._workflow_broker_node_id = "broker"
+    context._workflow_product = "overseas_futures"
+    await context.record_workflow_fill(
+        order_no="synthetic", order_date="20260909", symbol="HMH_SYNTHETIC", exchange="HKEX",
+        side="buy", quantity=1, price=25247, fill_time="120932213", commda_code="40",
+    )
+    assert len(events) == 1
+    assert events[0].currency is None and events[0].total_pnl_amount is None
+    assert events[0].monetary_unavailable_reason == "account_positions_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_stock_listener_keeps_existing_numeric_contract():
+    events = []
+
+    async def observe(event):
+        events.append(event)
+
+    context = ExecutionContext(job_id="stock-test", workflow_id="stock-workflow")
+    context.add_listener(SimpleNamespace(on_workflow_pnl_update=observe))
+    await context.notify_workflow_pnl(
+        "broker", "overseas_stock", "ls", {"synthetic": 110},
+        {"synthetic": {"quantity": 1, "buy_price": 100, "current_price": 110,
+                       "pnl_rate": 10, "product": "overseas_stock"}}, currency="USD",
+    )
+    assert events[0].total_pnl_amount == 10
+    assert events[0].currency == "USD" and events[0].monetary_status is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hkd_current", [25010, 25000, 24990])
+async def test_actual_sdk_rest_and_tick_reach_listeners_in_native_currency(hkd_current):
+    from programgarden_finance.ls.overseas_futureoption.accno.CIDBQ01500.blocks import CIDBQ01500OutBlock2
+    from programgarden_finance.ls.overseas_futureoption.extension.symbol_spec_manager import SymbolSpec
+    from programgarden_finance.ls.overseas_futureoption.extension.tracker import FuturesAccountTracker
+
+    rows = [CIDBQ01500OutBlock2(
+        IsuCodeVal="HMH_SYNTHETIC", CrcyCodeVal="HKD", BnsTpCode="2",
+        PchsPrc=25000, OvrsDrvtNowPrc=hkd_current, AbrdFutsEvalPnlAmt=777,
+        BalQty=1, CsgnMgn=1000,
+    )]
+    account = SimpleNamespace(CIDBQ01500=lambda **kwargs: SimpleNamespace(
+        req_async=AsyncMock(return_value=SimpleNamespace(
+            rsp_cd="00000", rsp_msg="Synthetic fixture", block2=rows,
+        )),
+    ))
+    sdk = FuturesAccountTracker(account, market_client=None)
+    sdk._spec_manager._specs["HMH_SYNTHETIC"] = SymbolSpec(
+        symbol="HMH_SYNTHETIC", currency="HKD", tick_size=Decimal("1"),
+        tick_value=Decimal("10"), exchange_code="SYNTHETIC", decimal_places=0,
+    )
+    await sdk._fetch_positions()
+    for expected, tick in [((hkd_current - 25000) * 10, None), (-50, 24995)]:
+        if tick is not None:
+            sdk._on_tick_received(SimpleNamespace(body=SimpleNamespace(
+                symbol="HMH_SYNTHETIC", curpr=tick,
+            )))
+        for event in await callback_event(sdk.get_positions()):
+            assert event.currency == "HKD"
+            assert event.pnl_by_currency["HKD"]["total_pnl_amount"] == expected
+            assert event.monetary_positions["HMH_SYNTHETIC"]["broker_pnl_amount"] == 777
+            assert event.total_pnl_amount is None and event.account_total_pnl_rate is None
+            assert event.competition_account_pnl_rate is None
+
+
+@pytest.mark.asyncio
+async def test_futures_product_guard_does_not_require_repeated_position_product():
+    events = []
+
+    async def observe(event):
+        events.append(event)
+
+    context = ExecutionContext(job_id="product-guard", workflow_id="product-guard")
+    context.add_listener(SimpleNamespace(on_workflow_pnl_update=observe, pnl_start_date="20260909"))
+    await context.notify_workflow_pnl("broker", "overseas_futures", "ls", {"synthetic": 110}, {
+        "synthetic": {"quantity": 1, "buy_price": 100, "current_price": 110},
+    })
+    assert events[0].account_total_pnl_amount is None
+    assert events[0].competition_account_pnl_amount is None
+    assert events[0].currency is None

--- a/src/programgarden/tests/test_futures_tc3_side.py
+++ b/src/programgarden/tests/test_futures_tc3_side.py
@@ -1,0 +1,140 @@
+"""Pass real SDK TC3 messages through the engine without network access."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from programgarden.executor import BrokerNodeExecutor
+from programgarden_finance.ls.overseas_futureoption.real import Real
+from programgarden_finance.ls.overseas_futureoption.real.TC3.blocks import TC3RealResponseBody
+
+
+class MemorySocket:
+    def __init__(self):
+        self.messages = asyncio.Queue()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    async def recv(self):
+        return await self.messages.get()
+
+    async def send(self, message):
+        # Subscription envelopes stay inside this in-memory transport.
+        pass
+
+    async def close(self):
+        pass
+
+
+def tc3_packet(side):
+    body = {
+        name: "" for name, field in TC3RealResponseBody.model_fields.items()
+        if field.is_required()
+    }
+    body.update(
+        lineseq="1", key="synthetic-key", user="synthetic-user", svc_id="CH01",
+        ordr_dt="20260909", ordr_no="000123", is_cd="SYNTHETIC", s_b_ccd=side,
+        ccls_q="2", ccls_prc="100.25", ccls_no="000777",
+        ccls_dt="20260910", ccls_tm="001500",
+    )
+    return {
+        "header": {"tr_cd": "TC3", "rsp_cd": "00000", "rsp_msg": "synthetic"},
+        "body": body,
+    }
+
+
+async def deliver_tc3(monkeypatch, side, *, managed=False, shutdown=False):
+    socket = MemorySocket()
+    connect = Mock(return_value=socket)
+    monkeypatch.setattr("programgarden_finance.ls.real_base.connect", connect)
+    monkeypatch.setattr(BrokerNodeExecutor, "_active_trackers", {})
+    real = Real(
+        token_manager=SimpleNamespace(
+            access_token="synthetic-token", wss_url="wss://offline.invalid",
+        ),
+        reconnect=False,
+    )
+    writes, scheduled, parsed = [], [], []
+
+    async def record(**fields):
+        writes.append(fields)
+
+    context = SimpleNamespace(
+        job_id="tc3-side-offline", is_shutdown=shutdown,
+        order_lifecycle_handler=object() if managed else None,
+        log=Mock(), record_workflow_fill=record,
+    )
+    ls = SimpleNamespace(overseas_futureoption=lambda: SimpleNamespace(real=lambda: real))
+    executor = BrokerNodeExecutor()
+    original_schedule = asyncio.run_coroutine_threadsafe
+
+    def schedule(coroutine, loop):
+        future = original_schedule(coroutine, loop)
+        scheduled.append(future)
+        return future
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", schedule)
+    loop = asyncio.get_running_loop()
+    processed = asyncio.Event()
+    try:
+        await executor._subscribe_overseas_futures_fill_events(ls, "broker", context)
+        callback = real._on_message_listeners["TC3"]
+
+        def observe(response):
+            try:
+                parsed.append(response)
+                callback(response)
+            finally:
+                loop.call_soon_threadsafe(processed.set)
+
+        real.TC3().on_tc3_message(observe)
+        await socket.messages.put(json.dumps(tc3_packet(side)))
+        await asyncio.wait_for(processed.wait(), timeout=2)
+        # The callback has finished on the SDK thread. Drain every submitted
+        # coroutine so a skipped event cannot appear successful due to a race.
+        for future in scheduled:
+            await asyncio.wait_for(asyncio.wrap_future(future), timeout=2)
+        connect.assert_called_once()
+        assert len(parsed) == 1
+        assert isinstance(parsed[0].body, TC3RealResponseBody)
+        assert parsed[0].body.s_b_ccd == side
+        return writes, len(scheduled)
+    finally:
+        await real.close(force=True)
+        executor._active_trackers.clear()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("managed", [False, True], ids=["standalone", "app-managed"])
+@pytest.mark.parametrize("side, expected", [("1", "sell"), ("2", "buy"), ("9", None), ("", None)])
+async def test_tc3_sdk_side_and_managed_reconciliation_guard(monkeypatch, caplog, side, expected, managed):
+    writes, scheduled = await deliver_tc3(monkeypatch, side, managed=managed)
+    if managed or expected is None:
+        assert writes == []
+        assert scheduled == 0
+        if not managed:
+            assert "Ignoring TC3 fill with unknown side code" in caplog.text
+    else:
+        assert scheduled == 1
+        assert writes == [{
+            "order_no": "000123", "order_date": "20260909", "symbol": "SYNTHETIC",
+            "exchange": "FUTURES", "side": expected, "quantity": 2, "price": 100.25,
+            "fill_time": "001500", "commda_code": "40",
+        }]
+        # This fix does not invent TC3/REST execution identity or time aliases.
+        assert "execution_id" not in writes[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("side", ["1", "2"])
+async def test_tc3_after_shutdown_never_schedules_inventory_write(monkeypatch, side):
+    writes, scheduled = await deliver_tc3(monkeypatch, side, shutdown=True)
+    assert writes == []
+    assert scheduled == 0

--- a/src/programgarden/tests/test_managed_futures_tc3.py
+++ b/src/programgarden/tests/test_managed_futures_tc3.py
@@ -1,0 +1,45 @@
+"""Managed futures cannot double-write the legacy TC3 FIFO path."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import programgarden.executor as engine
+from programgarden.context import ExecutionContext
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("managed", [True, False])
+async def test_tc3_managed_session_uses_only_canonical_reconciliation(tmp_path, monkeypatch, managed):
+    callbacks = {}
+    real = SimpleNamespace(
+        connect=AsyncMock(),
+        TC2=lambda: SimpleNamespace(on_tc2_message=lambda cb: callbacks.update(tc2=cb)),
+        TC3=lambda: SimpleNamespace(on_tc3_message=lambda cb: callbacks.update(tc3=cb)),
+    )
+    ls = SimpleNamespace(overseas_futureoption=lambda: SimpleNamespace(real=lambda: real))
+    ctx = ExecutionContext(job_id="synthetic-job", workflow_id="synthetic-workflow",
+        storage_dir=str(tmp_path), order_lifecycle_handler=object() if managed else None)
+    writes = []
+    def record(**fields):
+        writes.append(fields)
+        return object()
+    ctx.record_workflow_fill = record
+    scheduled = []
+    monkeypatch.setattr(engine.asyncio, "run_coroutine_threadsafe",
+                        lambda operation, loop: scheduled.append(operation))
+    executor = engine.BrokerNodeExecutor()
+    await executor._subscribe_overseas_futures_fill_events(ls, "synthetic-broker", ctx)
+    event = SimpleNamespace(body=SimpleNamespace(svc_id="CH01", ordr_no="000123",
+        ordr_dt="20260908", ccls_dt="20260909", ccls_no="456", ccls_tm="121000123",
+        is_cd="SYNTHETIC", s_b_ccd="2", ccls_q=1, ccls_prc="100.25"))
+    callbacks["tc3"](event)
+    callbacks["tc3"](event)
+    if managed:
+        assert not writes and not scheduled
+    else:
+        # Standalone compatibility is deliberately unchanged in this guard.
+        assert len(writes) == len(scheduled) == 2
+    ctx._is_shutdown = True
+    executor._active_trackers.clear()

--- a/src/programgarden/tests/test_order_error_mapping.py
+++ b/src/programgarden/tests/test_order_error_mapping.py
@@ -598,16 +598,29 @@ def _futures_response(*, rsp_cd="00000", rsp_msg="정상처리", error_msg=None,
 FUT_ORDER = {"symbol": "HSIM25", "exchange": "HKEX", "quantity": 1, "price": 18000.0}
 
 
+FUTURES_CONNECTION = {"product": "overseas_futures", "paper_trading": True, "broker_node_id": "broker", "credential_id": "fixture"}
+
+
+def _make_futures_context():
+    from programgarden.context import ExecutionContext
+    ctx = ExecutionContext(
+        job_id="futures-diagnostic", workflow_id="futures-diagnostic",
+        workflow_credentials=[{"credential_id": "fixture", "data": {"appkey": "fixture-key", "appsecret": "fixture-secret"}}],
+    )
+    ctx.send_notification = AsyncMock()
+    return ctx
+
+
 class TestOverseasFuturesRejectDiagnostics:
     @pytest.mark.asyncio
     async def test_futures_error_msg_attaches_diagnostics_and_notifies(self):
         ex = NewOrderNodeExecutor()
-        ctx = _make_context()
+        ctx = _make_futures_context()
         resp = _futures_response(rsp_cd="50001", error_msg="증거금 부족")
         ls = _make_ls_with_futures_response(resp)
 
         result = await ex._execute_overseas_futures(
-            ls, dict(FUT_ORDER), "buy", "limit", {}, ctx, "fut-1"
+            ls, dict(FUT_ORDER), "buy", "limit", {"connection": FUTURES_CONNECTION}, ctx, "fut-1"
         )
         order_result = result["order_result"]
         assert order_result["success"] is False
@@ -632,12 +645,12 @@ class TestOverseasFuturesRejectDiagnostics:
     @pytest.mark.asyncio
     async def test_futures_empty_order_no_uses_dedicated_diagnostic(self):
         ex = NewOrderNodeExecutor()
-        ctx = _make_context()
+        ctx = _make_futures_context()
         resp = _futures_response(rsp_cd="00000", rsp_msg="처리중", ord_no="")
         ls = _make_ls_with_futures_response(resp)
 
         result = await ex._execute_overseas_futures(
-            ls, dict(FUT_ORDER), "buy", "limit", {}, ctx, "fut-2"
+            ls, dict(FUT_ORDER), "buy", "limit", {"connection": FUTURES_CONNECTION}, ctx, "fut-2"
         )
         order_result = result["order_result"]
         assert order_result["success"] is False
@@ -651,7 +664,7 @@ class TestOverseasFuturesRejectDiagnostics:
     @pytest.mark.asyncio
     async def test_futures_exception_attaches_fallback_diagnostic(self):
         ex = NewOrderNodeExecutor()
-        ctx = _make_context()
+        ctx = _make_futures_context()
         order_api = MagicMock()
         order_api.req_async = AsyncMock(side_effect=RuntimeError("net down"))
         order_ns = MagicMock()
@@ -662,7 +675,7 @@ class TestOverseasFuturesRejectDiagnostics:
         ls.overseas_futureoption = MagicMock(return_value=ofo)
 
         result = await ex._execute_overseas_futures(
-            ls, dict(FUT_ORDER), "buy", "limit", {}, ctx, "fut-3"
+            ls, dict(FUT_ORDER), "buy", "limit", {"connection": FUTURES_CONNECTION}, ctx, "fut-3"
         )
         order_result = result["order_result"]
         assert order_result["success"] is False
@@ -675,12 +688,12 @@ class TestOverseasFuturesRejectDiagnostics:
     @pytest.mark.asyncio
     async def test_futures_success_has_null_diagnostics(self):
         ex = NewOrderNodeExecutor()
-        ctx = _make_context()
+        ctx = _make_futures_context()
         resp = _futures_response(rsp_cd="00000", ord_no="F987654")
         ls = _make_ls_with_futures_response(resp)
 
         result = await ex._execute_overseas_futures(
-            ls, dict(FUT_ORDER), "buy", "limit", {}, ctx, "fut-4"
+            ls, dict(FUT_ORDER), "buy", "limit", {"connection": FUTURES_CONNECTION}, ctx, "fut-4"
         )
         order_result = result["order_result"]
         assert order_result["success"] is True

--- a/src/programgarden/tests/test_order_result_port.py
+++ b/src/programgarden/tests/test_order_result_port.py
@@ -1,0 +1,272 @@
+"""Catalog result rows resolve in direct, standalone, and saved workflow paths."""
+
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import NewOrderNodeExecutor, WorkflowExecutor, WorkflowJob
+from programgarden.node_runner import NodeRunner
+from programgarden_core import EmptyOrderReason
+from programgarden_core.expression import ExpressionEvaluator
+from programgarden_core.nodes.order import (
+    KoreaStockNewOrderNode, OverseasFuturesNewOrderNode, OverseasStockNewOrderNode,
+)
+
+
+RAW_MESSAGE = "모의투자 주문가능금액이 부족합니다."
+ORDER = {"symbol": "HMHU26", "exchange": "HKEX", "quantity": 1, "price": 25250.0}
+FUTURES_CONNECTION = {"product": "overseas_futures", "paper_trading": True, "broker_node_id": "broker", "credential_id": "fixture"}
+MARKETS = [
+    (OverseasStockNewOrderNode, "overseas_stock", "_execute_overseas_stock"),
+    (OverseasFuturesNewOrderNode, "overseas_futures", "_execute_overseas_futures"),
+    (KoreaStockNewOrderNode, "korea_stock", "_execute_korea_stock"),
+]
+
+
+def context(tmp_path, *, dry_run=False):
+    return ExecutionContext(
+        job_id="result-port", workflow_id="result-port", storage_dir=str(tmp_path),
+        context_params={"dry_run": dry_run},
+        secrets={"credential_id": {"appkey": "fixture-key", "appsecret": "fixture-secret"}},
+        workflow_credentials=[{"credential_id": "fixture", "data": {"appkey": "fixture-key", "appsecret": "fixture-secret"}}],
+    )
+
+
+def result_for(executor, outcome, *, nested_id=False):
+    if outcome == "no_signal":
+        return executor._empty_result(EmptyOrderReason.NO_SIGNAL)
+    output = executor._order_result(
+        outcome == "accepted", ORDER["symbol"], ORDER["exchange"], "buy", 1, ORDER["price"],
+        None if outcome == "accepted" else RAW_MESSAGE,
+        "fixture-order" if outcome == "accepted" and not nested_id else "",
+    )
+    if nested_id and outcome == "accepted":
+        output["order_result"]["order_id"] = "fixture-order"
+        output["order_result"]["product"] = "korea_stock"
+    if outcome == "rejected":
+        output["order_result"]["diagnostics"] = {"rsp_cd": "01425", "raw_msg": RAW_MESSAGE}
+    return output
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("node_class,product,method", MARKETS)
+@pytest.mark.parametrize("outcome", ["accepted", "rejected", "no_signal"])
+async def test_catalog_result_list_preserves_final_legacy_output(tmp_path, monkeypatch, node_class, product, method, outcome):
+    executor = NewOrderNodeExecutor()
+    legacy = result_for(executor, outcome, nested_id=product == "korea_stock")
+    product_call = AsyncMock(return_value=legacy)
+    monkeypatch.setattr(executor, method, product_call)
+    monkeypatch.setattr("programgarden.executor.ensure_ls_login", lambda *a, **k: (object(), True, None))
+
+    async def confirm(ls, product, order_type, output, *args):
+        # Real confirmation updates legacy output in place, after result creation.
+        output["order_result"].update(status="open", filled_quantity=0, filled_count=0)
+
+    monkeypatch.setattr(executor, "_confirm_order_fill", confirm)
+    output = await executor.execute(
+        "order", node_class.__name__,
+        {"connection": FUTURES_CONNECTION if product == "overseas_futures" else {"product": product}, "order": dict(ORDER)}, context(tmp_path),
+    )
+    assert {key: value for key, value in output.items() if key != "result"} == legacy
+    assert isinstance(output["result"], list) and len(output["result"]) == 1
+    row = output["result"][0]
+    assert next(iter(row)) == "order_id"
+    assert row == {**legacy["order_result"], "order_id": "fixture-order" if outcome == "accepted" else ""}
+    assert row is not output["order_result"]
+    product_call.assert_awaited_once()
+    if outcome == "accepted":
+        assert row["status"] == "open" and row["filled_quantity"] == 0
+        # The declared successful row fields exist, including the formerly
+        # separate top-level order_id (or Korea's legacy inner order_id).
+        port = next(p for p in node_class(id="fixture")._outputs if p.name == "result")
+        assert isinstance(port.example, list)
+        assert {field["name"] for field in port.fields}.issubset(row)
+    elif outcome == "rejected":
+        assert row["status"] == "failed" and row["diagnostics"]["raw_msg"] == RAW_MESSAGE
+        row["diagnostics"]["raw_msg"] = "Consumer-local change"
+        assert legacy["order_result"]["diagnostics"]["raw_msg"] == RAW_MESSAGE
+    else:
+        assert row["reason"] == "no_signal" and row["success"] is False
+        assert "filled_quantity" not in row
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("node_class,product,method", MARKETS)
+async def test_dry_run_exposes_simulated_row_without_changing_flat_envelope(tmp_path, monkeypatch, node_class, product, method):
+    def no_login(*args, **kwargs):
+        pytest.fail("Dry-run result projection must not contact a broker")
+
+    monkeypatch.setattr("programgarden.executor.ensure_ls_login", no_login)
+    config = {"order": dict(ORDER), "connection": {"appsecret": "fixture-secret"}}
+    output = await NewOrderNodeExecutor().execute("order", node_class.__name__, config, context(tmp_path, dry_run=True))
+    assert output["requested"] is config and output["dry_run"] is True
+    assert output["status"] == "simulated" and output["order_id"].startswith("DRYRUN-")
+    assert output["result"] == [{"order_id": output["order_id"], "status": "simulated", "dry_run": True}]
+    assert "order_result" not in output  # Legacy simulation envelope stays intact.
+
+
+@pytest.mark.asyncio
+async def test_no_signal_and_early_error_have_rows_without_any_dispatch(tmp_path, monkeypatch):
+    def no_login(*args, **kwargs):
+        pytest.fail("Early results must return without broker login")
+
+    monkeypatch.setattr("programgarden.executor.ensure_ls_login", no_login)
+    executor = NewOrderNodeExecutor()
+    ctx = context(tmp_path)
+    ctx.set_output("sizing", "orders", [])
+    ctx.set_output("sizing", "reason", "no_signal")
+    output = await executor.execute("order", "OverseasFuturesNewOrderNode", {
+        "connection": dict(FUTURES_CONNECTION), "order": "{{ nodes.sizing.orders }}",
+    }, ctx)
+    assert output["result"][0]["reason"] == "no_signal"
+    assert output["result"][0]["order_id"] == ""
+    failed = await executor.execute("order", "OverseasFuturesNewOrderNode", {}, ctx)
+    assert failed["result"][0]["error"] == failed["order_result"]["error"]
+    assert failed["result"][0]["success"] is False
+
+
+@pytest.mark.asyncio
+async def test_replay_rebuilds_rows_after_replay_marker_without_mutating_registry(tmp_path, monkeypatch):
+    executor = NewOrderNodeExecutor()
+    cached = result_for(executor, "accepted")
+    cached["result"] = [{"status": "stale fixture"}]
+    before = deepcopy(cached)
+    ctx = context(tmp_path)
+    monkeypatch.setattr(ctx, "check_order_already_submitted", lambda **kwargs: cached)
+    monkeypatch.setattr("programgarden.executor.ensure_ls_login", lambda *a, **k: pytest.fail("Replay must not send an order"))
+    output = await executor.execute("order", "OverseasFuturesNewOrderNode", {
+        "connection": dict(FUTURES_CONNECTION), "order": dict(ORDER),
+    }, ctx)
+    assert output["result"][0]["idempotent_replay"] is True
+    assert output["result"][0]["order_id"] == "fixture-order"
+    assert output["result"][0]["status"] == "submitted"
+    assert cached == before
+
+
+@pytest.mark.asyncio
+async def test_fill_confirmation_and_fractional_metadata_are_projected_after_updates(tmp_path, monkeypatch):
+    executor = NewOrderNodeExecutor()
+    legacy = result_for(executor, "accepted")
+    monkeypatch.setattr(executor, "_execute_overseas_stock", AsyncMock(return_value=legacy))
+    monkeypatch.setattr("programgarden.executor.ensure_ls_login", lambda *a, **k: (object(), True, None))
+
+    async def confirm(ls, product, order_type, output, *args):
+        output["order_result"].update(status="filled", filled_quantity=1, filled_count=1, fill_price=25249.0)
+
+    monkeypatch.setattr(executor, "_confirm_order_fill", confirm)
+    output = await executor.execute("order", "OverseasStockNewOrderNode", {
+        "connection": {"product": "overseas_stock"}, "order": {**ORDER, "quantity": 1.5},
+    }, context(tmp_path))
+    row = output["result"][0]
+    assert (row["status"], row["filled_quantity"], row["filled_count"], row["fill_price"]) == ("filled", 1, 1, 25249.0)
+    assert row["fractional_remainder"] == 0.5
+    assert output["order_result"] == legacy["order_result"]
+
+
+@pytest.mark.asyncio
+async def test_node_runner_receives_the_same_result_port(tmp_path):
+    runner = NodeRunner()
+    runner._context = context(tmp_path)
+    # Missing connection returns a real executor error before broker setup.
+    output = await runner.run("OverseasFuturesNewOrderNode", node_id="order")
+    assert output["result"] == [{**output["order_result"], "order_id": ""}]
+    assert output["result"][0]["success"] is False
+    await runner.cleanup()
+
+
+def saved_four_node_workflow():
+    # Task 8e's generated/saved graph, node settings, and expression are intact.
+    # Only redacted identity/credential references are replaced with inert fixtures.
+    return {
+        "id": "saved-order-result-fixture", "name": "HMHU26 Paper One Shot", "version": "1.0.0",
+        "nodes": [
+            {"id": "start", "type": "StartNode"},
+            {"id": "broker", "type": "OverseasFuturesBrokerNode", "credential_id": "fixture", "paper_trading": True},
+            {"id": "order", "type": "OverseasFuturesNewOrderNode", "side": "buy", "order_type": "limit", "order": dict(ORDER)},
+            {"id": "display", "type": "TableDisplayNode", "data": "{{ nodes.order.result }}", "title": "HMHU26 주문 결과"},
+        ],
+        "edges": [{"from": "start", "to": "broker"}, {"from": "broker", "to": "order"}, {"from": "order", "to": "display"}],
+        "credentials": [{"credential_id": "fixture", "type": "broker_ls_overseas_futures", "data": []}],
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["accepted", "rejected", "no_signal"])
+async def test_saved_workflow_expression_and_table_receive_result_rows(tmp_path, monkeypatch, outcome):
+    executor = WorkflowExecutor()
+    resolved, validation = executor.compile(saved_four_node_workflow())
+    assert validation.is_valid, validation.errors
+    ctx = context(tmp_path)
+    broker = executor._executors["OverseasFuturesBrokerNode"]
+    monkeypatch.setattr(broker, "execute", AsyncMock(return_value={"connection": dict(FUTURES_CONNECTION)}))
+    order_executor = executor._executors["OverseasFuturesNewOrderNode"]
+    product_call = AsyncMock(return_value=result_for(order_executor, outcome))
+    monkeypatch.setattr(order_executor, "_execute_overseas_futures", product_call)
+    monkeypatch.setattr(order_executor, "_confirm_order_fill", AsyncMock())
+    monkeypatch.setattr("programgarden.executor.ensure_ls_login", lambda *a, **k: (object(), True, None))
+    job = WorkflowJob("result-port", resolved, ctx, executor)
+    ctx.start()
+    await job._run()
+    product_call.assert_awaited_once()
+    rows = ExpressionEvaluator(ctx.get_expression_context()).evaluate("{{ nodes.order.result }}")
+    assert isinstance(rows, list) and len(rows) == 1
+    assert ctx.get_all_outputs("display")["data"] == rows
+    assert ctx.get_all_outputs("display")["rendered"] is True
+    assert job.status == ("failed" if outcome == "rejected" else "completed")
+    assert job.stats["orders_filled"] == 0
+    if outcome == "accepted":
+        assert rows[0]["order_id"] == "fixture-order" and rows[0]["status"] == "submitted"
+        assert job.stats["orders_placed"] == 1
+    elif outcome == "rejected":
+        assert rows[0]["error"] == RAW_MESSAGE and rows[0]["diagnostics"]["rsp_cd"] == "01425"
+        assert rows[0]["order_id"] == "" and job.stats["orders_placed"] == 0
+    else:
+        assert rows[0]["reason"] == "no_signal" and job.stats["orders_placed"] == 0
+
+
+def test_existing_auto_iteration_merges_all_result_rows_without_changing_legacy_rule(tmp_path):
+    executor = NewOrderNodeExecutor()
+    outputs = [result_for(executor, "accepted"), result_for(executor, "rejected")]
+    for output in outputs:
+        output["result"] = [{**output["order_result"], "order_id": output["order_id"]}]
+    job = WorkflowJob("merge", SimpleNamespace(nodes={}), context(tmp_path), SimpleNamespace())
+    merged = job._merge_iterate_results(outputs)
+    assert len(merged["result"]) == 2
+    assert merged["result"][0]["order_id"] == "fixture-order"
+    assert merged["result"][1]["error"] == RAW_MESSAGE
+    assert merged["order_result"] == outputs[-1]["order_result"]
+
+
+@pytest.mark.asyncio
+async def test_implicit_split_order_collection_keeps_legacy_row_shape(tmp_path, monkeypatch):
+    definition = saved_four_node_workflow()
+    definition["nodes"].insert(2, {"id": "split", "type": "SplitNode", "array": [dict(ORDER)]})
+    definition["nodes"][-1] = {"id": "aggregate", "type": "AggregateNode", "mode": "collect"}
+    definition["edges"] = [
+        {"from": "start", "to": "broker"}, {"from": "broker", "to": "split"},
+        {"from": "split", "to": "order"}, {"from": "order", "to": "aggregate"},
+    ]
+    executor = WorkflowExecutor()
+    resolved, validation = executor.compile(definition)
+    assert validation.is_valid, validation.errors
+    ctx = context(tmp_path)
+    monkeypatch.setattr(executor._executors["OverseasFuturesBrokerNode"], "execute", AsyncMock(
+        return_value={"connection": dict(FUTURES_CONNECTION)},
+    ))
+    order_executor = executor._executors["OverseasFuturesNewOrderNode"]
+    legacy = result_for(order_executor, "accepted")
+    monkeypatch.setattr(order_executor, "_execute_overseas_futures", AsyncMock(return_value=legacy))
+    monkeypatch.setattr(order_executor, "_confirm_order_fill", AsyncMock())
+    monkeypatch.setattr("programgarden.executor.ensure_ls_login", lambda *a, **k: (object(), True, None))
+    job = WorkflowJob("result-port", resolved, ctx, executor)
+    ctx.start()
+    await job._run()
+    assert job.status == "completed"
+    assert ctx.get_all_outputs("aggregate")["array"] == [legacy["order_result"]]
+    # Explicit catalog expressions still resolve to their documented list.
+    assert ExpressionEvaluator(ctx.get_expression_context()).evaluate("{{ nodes.order.result }}") == [
+        {**legacy["order_result"], "order_id": "fixture-order"},
+    ]

--- a/src/programgarden/tests/test_order_terminal_outcome.py
+++ b/src/programgarden/tests/test_order_terminal_outcome.py
@@ -1,0 +1,238 @@
+"""One-shot order rejection is a failed run; handled cycle errors keep flowing."""
+
+from copy import deepcopy
+from dataclasses import asdict
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import NewOrderNodeExecutor, WorkflowJob
+from programgarden.resolver import ResolvedEdge, ResolvedNode, ResolvedWorkflow
+from programgarden_core.bases.listener import BaseExecutionListener
+from programgarden_finance.ls.overseas_futureoption.order.CIDBT00100 import TrCIDBT00100
+
+
+RAW_MESSAGE = "모의투자 주문가능금액이 부족합니다."
+REJECTION = {
+    "order_result": {"success": False, "error": RAW_MESSAGE},
+    "order_id": "",
+}
+
+
+class Capture(BaseExecutionListener):
+    def __init__(self):
+        self.notices = []
+        self.states = []
+
+    async def on_notification(self, event):
+        self.notices.append(asdict(event))
+
+    async def on_job_state_change(self, event):
+        self.states.append(event.state)
+
+
+def make_job(tmp_path, output=None, *, downstream=False, raised=False):
+    context = ExecutionContext(job_id="terminal-test", workflow_id="test", storage_dir=str(tmp_path))
+    nodes = {
+        "start": ResolvedNode("start", "StartNode", "infra", {}),
+        "order": ResolvedNode("order", "OverseasFuturesNewOrderNode", "order", {}),
+    }
+    edges = [ResolvedEdge("start", "order")]
+    if downstream:
+        nodes["display"] = ResolvedNode("display", "SummaryDisplayNode", "display", {})
+        edges.append(ResolvedEdge("order", "display"))
+    workflow = ResolvedWorkflow("test", "1.0.0", nodes, edges, list(nodes))
+    result = deepcopy(REJECTION if output is None else output)
+
+    async def execute_node(**kwargs):
+        if kwargs["node_id"] == "order":
+            if raised:
+                raise RuntimeError("Direct node exception")
+            return deepcopy(result)
+        return {}
+
+    job = WorkflowJob("terminal-test", workflow, context, SimpleNamespace(execute_node=execute_node))
+    capture = Capture()
+    context.add_listener(capture)
+    context.start()
+    return job, capture, result
+
+
+@pytest.mark.asyncio
+async def test_sdk_rejection_reaches_failed_terminal_state_with_original_message(tmp_path):
+    # Actual response parsing + futures executor, with no transport request.
+    response = TrCIDBT00100._build_response(
+        None, SimpleNamespace(status=200), {"rsp_cd": "01425", "rsp_msg": RAW_MESSAGE}, {}, None,
+    )
+    request = SimpleNamespace(req_async=AsyncMock(return_value=response))
+    ls = MagicMock()
+    ls.overseas_futureoption.return_value.order.return_value.CIDBT00100.return_value = request
+    context = ExecutionContext(
+        job_id="ack-test", workflow_id="test", storage_dir=str(tmp_path),
+        workflow_credentials=[{"credential_id": "fixture", "data": {"appkey": "fixture-key", "appsecret": "fixture-secret"}}],
+    )
+    connection = {"product": "overseas_futures", "paper_trading": True, "broker_node_id": "broker", "credential_id": "fixture"}
+    output = await NewOrderNodeExecutor()._execute_overseas_futures(
+        ls, {"symbol": "SYNTHETIC", "exchange": "TEST", "quantity": 1, "price": 1.0},
+        "buy", "limit", {"connection": connection}, context, "order",
+    )
+    request.req_async.assert_awaited_once()
+    assert output["order_result"]["diagnostics"]["raw_msg"] == RAW_MESSAGE
+    assert output["order_result"]["error"] == f"Empty OrderNo: {RAW_MESSAGE}"
+    job, capture, _ = make_job(tmp_path, output)
+    await job._run()
+    state = job.get_state()
+    assert state["status"] == "failed"
+    assert state["nodes"]["order"]["state"] == "failed"
+    assert RAW_MESSAGE in state["stats"]["last_error"]
+    assert state["nodes"]["order"]["outputs"]["order_result"]["diagnostics"]["raw_msg"] == RAW_MESSAGE
+    assert state["stats"]["orders_placed"] == state["stats"]["orders_filled"] == 0
+    assert capture.states[-1] == "failed"
+    assert [n["category"] for n in capture.notices] == ["workflow_failed"]
+    assert RAW_MESSAGE in capture.notices[0]["data"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_successful_downstream_does_not_handle_an_order_rejection(tmp_path):
+    job, capture, _ = make_job(tmp_path, downstream=True)
+    await job._run()
+    assert job.get_state()["nodes"]["display"]["state"] == "completed"
+    assert job.status == "failed"
+    assert capture.notices[-1]["category"] == "workflow_failed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reason", ["fetch_failed", "no_symbol"])
+async def test_direct_non_broker_order_failure_also_fails_one_shot(tmp_path, reason):
+    job, _, _ = make_job(tmp_path, {"order_result": {"success": False, "reason": reason}})
+    await job._run()
+    assert job.status == "failed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("output", [
+    {"order_result": {"success": True, "status": "submitted"}, "order_id": "fixture-order"},
+    {"order_result": {"success": False, "reason": "no_signal"}, "order_id": ""},
+])
+async def test_success_and_no_signal_still_complete(tmp_path, output):
+    job, capture, _ = make_job(tmp_path, output)
+    await job._run()
+    assert job.status == "completed"
+    assert job.stats["errors_count"] == 0
+    assert capture.notices[-1]["category"] == "workflow_completed"
+
+
+@pytest.mark.asyncio
+async def test_direct_exception_preserves_existing_fail_fast_contract(tmp_path):
+    job, _, _ = make_job(tmp_path, raised=True, downstream=True)
+    await job._run()
+    assert job.status == "failed"
+    assert job.get_state()["nodes"]["display"]["state"] == "pending"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source", ["schedule", "realtime"])
+async def test_rejected_cycle_does_not_kill_a_resident_job(tmp_path, source):
+    job, _, output = make_job(tmp_path)
+    if source == "schedule":
+        job._has_schedule_node = True
+    else:
+        job._stay_connected_nodes = ["realtime-fixture"]
+
+    async def next_cycle():
+        assert job.context.is_running and not job.context.is_failed
+        assert job.get_state()["nodes"]["order"]["state"] == "failed"
+        output["order_result"] = {"success": False, "reason": "no_signal"}
+        await job._execute_main_flow()
+        assert job.get_state()["nodes"]["order"]["state"] == "completed"
+
+    job._event_loop = AsyncMock(side_effect=next_cycle)
+    await job._run()
+    job._event_loop.assert_awaited_once()
+    assert job.status == "completed"
+    assert job.stats["errors_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_prior_pass_failure_and_historical_statistics_do_not_poison_success(tmp_path):
+    job, _, output = make_job(tmp_path)
+    await job._execute_main_flow()
+    assert job.stats["errors_count"] == 1
+    output["order_result"] = {"success": False, "reason": "no_signal"}
+    await job._run()
+    assert job.status == "completed"
+    assert job.stats["errors_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_explicit_stop_after_rejection_keeps_existing_stop_completion(tmp_path):
+    job, capture, _ = make_job(tmp_path)
+    main_flow = job._execute_main_flow
+
+    async def stopped_flow():
+        await main_flow()
+        job.context.stop()
+
+    job._execute_main_flow = stopped_flow
+    await job._run()
+    assert job.status == "completed"
+    assert capture.notices[-1]["category"] == "workflow_completed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("continue_on_error", [True, False])
+async def test_split_exception_obeys_its_explicit_continuation_policy(tmp_path, continue_on_error):
+    context = ExecutionContext(job_id="split-test", workflow_id="test", storage_dir=str(tmp_path))
+    nodes = {
+        "split": ResolvedNode("split", "SplitNode", "infra", {
+            "array": [1, 2], "continue_on_error": continue_on_error,
+        }),
+        "branch": ResolvedNode("branch", "FixtureNode", "data", {}),
+        "aggregate": ResolvedNode("aggregate", "AggregateNode", "infra", {}),
+    }
+    workflow = ResolvedWorkflow("test", "1.0.0", nodes, [
+        ResolvedEdge("split", "branch"), ResolvedEdge("branch", "aggregate"),
+    ], list(nodes))
+    branch_results = iter([RuntimeError("Handled branch failure"), {"value": 2}])
+
+    async def execute_node(**kwargs):
+        if kwargs["node_id"] == "branch":
+            result = next(branch_results)
+            if isinstance(result, Exception):
+                raise result
+            return result
+        return {"items": context.get_node_state("aggregate", "_collected_items")}
+
+    job = WorkflowJob("split-test", workflow, context, SimpleNamespace(execute_node=execute_node))
+    context.start()
+    await job._run()
+    assert job.status == ("completed" if continue_on_error else "failed")
+    if continue_on_error:
+        assert context.get_all_outputs("aggregate")["items"] == [None, 2]
+
+
+@pytest.mark.asyncio
+async def test_auto_iteration_keeps_its_existing_item_continuation_boundary(tmp_path):
+    job, _, _ = make_job(tmp_path)
+    executor = job.executor.execute_node
+    item_results = iter([RuntimeError("Handled item failure"), deepcopy(REJECTION)])
+
+    async def execute_node(**kwargs):
+        if kwargs["node_id"] != "order":
+            return await executor(**kwargs)
+        result = next(item_results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    job.executor.execute_node = execute_node
+    job._should_auto_iterate = lambda node_type, *_: (
+        (True, "order", [{"quantity": 1}, {"quantity": 1}])
+        if node_type == "OverseasFuturesNewOrderNode" else (False, None, [])
+    )
+    job._auto_iterate_pacing_sleep = AsyncMock()
+    await job._run()
+    assert job.status == "completed"
+    assert any("Handled item failure" in row["message"] for row in job.context.get_logs())

--- a/src/programgarden/tests/test_stock_as1_execution_identity.py
+++ b/src/programgarden/tests/test_stock_as1_execution_identity.py
@@ -1,0 +1,115 @@
+"""Actual AS1 callback and SQLite ledger preserve individual stock executions."""
+
+import asyncio
+from datetime import datetime
+import json
+import socket
+import sqlite3
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.database.workflow_position_tracker import WorkflowPositionTracker
+from programgarden.executor import BrokerNodeExecutor
+from programgarden_finance.ls.overseas_stock.real.AS1.blocks import AS1RealResponseBody
+
+
+@pytest.fixture(autouse=True)
+def isolate_runtime(monkeypatch):
+    def denied(*args, **kwargs):
+        raise AssertionError("Stock execution identity tests are offline")
+
+    for name in ("connect", "connect_ex", "sendto"):
+        monkeypatch.setattr(socket.socket, name, denied)
+    monkeypatch.setattr(socket, "getaddrinfo", denied)
+    monkeypatch.setattr(BrokerNodeExecutor, "_active_trackers", {})
+
+
+def execution_body(execution_id):
+    values = {name: field.examples[0] for name, field in AS1RealResponseBody.model_fields.items()}
+    values.update(sOrdNo=123, sExecNO=execution_id, sExecQty=0.5, sExecPrc=100,
+                  sShtnIsuNo="SYNTH", sOrdMktCode="82", sOrdPtnCode="02", sBnsTp="2",
+                  proctm="120000001")
+    return AS1RealResponseBody.model_validate(values)
+
+
+def ledger_rows(path):
+    with sqlite3.connect(path) as conn:
+        return conn.execute(
+            "SELECT execution_id, quantity, execution_payload FROM trade_history ORDER BY id"
+        ).fetchall()
+
+
+@pytest.mark.asyncio
+async def test_as1_replay_and_identical_partials_reach_durable_identity(tmp_path, monkeypatch):
+    context = ExecutionContext(job_id="stock-identity", workflow_id="offline")
+    path = str(tmp_path / "stock.sqlite")
+    tracker = WorkflowPositionTracker(path, context.job_id, "broker", product="overseas_stock")
+    context._workflow_position_tracker = tracker
+    tracker.record_order("123", datetime.now().strftime("%Y%m%d"), "SYNTH", "NASDAQ",
+                         "buy", 1, 100, context.job_id, "order-node")
+
+    callbacks = {}
+    real = SimpleNamespace(
+        connect=AsyncMock(),
+        AS0=lambda: SimpleNamespace(on_as0_message=lambda callback: callbacks.update(as0=callback)),
+        AS1=lambda: SimpleNamespace(on_as1_message=lambda callback: callbacks.update(as1=callback)),
+    )
+    ls = SimpleNamespace(overseas_stock=lambda: SimpleNamespace(real=lambda: real))
+    submitted = []
+    schedule = asyncio.run_coroutine_threadsafe
+
+    def capture(coroutine, loop):
+        future = schedule(coroutine, loop)
+        submitted.append(future)
+        return future
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", capture)
+    await BrokerNodeExecutor()._subscribe_overseas_stock_fill_events(ls, "broker", context)
+
+    async def emit(execution_id):
+        callbacks["as1"](SimpleNamespace(body=execution_body(execution_id)))
+        assert submitted, "AS1 callback did not schedule execution recording"
+        await asyncio.wrap_future(submitted.pop())
+
+    await emit("0001")
+    first = ledger_rows(path)
+    assert len(first) == 1 and first[0][:2] == ("1", 0.5)
+    assert json.loads(first[0][2])["reported_execution_id"] == "0001"
+
+    await emit("1")
+    assert ledger_rows(path) == first
+
+    # Same order, time, price and quantity; the distinct broker execution ID
+    # proves that this is another partial fill, not a repeated notification.
+    await emit("0002")
+    both = ledger_rows(path)
+    assert [(row[0], row[1]) for row in both] == [("1", 0.5), ("2", 0.5)]
+
+    context._workflow_position_tracker = WorkflowPositionTracker(
+        path, context.job_id, "broker", product="overseas_stock")
+    await emit("0002")
+    assert ledger_rows(path) == both
+    with sqlite3.connect(path) as conn:
+        assert conn.execute("SELECT SUM(remaining_qty) FROM workflow_position_lots").fetchone()[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_context_call_without_execution_identity_retains_legacy_arguments(tmp_path):
+    context = ExecutionContext(job_id="stock-legacy", workflow_id="offline")
+    calls = []
+
+    class LegacyTracker:
+        async def record_fill(self, **kwargs):
+            calls.append(kwargs)
+            return "manual"
+
+    context._workflow_position_tracker = LegacyTracker()
+    result = await context.record_workflow_fill(
+        "123", "20260909", "SYNTH", "NASDAQ", "buy", 0.5, 100, "120000001", "10")
+    assert result == "manual"
+    assert calls == [{"order_no": "123", "order_date": "20260909", "symbol": "SYNTH",
+                      "exchange": "NASDAQ", "side": "buy", "quantity": 0.5, "price": 100,
+                      "fill_time": "120000001", "commda_code": "10"}]

--- a/src/programgarden/tests/test_stock_open_orders_current_day.py
+++ b/src/programgarden/tests/test_stock_open_orders_current_day.py
@@ -1,0 +1,52 @@
+"""Current stock pending-order reads include same-day activity."""
+import asyncio
+import socket
+from types import SimpleNamespace
+
+from programgarden.executor import OpenOrdersNodeExecutor
+from programgarden_finance.ls.overseas_stock.accno.COSAQ00102.blocks import (
+    COSAQ00102InBlock1, COSAQ00102OutBlock3, COSAQ00102Response,
+)
+
+
+def test_open_orders_includes_current_day_and_preserves_fractional_row(monkeypatch):
+    def forbidden(*args, **kwargs):
+        raise AssertionError("Network transport is forbidden")
+
+    for method in ("connect", "connect_ex", "sendto"):
+        monkeypatch.setattr(socket.socket, method, forbidden)
+    monkeypatch.setattr(socket, "getaddrinfo", forbidden)
+    requests = []
+    row = COSAQ00102OutBlock3(
+        OrdNo=17, ShtnIsuNo="AAPL", BnsTpCode="02", OrdQty=1.25,
+        ExecQty=0.25, UnercQty=1, OvrsOrdPrc=100,
+    )
+
+    class API:
+        def overseas_stock(self):
+            return self
+
+        def accno(self):
+            return self
+
+        def cosaq00102(self, body):
+            requests.append(body)
+            return self
+
+        async def req_async(self):
+            return COSAQ00102Response(rsp_cd="00000", rsp_msg="Synthetic success", block3=[row])
+
+    node = OpenOrdersNodeExecutor.__new__(OpenOrdersNodeExecutor)
+    result = asyncio.run(node._ls_overseas_stock(
+        API(), "synthetic-node", SimpleNamespace(log=lambda *args: None),
+    ))
+    assert len(requests) == 1
+    request = requests[0]
+    assert isinstance(request, COSAQ00102InBlock1)
+    assert request.ThdayBnsAppYn == "1"
+    assert request.ExecYn == "2"
+    assert len(request.OrdDt) == 8 and request.OrdDt.isdigit()
+    assert result["count"] == 1
+    assert result["open_orders"][0]["quantity"] == 1.25
+    assert result["open_orders"][0]["filled_quantity"] == 0.25
+    assert result["open_orders"][0]["remaining_quantity"] == 1

--- a/src/programgarden/tests/test_stock_read_failures.py
+++ b/src/programgarden/tests/test_stock_read_failures.py
@@ -1,0 +1,238 @@
+"""Stock read failures retain original responses without fabricating empty success."""
+import asyncio
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+import programgarden.executor as ex
+from programgarden_core.expression import ExpressionContext
+from programgarden_finance.ls.overseas_stock.accno.COSAQ00102 import TrCOSAQ00102
+from programgarden_finance.ls.overseas_stock.market.g3101 import TrG3101
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    def deny(*args, **kwargs):
+        raise AssertionError("Network is forbidden in stock read regression tests")
+
+    for method in ("connect", "connect_ex", "sendto"):
+        monkeypatch.setattr(socket.socket, method, deny)
+    monkeypatch.setattr(socket, "getaddrinfo", deny)
+
+
+class Context:
+    is_deep_validate = False
+    _iteration_item = None
+
+    def __init__(self):
+        self.logs = []
+
+    def get_credential(self):
+        return {"appkey": "synthetic-unused", "appsecret": "synthetic-unused", "paper_trading": False}
+
+    def get_expression_context(self):
+        return ExpressionContext()
+
+    def get_output(self, *args):
+        return None
+
+    def log(self, level, message, node_id=None, **kwargs):
+        self.logs.append((level, message))
+
+
+def response(tr, payload, status=200, exception=None):
+    cls = TrG3101 if tr == "g3101" else TrCOSAQ00102
+    return cls._build_response(cls.__new__(cls), SimpleNamespace(status_code=status), payload, {}, exception)
+
+
+class API:
+    def __init__(self, responses):
+        self.responses = iter(responses)
+        self.requests = []
+
+    def overseas_stock(self):
+        return self
+
+    def market(self):
+        return self
+
+    def accno(self):
+        return self
+
+    def g3101(self, body):
+        self.requests.append(body)
+        return self
+
+    def cosaq00102(self, body):
+        self.requests.append(body)
+        return self
+
+    def req(self):
+        value = next(self.responses)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    async def req_async(self):
+        return self.req()
+
+
+def quote(monkeypatch, responses, symbols=None, public=False):
+    api = API(responses)
+    monkeypatch.setattr(ex, "ensure_ls_login", lambda *args, **kwargs: (api, True, None))
+    node = ex.MarketDataNodeExecutor.__new__(ex.MarketDataNodeExecutor)
+    symbols = symbols or [{"symbol": "AAPL", "exchange": "NASDAQ"}]
+    if public:
+        result = asyncio.run(node.execute("quote", "OverseasStockMarketDataNode", {
+            "connection": {"product": "overseas_stock"}, "symbols": symbols,
+        }, Context()))
+    else:
+        result = asyncio.run(node._fetch_overseas_stock(symbols, Context(), "quote"))
+    return result, api
+
+
+def valid_quote():
+    return response("g3101", {
+        "rsp_cd": "00000", "rsp_msg": "Synthetic success",
+        "g3101OutBlock": {"symbol": "AAPL", "price": "100", "diff": "2", "sign": "5"},
+    })
+
+
+@pytest.mark.parametrize("failure", [
+    None,
+    response("g3101", {"rsp_cd": "SYNTHETIC_HTTP", "rsp_msg": "Synthetic unavailable"}, 503),
+    response("g3101", {"rsp_cd": "SYNTHETIC_REJECT", "rsp_msg": "Synthetic rejection"}),
+    response("g3101", {"rsp_cd": "00000", "rsp_msg": "Synthetic no snapshot"}),
+])
+def test_required_quote_failure_is_structured(monkeypatch, failure):
+    result, api = quote(monkeypatch, [failure, failure], public=True)
+    assert result["values"] == []
+    assert result["error"] and result["reason"] == "fetch_failed"
+    assert ex.NewOrderNodeExecutor._extract_upstream_error(result)
+    assert len(api.requests) == 2
+    attempts = result["failures"][0]["attempts"]
+    assert len(attempts) == 2
+    assert [item["exchange_code"] for item in attempts] == ["82", "81"]
+    if failure is not None:
+        assert attempts[0]["rsp_cd"] == failure.rsp_cd
+        assert attempts[0]["rsp_msg"] == failure.rsp_msg
+        assert attempts[0]["error_msg"] == failure.error_msg
+
+
+def test_quote_attempts_preserve_distinct_original_messages(monkeypatch):
+    failures = [response("g3101", {"rsp_cd": f"SYNTHETIC_{i}", "rsp_msg": f"Original {i}"}) for i in (1, 2)]
+    result, _ = quote(monkeypatch, failures)
+    assert [item["rsp_msg"] for item in result["failures"][0]["attempts"]] == ["Original 1", "Original 2"]
+
+
+def test_quote_alternate_exchange_still_works(monkeypatch):
+    empty = response("g3101", {"rsp_cd": "00000", "rsp_msg": "Synthetic no snapshot"})
+    result, api = quote(monkeypatch, [empty, valid_quote()])
+    assert len(api.requests) == 2
+    assert result["values"][0]["price"] == 100
+    assert result["values"][0]["exchange"] == "NYSE"
+    assert result["values"][0]["change"] == -2
+    assert not result.get("error") and not result.get("_partial_failure")
+
+
+def test_quote_partial_success_keeps_values_and_failed_symbol(monkeypatch):
+    failure = response("g3101", {"rsp_cd": "SYNTHETIC_REJECT", "rsp_msg": "Original failure"})
+    result, api = quote(monkeypatch, [valid_quote(), failure, failure], [
+        {"symbol": "AAPL", "exchange": "NASDAQ"}, {"symbol": "MSFT", "exchange": "NASDAQ"},
+    ])
+    assert len(api.requests) == 3
+    assert [row["symbol"] for row in result["values"]] == ["AAPL"]
+    assert result["_partial_failure"] is True
+    assert result["_failure_reason"]
+    assert result["failures"][0]["symbol"] == "MSFT"
+    assert result["failures"][0]["attempts"][0]["rsp_msg"] == "Original failure"
+
+
+def pending(responses, public=False, monkeypatch=None):
+    api = API(responses)
+    node = ex.OpenOrdersNodeExecutor.__new__(ex.OpenOrdersNodeExecutor)
+    if public:
+        monkeypatch.setattr(ex, "ensure_ls_login", lambda *args, **kwargs: (api, True, None))
+        result = asyncio.run(node.execute("pending", "OverseasStockOpenOrdersNode", {
+            "connection": {"product": "overseas_stock"},
+        }, Context()))
+    else:
+        result = asyncio.run(node._ls_overseas_stock(api, "pending", Context()))
+    return result, api
+
+
+@pytest.mark.parametrize("failure", [
+    None,
+    response("COSAQ00102", {}),
+    response("COSAQ00102", {"rsp_cd": "00000", "rsp_msg": "Blockless success code is insufficient"}),
+    response("COSAQ00102", {"rsp_cd": "SYNTHETIC_REJECT", "rsp_msg": "Synthetic rejection"}),
+    response("COSAQ00102", {"rsp_cd": "SYNTHETIC_HTTP", "rsp_msg": "Synthetic HTTP failure"}, 503),
+    response("COSAQ00102", {"rsp_cd": "SYNTHETIC_REJECT", "rsp_msg": "Echo is not data", "COSAQ00102OutBlock1": {}}),
+    response("COSAQ00102", {
+        "rsp_cd": "SYNTHETIC_UNKNOWN", "rsp_msg": "Unknown even with envelope",
+        "COSAQ00102OutBlock1": {}, "COSAQ00102OutBlock2": {}, "COSAQ00102OutBlock3": [],
+    }),
+])
+def test_pending_unavailable_does_not_become_empty_success(monkeypatch, failure):
+    result, api = pending([failure], public=True, monkeypatch=monkeypatch)
+    assert result["error"] and result["reason"] == "fetch_failed"
+    assert result["diagnostics"]["tr"] == "COSAQ00102"
+    assert len(api.requests) == 1 and api.requests[0].ThdayBnsAppYn == "1"
+    if failure is not None:
+        assert result["diagnostics"]["rsp_cd"] == failure.rsp_cd
+        assert result["diagnostics"]["rsp_msg"] == failure.rsp_msg
+        assert result["diagnostics"]["error_msg"] == failure.error_msg
+
+
+def test_pending_documented_success_empty_is_preserved():
+    empty = response("COSAQ00102", {
+        "rsp_cd": "00000", "rsp_msg": "Synthetic success",
+        "COSAQ00102OutBlock1": {}, "COSAQ00102OutBlock2": {}, "COSAQ00102OutBlock3": [],
+    })
+    result, _ = pending([empty])
+    assert result == {"open_orders": [], "count": 0}
+
+
+def test_pending_nonempty_fractional_row_is_preserved():
+    rows = response("COSAQ00102", {
+        "rsp_cd": "00000", "rsp_msg": "Synthetic success", "COSAQ00102OutBlock3": [
+            {"OrdNo": 17, "ShtnIsuNo": "AAPL", "BnsTpCode": "02", "OrdQty": 1.25, "ExecQty": 0.25, "UnercQty": 1},
+        ],
+    })
+    result, _ = pending([rows])
+    assert result["count"] == 1 and not result.get("error")
+    assert result["open_orders"][0]["quantity"] == 1.25
+    assert result["open_orders"][0]["filled_quantity"] == 0.25
+
+
+def test_pending_transport_exception_keeps_original_message(monkeypatch):
+    result, _ = pending([RuntimeError("Synthetic original transport error")], public=True, monkeypatch=monkeypatch)
+    assert result["reason"] == "fetch_failed"
+    assert result["diagnostics"]["tr"] == "COSAQ00102"
+    assert result["diagnostics"]["error_msg"] == "Synthetic original transport error"
+
+
+def test_quote_transport_exception_keeps_original_message(monkeypatch):
+    result, _ = quote(monkeypatch, [RuntimeError("Synthetic original transport error")] * 2)
+    assert result["reason"] == "fetch_failed"
+    assert result["failures"][0]["attempts"][0]["error_msg"] == "Synthetic original transport error"
+
+
+def test_unknown_code_with_usable_pending_row_keeps_existing_data_behavior():
+    data = response("COSAQ00102", {
+        "rsp_cd": "SYNTHETIC_UNKNOWN", "rsp_msg": "Synthetic usable data",
+        "COSAQ00102OutBlock3": [{"OrdNo": 17, "ShtnIsuNo": "AAPL", "UnercQty": 1}],
+    })
+    result, _ = pending([data])
+    assert result["count"] == 1 and not result.get("error")
+
+
+def test_unusable_pending_identity_is_not_empty_evidence():
+    data = response("COSAQ00102", {
+        "rsp_cd": "00000", "rsp_msg": "Synthetic malformed identity",
+        "COSAQ00102OutBlock1": {}, "COSAQ00102OutBlock2": {},
+        "COSAQ00102OutBlock3": [{"OrdNo": 0}],
+    })
+    result, _ = pending([data])
+    assert result["reason"] == "fetch_failed"

--- a/src/programgarden/tests/test_workflow_position_tracker.py
+++ b/src/programgarden/tests/test_workflow_position_tracker.py
@@ -380,12 +380,11 @@ class TestFuturesMultiplierInference:
             assert float(pnl['total_pnl_amount']) == pytest.approx(broker_pnl, rel=1e-3)
             assert float(pnl['other_pnl_amount']) == pytest.approx(broker_pnl, rel=1e-3)
 
-            # account 경로(pnl_amount 우선)와 스케일 일치 → 자기모순 없음
+            # Legacy local arithmetic is not sufficient currency/account-basis
+            # evidence for the actual listener's account totals.
             ctx = ExecutionContext(job_id='v', workflow_id='v')
             acct = ctx._calculate_account_pnl(snapshot)
-            assert float(acct['account_overseas_futures_pnl_amount']) == pytest.approx(
-                float(pnl['total_pnl_amount']), rel=1e-3
-            )
+            assert acct['account_overseas_futures_pnl_amount'] is None
 
     @pytest.mark.asyncio
     async def test_mislabeled_short_as_long_rejects_negative_mult(self):


### PR DESCRIPTION
Delayed futures executions and repeated stock execution notifications could lose their original order association or inflate positions. This change adds durable execution identity, delayed-recovery lifecycle hooks and exact AS1 execution-number forwarding; unavailable broker reads and futures monetary evidence remain explicit instead of becoming successful empty/zero results.

The release is programgarden 1.33.5 with core ^1.25.3 and finance ^1.9.4 (PR #41), including actual published dependency hashes in the lock. Core, finance and engine changelogs describe the complete release set.

Validation: 321 focused offline engine regressions passed; 214 finance/contract regressions and 258 changed-field examples passed. Paper-futures execution and durable recovery were confirmed. Complete all-account contest count/ROI/MDD acceptance and the user's nighttime real-stock verification remain open.

Release procedure: follow the team's pg-release.md and pg-publish.md, verify TestPyPI installation from the merged artifact, publish the same engine artifact, then create tag/GitHub Release v1.33.5. Consumers deploy the three matching versions together.
