### PR TITLE
release: core 1.26.0 · finance 1.9.5 · engine 1.34.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "programgarden"
-version = "1.33.5"
+version = "1.34.0"
 description = "LS증권 API을 메인으로 제작된 노코딩 시스템 트레이딩 DSL 오픈소스"
 authors = [
     {name = "장용준",email = "coding@programgarden.com"}

--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [1.26.0] - 2026-09-10
+
+### Added
+- Carry a versioned `personal_metrics` envelope on `WorkflowPnLEvent` so an execution
+  ledger's own evidence reaches listeners without being confused with contest evidence.
+
+### Notes
+- Pair with finance 1.9.5 and engine 1.34.0. Engine 1.34.0 requires this version: it always
+  populates `personal_metrics`, so resolving core 1.25.x makes the event unconstructible and
+  the failure is swallowed, stopping PnL events silently.
+
 ## [1.25.3] - 2026-09-09
 
 ### Added

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-core"
-version = "1.25.3"
+version = "1.26.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 readme = "README.md"

--- a/src/finance/CHANGELOG.md
+++ b/src/finance/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.9.5] - 2026-09-10
+
+### Fixed
+- Handle scoped overseas-stock pending-order responses that return no data instead of an error.
+- Preserve omitted stock order detail blocks rather than dropping the response.
+- Correct FOCCQ33600 block field definitions against the observed response.
+
+### Notes
+- Pair with core 1.26.0 and engine 1.34.0.
+
 ## [1.9.4] - 2026-09-09
 
 ### Added

--- a/src/finance/pyproject.toml
+++ b/src/finance/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-finance"
-version = "1.9.4"
+version = "1.9.5"
 license = "AGPL-3.0-or-later"
 description = "프로그램 동산 운영진이 관리하는 증권사 데이터 오픈소스"
 readme = "README.md"

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,5 +1,27 @@
 ## [Unreleased]
 
+## [1.34.0] - 2026-09-10
+
+### Added
+- Report a retained per-workflow execution ledger (`personal_metrics`) on PnL events, kept
+  separate from contest evidence.
+
+### Fixed
+- Stop pinning broker fill queries to the ordering machine's calendar date. LS files an
+  overnight order under the previous business day, so a matching execution was silently
+  discarded and the order stayed unreconciled forever.
+- Widen the overseas-stock fill search without changing the ledger's order identity, so a
+  fill found on the earlier date is still classified against its workflow order.
+- Refresh personal metrics when the ledger changes rather than only on a timer; a fill
+  arriving just after a computation was previously reported as zero executed orders.
+- Report a futures executed-order count as unavailable, never zero, while an app session owns
+  reconciliation: `on_tc3_event` deliberately stops feeding that ledger, so its zero means
+  "not counted here", not "nothing executed".
+
+### Changed
+- deps: require core ^1.26.0 and finance ^1.9.5. Lower bounds are deliberate — this version
+  always emits `personal_metrics`, which core gained in 1.26.0.
+
 ## [1.33.5] - 2026-09-09
 
 ### Added

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.33.5"
+version = "1.34.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
@@ -29,8 +29,12 @@ lxml = "^6.0.2"
 pytickersymbols = {version = ">=1.17.5", python = ">=3.12,<4.0"}
 aiosqlite = "^0.20.0"
 litellm = ">=1.40.0"
-programgarden-core = "^1.25.3"
-programgarden-finance = "^1.9.4"
+# 🔴 core 하한은 1.26.0 이어야 한다 — context.py 가 event_data 에 personal_metrics 를
+# 무조건 실어 WorkflowPnLEvent(**event_data) 를 만드는데, 그 필드는 core 1.26.0 에서
+# 추가됐다. 하한을 낮게 두면 core 1.25.x 로 해석된 환경에서 생성이 TypeError 로 죽고,
+# 그 예외가 바로 위 except Exception 에 삼켜져 **PnL 이벤트가 통째로 조용히 멈춘다.**
+programgarden-core = "^1.26.0"
+programgarden-finance = "^1.9.5"
 programgarden-community = "^1.15.0"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
PyPI 게시 직전 준비 커밋입니다. 사전점검에서 **그대로 게시하면 안 되는 것 3건**이 나와 함께 고쳤습니다.

## 1. 버전이 아예 안 올라가 있었습니다

`v1.33.5` 이후 4패키지 전부 버전 그대로였습니다 → `poetry publish` 가 첫 패키지에서 **400 "File already exists"** 로 죽습니다. 그리고 PyPI 게시는 되돌릴 수 없어서, 중간에 죽으면 반쪽 릴리스가 됩니다.

| 패키지 | 버전 | 근거 |
|---|---|---|
| core | 1.25.3 → **1.26.0** | `WorkflowPnLEvent` 에 필드 추가 = 마이너 |
| finance | 1.9.4 → **1.9.5** | 주식 미체결 응답·FOCCQ33600 블록 수정 = 패치 |
| programgarden | 1.33.5 → **1.34.0** | 보관 실행 원장 도입 = 마이너 |
| community | 1.15.1 (**게시 제외**) | `v1.33.5..main` diff 0줄 |

## 2. 🔴 core 하한을 안 올리면 PnL 이벤트가 **조용히** 멈춥니다

`context.py` 는 `event_data` 에 `personal_metrics` 를 **무조건** 실어 `WorkflowPnLEvent(**event_data)` 를 만드는데, 그 필드는 **core 1.26.0 에서 처음 생깁니다.** 하한이 `^1.25.3` 이면 core 1.25.x 로 해석된 환경에서 생성이 `TypeError` 로 죽고, 그 예외가 바로 위 `except Exception` 에 삼켜집니다 → **PnL 이벤트가 통째로 멈추는데 로그에 아무것도 안 남습니다.**

→ `programgarden-core = "^1.26.0"`, `programgarden-finance = "^1.9.5"` 로 상향했습니다.

## 3. 릴리스 브랜치를 `origin/main` 에서 잘랐습니다

로컬 `main` 이 아직 **v1.33.4(b4ce985)** 였습니다. 거기서 `git push origin main --tags` 를 하면 원격이 **2릴리스 되돌아갑니다.**

## 확인

- 세 패키지 `poetry build` 전부 성공 (`programgarden_core-1.26.0`, `programgarden_finance-1.9.5`, `programgarden-1.34.0`)
- 엔진 테스트 1,493 passed / 25 skipped (기존 실패 6·에러 62 는 이 브랜치의 원래 상태)
- 내부 의존성은 이미 PyPI 버전 표기라 develop→PyPI 재작성 단계는 없습니다
- 참고: `/pg-publish` 문서의 `poetry lock --no-update` 는 Poetry 2.4.1 에 **없는 옵션**이라 그 줄에서 멈춥니다 — 로컬 명령 문서(`.claude/`, gitignore)에서 `poetry lock` 으로 고쳤습니다

## 게시 순서

core → finance → (`poetry lock`) → programgarden. `programgarden` 의 lock 은 **core 1.26.0 이 PyPI 에 올라간 뒤에야** 풀립니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WMecPdhQ2ZMMT5VcGNRNq
