### PR TITLE
feat(ledger): personal_metrics v2 — 체결 단위 승/패·손익 집계

### DIFF
--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -1033,6 +1033,18 @@ class WorkflowPositionTracker:
         Historical FIFO rows have no currency or fee evidence. Keep their amounts
         per symbol/exchange and reject mixed ownership or an incomplete FIFO basis.
         Futures FIFO is not a monetary ledger. No equity/MDD basis is inferred.
+
+        Version 2 adds closed-trade outcomes. One closed trade = one sell fill,
+        using its *stored* realized amount — the replay below only validates the
+        basis and never replaces a stored value, so the outcome is read from the
+        same number the ledger committed.
+
+        Counts aggregate across symbols because a count carries no currency.
+        Amounts do not: with `currency` unproven per row, summing gross profit
+        across symbols would invent the very unit this method refuses to claim.
+        So gross amounts stay inside each group, and the top-level profit/loss
+        ratio is published only when a single group carries the whole ledger —
+        the one case where "the currency is the same" needs no evidence.
         """
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
@@ -1069,6 +1081,7 @@ class WorkflowPositionTracker:
         for (symbol, exchange), fills in sorted(groups.items()):
             reason = None
             amount = None
+            outcome = None
             if self.product == "overseas_futures":
                 reason = "futures_fifo_not_monetary"
             elif not symbol:
@@ -1084,6 +1097,11 @@ class WorkflowPositionTracker:
                 try:
                     lots = []
                     total = Decimal(0)
+                    # NB: `closed` below is the matched lot quantity — do not
+                    # reuse that name for a counter.
+                    trades = wins = losses = evens = 0
+                    gross_profit = Decimal(0)
+                    gross_loss = Decimal(0)
                     for fill in fills:
                         quantity = Decimal(str(fill["quantity"]))
                         price = Decimal(str(fill["price"]))
@@ -1111,18 +1129,84 @@ class WorkflowPositionTracker:
                             # Preserve the stored amount; replay arithmetic only
                             # validates the basis and never replaces its value.
                             total += stored
+                            # One sell fill = one closed trade. Read the outcome
+                            # from the stored amount for the same reason.
+                            trades += 1
+                            if stored > 0:
+                                wins += 1
+                                gross_profit += stored
+                            elif stored < 0:
+                                losses += 1
+                                gross_loss += -stored
+                            else:
+                                evens += 1
                         else:
                             raise ValueError("Unknown fill side")
                     amount = float(total)
                     if not Decimal(str(amount)).is_finite():
                         raise ValueError("Non-finite total")
+                    gross_profit_f = float(gross_profit)
+                    gross_loss_f = float(gross_loss)
+                    if not all(Decimal(str(v)).is_finite() for v in (gross_profit_f, gross_loss_f)):
+                        raise ValueError("Non-finite gross amount")
+                    outcome = {"closed_trades": trades, "winning_trades": wins,
+                               "losing_trades": losses, "breakeven_trades": evens,
+                               "gross_profit": gross_profit_f, "gross_loss": gross_loss_f}
                 except (ValueError, TypeError, ArithmeticError, OverflowError):
                     reason = "incomplete_fifo_basis"
-            realized.append({"symbol": symbol, "exchange": exchange, "currency": None,
-                             "amount": amount, "status": "available" if reason is None else "unavailable",
-                             "reason": reason})
+                    outcome = None
+            entry = {"symbol": symbol, "exchange": exchange, "currency": None,
+                     "amount": amount, "status": "available" if reason is None else "unavailable",
+                     "reason": reason}
+            # A rejected group publishes no outcome: its trades are unknown, and
+            # unknown trades must not be counted as zero of anything.
+            entry.update(outcome or {"closed_trades": None, "winning_trades": None,
+                                     "losing_trades": None, "breakeven_trades": None,
+                                     "gross_profit": None, "gross_loss": None})
+            realized.append(entry)
+        # Counts carry no currency, so they aggregate across symbols. A group the
+        # replay rejected is excluded and downgrades the status to "partial" —
+        # "some of this strategy's trades are not in these numbers" is a different
+        # claim from "these are all of them", and the caller must be able to tell.
+        scored = [g for g in realized if g["closed_trades"] is not None]
+        counted = [g for g in scored if g["closed_trades"] > 0]
+        if not scored:
+            trade_status, trade_reason = "unavailable", (
+                "futures_fifo_not_monetary" if self.product == "overseas_futures"
+                else "no_scorable_fifo_basis")
+            closed_total = winning_total = losing_total = breakeven_total = None
+        else:
+            trade_status = "available" if len(scored) == len(realized) else "partial"
+            trade_reason = None if trade_status == "available" else "some_groups_unscorable"
+            closed_total = sum(g["closed_trades"] for g in scored)
+            winning_total = sum(g["winning_trades"] for g in scored)
+            losing_total = sum(g["losing_trades"] for g in scored)
+            breakeven_total = sum(g["breakeven_trades"] for g in scored)
+
+        # The ratio is money, and money needs a unit. One group means one symbol,
+        # hence one currency — the only case where the unit is provable without
+        # currency evidence. Anything else stays per group.
+        ratio = None
+        ratio_status = "unavailable"
+        if len(counted) != 1:
+            ratio_reason = ("no_closed_trades" if not counted
+                            else "multi_symbol_currency_unknown")
+        else:
+            group = counted[0]
+            if group["gross_loss"] > 0:
+                candidate = group["gross_profit"] / group["gross_loss"]
+                if Decimal(str(candidate)).is_finite():
+                    ratio, ratio_status, ratio_reason = candidate, "available", None
+                else:
+                    ratio_reason = "non_finite_ratio"
+            else:
+                # No losing trade means no denominator. Publishing gross profit
+                # here (the server's day-based metric does) reads as a ratio of
+                # that size and overstates the strategy.
+                ratio_reason = "no_losing_trades"
+
         return {
-            "version": 1,
+            "version": 2,
             "scope": {"kind": "local_workflow_ledger", "product": self.product,
                       "provider": self.provider, "trading_mode": self.trading_mode},
             "as_of": datetime.now(timezone.utc).isoformat(),
@@ -1131,6 +1215,15 @@ class WorkflowPositionTracker:
             "executed_order_count_status": "unavailable" if invalid_count else "available",
             "executed_order_count_reason": "invalid_execution_identity" if invalid_count else None,
             "realized_pnl": realized,
+            "closed_trade_count": closed_total,
+            "winning_trade_count": winning_total,
+            "losing_trade_count": losing_total,
+            "breakeven_trade_count": breakeven_total,
+            "closed_trade_status": trade_status,
+            "closed_trade_reason": trade_reason,
+            "profit_loss_ratio": ratio,
+            "profit_loss_ratio_status": ratio_status,
+            "profit_loss_ratio_reason": ratio_reason,
             "max_drawdown": None,
             "max_drawdown_status": "unavailable",
             "max_drawdown_reason": "equity_history_unavailable",

--- a/src/programgarden/tests/test_personal_monitoring_metrics.py
+++ b/src/programgarden/tests/test_personal_monitoring_metrics.py
@@ -207,3 +207,112 @@ async def test_nonfinite_history_and_inconsistent_realized_value_remain_unavaila
     result = ledger.personal_metrics()
     assert result["executed_order_count"] is None
     assert result["realized_pnl"][0]["amount"] is None
+
+
+# --- v2: closed-trade outcomes -------------------------------------------
+# One closed trade = one sell fill, scored from its *stored* realized amount.
+# Counts aggregate across symbols (a count has no currency); gross amounts do
+# not, so the ratio is published only when one group carries the whole ledger.
+
+
+@pytest.mark.asyncio
+async def test_closed_trades_are_scored_from_the_stored_amount(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 3, 100, "11")
+    await fill(ledger, "2", "sell", 1, 110, "12")   # +10
+    await fill(ledger, "3", "sell", 1, 90, "13")    # -10
+    await fill(ledger, "4", "sell", 1, 100, "14")   # 0
+    result = ledger.personal_metrics()
+    assert result["version"] == 2
+    assert result["closed_trade_count"] == 3
+    assert result["winning_trade_count"] == 1
+    assert result["losing_trade_count"] == 1
+    assert result["breakeven_trade_count"] == 1
+    assert result["closed_trade_status"] == "available"
+    group = result["realized_pnl"][0]
+    assert group["gross_profit"] == 10 and group["gross_loss"] == 10
+    assert result["profit_loss_ratio"] == 1.0
+    assert result["profit_loss_ratio_status"] == "available"
+
+
+@pytest.mark.asyncio
+async def test_open_position_has_no_closed_trade(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11")
+    result = ledger.personal_metrics()
+    assert result["closed_trade_count"] == 0
+    assert result["closed_trade_status"] == "available"
+    # Nothing has been closed, so there is no ratio to speak of — and saying so
+    # is different from saying the ratio is zero.
+    assert result["profit_loss_ratio"] is None
+    assert result["profit_loss_ratio_reason"] == "no_closed_trades"
+
+
+@pytest.mark.asyncio
+async def test_winning_only_ledger_does_not_publish_profit_as_a_ratio(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11")
+    await fill(ledger, "2", "sell", 1, 130, "12")
+    result = ledger.personal_metrics()
+    assert result["winning_trade_count"] == 1 and result["losing_trade_count"] == 0
+    assert result["realized_pnl"][0]["gross_profit"] == 30
+    # The server's day-based metric returns gross profit here and the screen
+    # reads it as "ratio 30.00". No denominator means no ratio.
+    assert result["profit_loss_ratio"] is None
+    assert result["profit_loss_ratio_reason"] == "no_losing_trades"
+
+
+@pytest.mark.asyncio
+async def test_two_symbols_count_together_but_publish_no_ratio(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11", symbol="AAA")
+    await fill(ledger, "2", "sell", 1, 110, "12", symbol="AAA")
+    await fill(ledger, "3", "buy", 1, 200, "13", symbol="BBB")
+    await fill(ledger, "4", "sell", 1, 180, "14", symbol="BBB")
+    result = ledger.personal_metrics()
+    assert result["closed_trade_count"] == 2
+    assert result["winning_trade_count"] == 1 and result["losing_trade_count"] == 1
+    # Two symbols may settle in two currencies, and the ledger holds no currency
+    # evidence — so the amounts stay in their groups.
+    assert result["profit_loss_ratio"] is None
+    assert result["profit_loss_ratio_reason"] == "multi_symbol_currency_unknown"
+    assert {g["symbol"] for g in result["realized_pnl"]} == {"AAA", "BBB"}
+
+
+@pytest.mark.asyncio
+async def test_unscorable_group_downgrades_the_total_instead_of_shrinking_it(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11", symbol="AAA")
+    await fill(ledger, "2", "sell", 1, 110, "12", symbol="AAA")
+    await fill(ledger, "3", "sell", 1, 50, "13", symbol="BBB")   # unmatched
+    result = ledger.personal_metrics()
+    assert result["closed_trade_count"] == 1
+    assert result["closed_trade_status"] == "partial"
+    assert result["closed_trade_reason"] == "some_groups_unscorable"
+    rejected = [g for g in result["realized_pnl"] if g["symbol"] == "BBB"][0]
+    # An unknown group contributes no trades, not zero trades.
+    assert rejected["closed_trades"] is None and rejected["gross_profit"] is None
+
+
+@pytest.mark.asyncio
+async def test_futures_ledger_scores_no_trades(tmp_path):
+    ledger = tracker(tmp_path, product="overseas_futures", trading_mode="paper")
+    await fill(ledger, "1", "buy", 1, 100, "11")
+    await fill(ledger, "2", "sell", 1, 110, "12")
+    result = ledger.personal_metrics()
+    assert result["closed_trade_count"] is None
+    assert result["closed_trade_status"] == "unavailable"
+    assert result["closed_trade_reason"] == "futures_fifo_not_monetary"
+    assert result["profit_loss_ratio"] is None
+
+
+@pytest.mark.asyncio
+async def test_mixed_ownership_keeps_its_trades_out_of_the_count(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11", manual=True)
+    await fill(ledger, "2", "sell", 1, 110, "12")
+    result = ledger.personal_metrics()
+    assert result["realized_pnl"][0]["reason"] == "mixed_fifo_ownership"
+    assert result["closed_trade_count"] is None
+    assert result["closed_trade_status"] == "unavailable"
+    assert result["closed_trade_reason"] == "no_scorable_fifo_basis"


### PR DESCRIPTION
## 무엇

`WorkflowPositionTracker.personal_metrics()` 봉투를 **v2**로 올린다 — 체결 단위 승/패·총이익·총손실.
서버(dsl-api)·대시보드가 v2 를 받도록 하는 변경은 부모 repo PR #831 에 있다.

## 왜

커뮤니티 공유 상세의 승률·손익비는 체결 원천이 없어 "수익 난 날 비율 / 양수 날 합 ÷ 음수 날 합" 이었다.
엔진은 이미 체결마다 FIFO 실현손익을 `trade_history.realized_pnl` 에 적고 `personal_metrics()` 가
그걸 되짚어 검증한다 — **되짚는 루프 안에서 라운드트립 손익을 계산해 놓고 합계만 쓰고 버리고 있었다.**
이 PR 은 그 자리에서 승/패를 센다. 새 원천·새 브로커 조회 없음.

## 규칙 (이 모듈의 기존 규율 그대로)

- 매도 체결 1건 = 닫힌 거래 1건. 승/패는 **저장된** 실현손익으로 판정(되짚기는 검증만, 값 대체 금지 — 기존 불변식).
- **개수는 종목 간 합산**(개수엔 통화가 없다). **금액은 합산 금지**(행에 통화 증거가 없다 → 그룹 안에만).
- `profit_loss_ratio` 는 **거래가 있는 그룹이 정확히 하나 + 손실 거래 존재**일 때만. 손실 0 이면 `no_losing_trades`
  (총이익을 비율인 척 내보내지 않는다).
- 되짚기가 거부한 그룹은 여섯 칸 전부 None — 모르는 거래는 0건이 아니다. 상위 status 는 `partial` 로 내려간다.

## 검증

- `tests/test_personal_monitoring_metrics.py` +7 · `pytest tests/test_personal_monitoring_metrics.py tests/test_workflow_position_tracker.py` → **47 passed**
- 테스트가 잡은 내 버그 1건: 카운터 이름 `closed` 가 로트 매칭 루프의 매칭수량 변수와 충돌 → 개명.

## 배포 순서 (🔴)

dsl-api 리더는 `version != 1` 이면 봉투를 통째로 버리고, 대시보드 zod 는 `version: z.literal(1)` + `.catch(null)` 이다.
**dsl-api → 대시보드 → 이 엔진 릴리스** 순서가 아니면 기존 모니터링 타일이 빈다. 릴리스(PyPI·pg-worker 핀)는 별도 단계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jgvXMHMiFPHPEsadb6ydr
