### PR TITLE
feat(ledger): 매체코드 표 기준 분류 + 계좌 평균매입가 추정 + off_strategy_fills (봉투 v2 확장)

### DIFF
--- a/src/programgarden/programgarden/context.py
+++ b/src/programgarden/programgarden/context.py
@@ -2612,6 +2612,7 @@ class ExecutionContext:
         commda_code: str = "40",
         *,
         execution_id: Optional[str | int] = None,
+        account_avg_price: Optional[float] = None,
     ) -> str:
         """Record fill event for FIFO position tracking.
         
@@ -2626,9 +2627,11 @@ class ExecutionContext:
             quantity: 체결 수량
             price: 체결 가격
             fill_time: 체결시각 (HHMMSSsss)
-            commda_code: 매체구분코드 ("40"=OPEN API, 기타=수동)
+            commda_code: 매체구분코드 (프레임 값 그대로; "40"=OPEN API, 기타=수동/HTS)
             execution_id: Optional broker execution number, preserved for durable replay detection.
-            
+            account_avg_price: Optional account average purchase price for this
+                symbol at fill time; only a workflow sell's residual tail uses it.
+
         Returns:
             분류 결과: "workflow" | "manual" | "unknown_api" | "pending"
         """
@@ -2638,6 +2641,8 @@ class ExecutionContext:
         
         try:
             identity_kwargs = {"execution_id": execution_id} if execution_id is not None else {}
+            if account_avg_price is not None:
+                identity_kwargs["account_avg_price"] = account_avg_price
             result = await self._workflow_position_tracker.record_fill(
                 order_no=order_no,
                 order_date=order_date,

--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -102,10 +102,13 @@ class ExecutionIdentityConflictError(ValueError):
 #  85=HTS, 96=final settlement, LP=loss cut, SK=CashCall and SO=conditional order.
 #  The example uses 40, which the table does not map. Preserve it as returned;
 #  do not classify it by guessing a nearby code."
-# '40' 은 표에 없지만 우리 OPEN API 주문이 실제로 받는 값이다(dev verified_fills 실측 4건) —
-# 표의 41/43 과 함께 API 묶음으로 둔다. 표에 없는 값은 추측하지 않고 "other" 로 남긴다.
-MEDIA_CODES_HUMAN = frozenset({"85", "22", "23", "00"})   # HTS · iPhone · Android · 지점
-MEDIA_CODES_API = frozenset({"40", "41", "43"})           # OPEN API(실측) · API · Robo API
+# '40' 은 표에 없지만 우리 OPEN API 주문이 실제로 받는 값이다(dev verified_fills 실측 4건 +
+# 2026-09-12 해외주식 AS1 실측: 우리 매도 주문 244 → 40) — 표의 41/43 과 함께 API 묶음으로 둔다.
+# 🔴 해외주식 AS1 실측(2026-09-12, 실계좌 NIO 1주씩): HTS → 85(표와 일치) · iPhone 투혼앱 → **51**
+# (표의 22 아님) · 투혼 웹 → **03**(표에 없음). 표는 해외선물 TR 문서라 해외주식 푸시와 앱/웹 코드가
+# 다르다. 관측된 값만 사람 채널에 추가한다 — 표에 없고 관측도 안 된 값은 여전히 "other".
+MEDIA_CODES_HUMAN = frozenset({"85", "22", "23", "00", "51", "03"})   # HTS · iPhone(표) · Android(표) · 지점 · 투혼앱(실측) · 투혼웹(실측)
+MEDIA_CODES_API = frozenset({"40", "41", "43"})                       # OPEN API(실측) · API · Robo API
 
 
 def media_channel(commda_code: str | None) -> str:

--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -87,6 +87,10 @@ class PendingFill:
     commda_code: str
     received_at: datetime
     execution_id: Optional[str | int] = None
+    # Account average purchase price for this symbol at the moment of the fill,
+    # read from the broker snapshot before it refreshes. Used only to estimate a
+    # workflow sell's residual tail (see _process_sell_fifo); None → no estimate.
+    account_avg_price: Optional[float] = None
 
 
 class ExecutionIdentityConflictError(ValueError):
@@ -251,6 +255,19 @@ class WorkflowPositionTracker:
             for column in ("execution_id", "normalized_order_no", "execution_payload"):
                 if column not in columns:
                     cursor.execute(f"ALTER TABLE trade_history ADD COLUMN {column} TEXT")
+            # Additive columns for the account-average-price sell estimate. A
+            # workflow sell that empties the strategy's own lots and still has a
+            # tail records that tail here (the residual quantity, the account
+            # average purchase price it was estimated against, the source label,
+            # and the estimated PnL). realized_pnl stays FIFO-matched only; these
+            # never enter _execution_facts / conflict detection. NULL on every
+            # row that carries no estimate (buys, fully matched sells, old rows).
+            for column, coltype in (("unmatched_qty", "REAL"),
+                                    ("estimate_basis_price", "REAL"),
+                                    ("estimate_source", "TEXT"),
+                                    ("estimated_pnl", "REAL")):
+                if column not in columns:
+                    cursor.execute(f"ALTER TABLE trade_history ADD COLUMN {column} {coltype}")
             cursor.execute("""
                 CREATE UNIQUE INDEX IF NOT EXISTS uq_trade_history_execution_v1
                 ON trade_history(product, provider, trading_mode, order_date,
@@ -386,6 +403,7 @@ class WorkflowPositionTracker:
         commda_code: str,
         *,
         execution_id: Optional[str | int] = None,
+        account_avg_price: Optional[float] = None,
     ) -> str:
         """
         체결 기록 및 FIFO 처리
@@ -401,7 +419,12 @@ class WorkflowPositionTracker:
             quantity: 수량
             price: 체결가
             fill_time: 체결시각 (HHMMSSsss)
-            commda_code: 매체구분코드 (40=OPEN API)
+            commda_code: 매체구분코드 (40=OPEN API). 프레임에서 온 값을 그대로
+                받는다 — 우리 주문과 일치하면 매체코드와 무관하게 workflow 로,
+                일치하지 않는 fill 만 매체코드로 manual(HTS)/unknown_api 를 가른다.
+            account_avg_price: Optional account average purchase price for this
+                symbol at fill time. Only a workflow sell whose own lots run out
+                uses it, to estimate the residual tail. None → no estimate.
             execution_id: Optional broker execution identity. Positive numeric
                 strings/integers ignore padding; opaque strings retain case.
                 None, blank, and zero mean no identity and retain legacy replay
@@ -423,7 +446,7 @@ class WorkflowPositionTracker:
             order_no=order_no, order_date=order_date, symbol=symbol,
             exchange=exchange, side=side, quantity=quantity, price=price,
             fill_time=fill_time, commda_code=commda_code, received_at=datetime.now(),
-            execution_id=execution_id,
+            execution_id=execution_id, account_avg_price=account_avg_price,
         )
         identity = self._execution_key(fill)
         async with self._buffer_lock:
@@ -437,11 +460,25 @@ class WorkflowPositionTracker:
                 if previous is not None:
                     return previous
 
-            if commda_code != "40":
-                return await self._process_fill_internal(fill, "manual")
+            # A fill that matches one of our recorded workflow orders is ours,
+            # whatever communication-media code the broker stamped on it — the
+            # recorded order is the authoritative ownership signal, so it is
+            # checked first. (Now that the real media code is forwarded instead
+            # of a hardcoded '40', our own OPEN-API fills may not carry '40'; the
+            # old media-first ordering would then misfile them as manual.)
             if self._is_workflow_fill(fill):
                 return await self._process_fill_internal(fill, "workflow")
+            # No matching order. A definite, non-'40' media code identifies a
+            # trade placed on this account through another channel (HTS/web) —
+            # a person, classified "manual".
+            if commda_code and commda_code != "40":
+                return await self._process_fill_internal(fill, "manual")
 
+            # '40' (OPEN API) or an empty/None media code ("medium unknown"):
+            # buffer to give a lagging order record a chance to arrive, then
+            # _process_timeout_fill files it as workflow (matched) or unknown_api
+            # (unmatched). An unknown medium is never asserted to be a person's
+            # HTS trade, so it floors to unknown_api rather than manual.
             self._next_pending_fill += 1
             key = self._next_pending_fill
             self._pending_fills[key] = fill
@@ -554,6 +591,7 @@ class WorkflowPositionTracker:
                     "reported_execution_id": fill.execution_id,
                 }, sort_keys=True)
             realized_pnl = 0.0
+            estimate = None
 
             if fill.side == "buy":
                 # 매수: 새 로트 생성
@@ -570,8 +608,9 @@ class WorkflowPositionTracker:
                 ))
             else:
                 # 매도: FIFO 청산 (현재 trading_mode 내에서만)
-                realized_pnl = self._process_sell_fifo(
-                    cursor, fill.symbol, fill.quantity, fill.price, classification
+                realized_pnl, estimate = self._process_sell_fifo(
+                    cursor, fill.symbol, fill.quantity, fill.price, classification,
+                    account_avg_price=fill.account_avg_price,
                 )
 
             # 체결 내역 저장
@@ -579,14 +618,19 @@ class WorkflowPositionTracker:
                 INSERT INTO trade_history
                 (product, provider, order_no, order_date, symbol, exchange, side, quantity, price,
                  fill_datetime, classification, commda_code, realized_pnl, trading_mode, created_at,
-                 execution_id, normalized_order_no, execution_payload)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 execution_id, normalized_order_no, execution_payload,
+                 unmatched_qty, estimate_basis_price, estimate_source, estimated_pnl)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 self.product, self.provider,
                 fill.order_no, fill.order_date, fill.symbol, fill.exchange,
                 fill.side, fill.quantity, fill.price, fill_datetime,
                 classification, fill.commda_code, realized_pnl, self.trading_mode, datetime.now().isoformat(),
                 identity[5] if identity else None, identity[4] if identity else None, payload,
+                estimate["unmatched_qty"] if estimate else None,
+                estimate["estimate_basis_price"] if estimate else None,
+                estimate["estimate_source"] if estimate else None,
+                estimate["estimated_pnl"] if estimate else None,
             ))
 
             conn.commit()
@@ -605,62 +649,97 @@ class WorkflowPositionTracker:
         quantity: int,
         sell_price: float,
         classification: str,
-    ) -> float:
+        account_avg_price: Optional[float] = None,
+    ) -> Tuple[float, Optional[Dict[str, Any]]]:
         """
         FIFO 매도 처리
-        
+
         fill_datetime 순으로 정렬하여 선입선출 방식으로 청산합니다.
-        
+
+        classification 이 'workflow' 인 매도는 **workflow 로트만** 소진한다. 수동/타
+        API 로트를 먹으면 이 전략이 열지 않은 포지션의 손익까지 실현한 셈이 되기
+        때문이다. workflow 로트가 바닥난 뒤 남는 수량(remaining)은 이 전략이 여기서
+        사지 않은 물량을 판 것이므로, 계좌 평균매입가(account_avg_price)가 주어지면
+        그 잔량을 추정손익으로 매도 행에 기록한다(realized_pnl 은 FIFO 매칭분만 유지).
+        non-workflow 매도는 종전과 동일하게 분류 무관 로트를 FIFO 소진한다.
+
         Args:
             cursor: DB 커서
             symbol: 종목코드
             quantity: 매도 수량
             sell_price: 매도가
-            classification: 분류 (로깅용)
-            
+            classification: 분류 ("workflow" 면 workflow 로트만 소진)
+            account_avg_price: 계좌 평균매입가 (workflow 매도의 잔량 추정용, 없으면 추정 없음)
+
         Returns:
-            실현 손익
+            (실현 손익 FIFO 매칭분, 추정 정보 dict 또는 None)
         """
         remaining_to_sell = quantity
         total_realized_pnl = 0.0
-        
-        # fill_datetime 순으로 정렬 (FIFO, 현재 trading_mode 내에서만)
-        cursor.execute("""
-            SELECT id, buy_price, remaining_qty, classification
-            FROM workflow_position_lots
-            WHERE symbol = ? AND remaining_qty > 0 AND trading_mode = ?
-            ORDER BY fill_datetime ASC
-        """, (symbol, self.trading_mode))
-        
+
+        # fill_datetime 순으로 정렬 (FIFO, 현재 trading_mode 내에서만).
+        # workflow 매도는 workflow 로트로 소진 대상을 좁힌다.
+        if classification == "workflow":
+            cursor.execute("""
+                SELECT id, buy_price, remaining_qty, classification
+                FROM workflow_position_lots
+                WHERE symbol = ? AND remaining_qty > 0 AND trading_mode = ?
+                  AND classification = 'workflow'
+                ORDER BY fill_datetime ASC
+            """, (symbol, self.trading_mode))
+        else:
+            cursor.execute("""
+                SELECT id, buy_price, remaining_qty, classification
+                FROM workflow_position_lots
+                WHERE symbol = ? AND remaining_qty > 0 AND trading_mode = ?
+                ORDER BY fill_datetime ASC
+            """, (symbol, self.trading_mode))
+
         lots = cursor.fetchall()
-        
+
         for lot_id, buy_price, remaining_qty, lot_classification in lots:
             if remaining_to_sell <= 0:
                 break
-            
+
             sell_qty = min(remaining_to_sell, remaining_qty)
             new_remaining = remaining_qty - sell_qty
-            
+
             # 로트 업데이트
             cursor.execute("""
                 UPDATE workflow_position_lots
                 SET remaining_qty = ?
                 WHERE id = ?
             """, (new_remaining, lot_id))
-            
+
             # 실현 손익 계산
             pnl = (sell_price - buy_price) * sell_qty
             total_realized_pnl += pnl
-            
+
             remaining_to_sell -= sell_qty
-            
+
             logger.debug(f"FIFO sell: lot {lot_id} ({lot_classification}), "
                         f"qty={sell_qty}, pnl={pnl:.2f}")
-        
+
+        estimate: Optional[Dict[str, Any]] = None
         if remaining_to_sell > 0:
-            logger.warning(f"Sell without enough position: {symbol} remaining={remaining_to_sell}")
-        
-        return total_realized_pnl
+            if (classification == "workflow" and account_avg_price is not None
+                    and account_avg_price > 0):
+                # 이 전략이 여기서 사지 않은 잔량 — 같은 종목을 계좌의 다른 경로로
+                # 사둔 것으로 보고 계좌 평균매입가 기준 추정손익을 기록한다.
+                # realized_pnl(FIFO 매칭분)에는 넣지 않고 별도 컬럼으로만 남긴다.
+                estimated_pnl = (sell_price - account_avg_price) * remaining_to_sell
+                estimate = {
+                    "unmatched_qty": float(remaining_to_sell),
+                    "estimate_basis_price": float(account_avg_price),
+                    "estimate_source": "account_balance_avg_price",
+                    "estimated_pnl": float(estimated_pnl),
+                }
+                logger.debug(f"Estimated sell tail: {symbol} qty={remaining_to_sell} "
+                             f"@avg={account_avg_price} est_pnl={estimated_pnl:.2f}")
+            else:
+                logger.warning(f"Sell without enough position: {symbol} remaining={remaining_to_sell}")
+
+        return total_realized_pnl, estimate
     
     def _check_workflow_order(self, order_no: str, order_date: str) -> bool:
         """워크플로우 주문 여부 확인 (현재 trading_mode 기준)"""
@@ -1039,6 +1118,22 @@ class WorkflowPositionTracker:
         basis and never replaces a stored value, so the outcome is read from the
         same number the ledger committed.
 
+        A workflow sell now consumes only workflow lots (_process_sell_fifo), so
+        the old ``mixed_fifo_ownership`` pre-check is gone: a workflow sell can
+        no longer have realized a non-workflow lot, so there is nothing to guard
+        against. Old ledger rows written under the previous (classification-blind)
+        sell replay with ``stored != expected`` and are rejected below as
+        ``incomplete_fifo_basis`` — the honest outcome for a basis we can no
+        longer reconstruct.
+
+        A workflow sell whose own lots run out leaves a residual. When that
+        residual was recorded with an account-average-price estimate covering
+        exactly it (``estimate_basis_price`` present and ``unmatched_qty`` equal
+        to the residual), the group is not rejected: its status becomes
+        ``estimated``, its basis ``fifo_with_account_avg_price_estimate``, and
+        the sell scores on ``stored + estimated_pnl`` (the FIFO-matched amount
+        plus the estimated tail). Any other residual is an incomplete basis.
+
         Counts aggregate across symbols because a count carries no currency.
         Amounts do not: with `currency` unproven per row, summing gross profit
         across symbols would invent the very unit this method refuses to claim.
@@ -1082,18 +1177,19 @@ class WorkflowPositionTracker:
             reason = None
             amount = None
             outcome = None
+            # Whether this group's amount includes an account-avg-price estimate,
+            # and how much quantity was estimated (Σ unmatched over its sells).
+            group_estimated = False
+            group_est_qty = Decimal(0)
             if self.product == "overseas_futures":
                 reason = "futures_fifo_not_monetary"
             elif not symbol:
                 reason = "missing_symbol"
-            elif any(row["symbol"] == symbol and (
-                row["product"] != self.product or row["provider"] != self.provider
-                or row["classification"] != "workflow" or (row["exchange"] or "") != exchange
-            ) for row in rows):
-                # The historical sell writer matches symbol/mode across all lots.
-                # It cannot prove workflow ownership when those domains overlap.
-                reason = "mixed_fifo_ownership"
             else:
+                # The old mixed_fifo_ownership pre-check is gone: a workflow sell
+                # now consumes only workflow lots, so it can never have realized a
+                # non-workflow lot. Old rows written under the previous replay
+                # fall out below as incomplete_fifo_basis (stored != expected).
                 try:
                     lots = []
                     total = Decimal(0)
@@ -1124,20 +1220,41 @@ class WorkflowPositionTracker:
                                 if remaining == 0:
                                     break
                             tolerance = max(Decimal("0.000001"), abs(expected) * Decimal("0.000000001"))
-                            if remaining > 0 or abs(stored - expected) > tolerance:
-                                raise ValueError("Incomplete or inconsistent FIFO basis")
-                            # Preserve the stored amount; replay arithmetic only
-                            # validates the basis and never replaces its value.
-                            total += stored
-                            # One sell fill = one closed trade. Read the outcome
-                            # from the stored amount for the same reason.
+                            # The FIFO-matched portion must reproduce the stored
+                            # amount, whether or not a tail remains.
+                            if abs(stored - expected) > tolerance:
+                                raise ValueError("Inconsistent FIFO basis")
+                            # trade_amount is what this one closed trade scores on;
+                            # it starts as the stored (matched) value and grows by
+                            # the recorded estimate when a tail remains.
+                            trade_amount = stored
+                            if remaining > 0:
+                                # A residual after the workflow lots run out is
+                                # accepted only as a recorded account-avg-price
+                                # estimate covering exactly this residual; anything
+                                # else is an incomplete basis.
+                                est_basis = fill["estimate_basis_price"]
+                                est_unmatched = fill["unmatched_qty"]
+                                est_pnl = fill["estimated_pnl"]
+                                if est_basis is None or est_unmatched is None or est_pnl is None:
+                                    raise ValueError("Incomplete FIFO basis without estimate")
+                                est_unmatched_d = Decimal(str(est_unmatched))
+                                est_pnl_d = Decimal(str(est_pnl))
+                                if est_unmatched_d != remaining or not est_pnl_d.is_finite():
+                                    raise ValueError("Estimate does not cover the residual")
+                                # Add (never replace) the stored estimate to the
+                                # matched amount; one sell fill is still one trade.
+                                trade_amount = stored + est_pnl_d
+                                group_estimated = True
+                                group_est_qty += remaining
+                            total += trade_amount
                             trades += 1
-                            if stored > 0:
+                            if trade_amount > 0:
                                 wins += 1
-                                gross_profit += stored
-                            elif stored < 0:
+                                gross_profit += trade_amount
+                            elif trade_amount < 0:
                                 losses += 1
-                                gross_loss += -stored
+                                gross_loss += -trade_amount
                             else:
                                 evens += 1
                         else:
@@ -1155,9 +1272,23 @@ class WorkflowPositionTracker:
                 except (ValueError, TypeError, ArithmeticError, OverflowError):
                     reason = "incomplete_fifo_basis"
                     outcome = None
+                    group_estimated = False
+                    group_est_qty = Decimal(0)
+            if reason is not None:
+                status = "unavailable"
+                basis = None
+                estimated_quantity = None
+            elif group_estimated:
+                status = "estimated"
+                basis = "fifo_with_account_avg_price_estimate"
+                estimated_quantity = float(group_est_qty)
+            else:
+                status = "available"
+                basis = "fifo"
+                estimated_quantity = 0
             entry = {"symbol": symbol, "exchange": exchange, "currency": None,
-                     "amount": amount, "status": "available" if reason is None else "unavailable",
-                     "reason": reason}
+                     "amount": amount, "status": status, "reason": reason,
+                     "basis": basis, "estimated_quantity": estimated_quantity}
             # A rejected group publishes no outcome: its trades are unknown, and
             # unknown trades must not be counted as zero of anything.
             entry.update(outcome or {"closed_trades": None, "winning_trades": None,
@@ -1205,6 +1336,42 @@ class WorkflowPositionTracker:
                 # that size and overstates the strategy.
                 ratio_reason = "no_losing_trades"
 
+        # How many groups carry an account-avg-price estimate, and whether the
+        # aggregated figures rest on any estimate. A count is null when it is
+        # itself unavailable; otherwise it is "measured" unless a scored group
+        # was estimated. The ratio comes from a single group, so its basis is
+        # that one group's.
+        estimated_group_count = sum(1 for g in realized if g["status"] == "estimated")
+        if trade_status == "unavailable":
+            closed_trade_basis = None
+        else:
+            closed_trade_basis = ("includes_estimates"
+                                  if any(g["status"] == "estimated" for g in scored)
+                                  else "measured")
+        if ratio_status != "available":
+            profit_loss_ratio_basis = None
+        else:
+            profit_loss_ratio_basis = ("includes_estimates"
+                                       if counted[0]["status"] == "estimated"
+                                       else "measured")
+
+        # Fills on this same account placed outside this strategy, by classification:
+        # manual (a person via HTS/web) → hts, unknown_api (another OPEN-API
+        # client) → other_api. Futures fill frames carry no communication-media
+        # field, so HTS vs OPEN-API cannot be told apart for them — unavailable.
+        if self.product == "overseas_futures":
+            off_strategy_fills = {"hts": None, "other_api": None,
+                                  "status": "unavailable",
+                                  "reason": "futures_fills_have_no_media_code"}
+        else:
+            in_scope = [r for r in rows if r["product"] == self.product
+                        and r["provider"] == self.provider]
+            off_strategy_fills = {
+                "hts": sum(1 for r in in_scope if r["classification"] == "manual"),
+                "other_api": sum(1 for r in in_scope if r["classification"] == "unknown_api"),
+                "status": "available", "reason": None,
+            }
+
         return {
             "version": 2,
             "scope": {"kind": "local_workflow_ledger", "product": self.product,
@@ -1221,9 +1388,13 @@ class WorkflowPositionTracker:
             "breakeven_trade_count": breakeven_total,
             "closed_trade_status": trade_status,
             "closed_trade_reason": trade_reason,
+            "closed_trade_basis": closed_trade_basis,
+            "estimated_group_count": estimated_group_count,
             "profit_loss_ratio": ratio,
             "profit_loss_ratio_status": ratio_status,
             "profit_loss_ratio_reason": ratio_reason,
+            "profit_loss_ratio_basis": profit_loss_ratio_basis,
+            "off_strategy_fills": off_strategy_fills,
             "max_drawdown": None,
             "max_drawdown_status": "unavailable",
             "max_drawdown_reason": "equity_history_unavailable",

--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -1033,6 +1033,18 @@ class WorkflowPositionTracker:
         Historical FIFO rows have no currency or fee evidence. Keep their amounts
         per symbol/exchange and reject mixed ownership or an incomplete FIFO basis.
         Futures FIFO is not a monetary ledger. No equity/MDD basis is inferred.
+
+        Version 2 adds closed-trade outcomes. One closed trade = one sell fill,
+        using its *stored* realized amount — the replay below only validates the
+        basis and never replaces a stored value, so the outcome is read from the
+        same number the ledger committed.
+
+        Counts aggregate across symbols because a count carries no currency.
+        Amounts do not: with `currency` unproven per row, summing gross profit
+        across symbols would invent the very unit this method refuses to claim.
+        So gross amounts stay inside each group, and the top-level profit/loss
+        ratio is published only when a single group carries the whole ledger —
+        the one case where "the currency is the same" needs no evidence.
         """
         with sqlite3.connect(self.db_path) as conn:
             conn.row_factory = sqlite3.Row
@@ -1069,6 +1081,7 @@ class WorkflowPositionTracker:
         for (symbol, exchange), fills in sorted(groups.items()):
             reason = None
             amount = None
+            outcome = None
             if self.product == "overseas_futures":
                 reason = "futures_fifo_not_monetary"
             elif not symbol:
@@ -1084,6 +1097,11 @@ class WorkflowPositionTracker:
                 try:
                     lots = []
                     total = Decimal(0)
+                    # NB: `closed` below is the matched lot quantity — do not
+                    # reuse that name for a counter.
+                    trades = wins = losses = evens = 0
+                    gross_profit = Decimal(0)
+                    gross_loss = Decimal(0)
                     for fill in fills:
                         quantity = Decimal(str(fill["quantity"]))
                         price = Decimal(str(fill["price"]))
@@ -1111,18 +1129,84 @@ class WorkflowPositionTracker:
                             # Preserve the stored amount; replay arithmetic only
                             # validates the basis and never replaces its value.
                             total += stored
+                            # One sell fill = one closed trade. Read the outcome
+                            # from the stored amount for the same reason.
+                            trades += 1
+                            if stored > 0:
+                                wins += 1
+                                gross_profit += stored
+                            elif stored < 0:
+                                losses += 1
+                                gross_loss += -stored
+                            else:
+                                evens += 1
                         else:
                             raise ValueError("Unknown fill side")
                     amount = float(total)
                     if not Decimal(str(amount)).is_finite():
                         raise ValueError("Non-finite total")
+                    gross_profit_f = float(gross_profit)
+                    gross_loss_f = float(gross_loss)
+                    if not all(Decimal(str(v)).is_finite() for v in (gross_profit_f, gross_loss_f)):
+                        raise ValueError("Non-finite gross amount")
+                    outcome = {"closed_trades": trades, "winning_trades": wins,
+                               "losing_trades": losses, "breakeven_trades": evens,
+                               "gross_profit": gross_profit_f, "gross_loss": gross_loss_f}
                 except (ValueError, TypeError, ArithmeticError, OverflowError):
                     reason = "incomplete_fifo_basis"
-            realized.append({"symbol": symbol, "exchange": exchange, "currency": None,
-                             "amount": amount, "status": "available" if reason is None else "unavailable",
-                             "reason": reason})
+                    outcome = None
+            entry = {"symbol": symbol, "exchange": exchange, "currency": None,
+                     "amount": amount, "status": "available" if reason is None else "unavailable",
+                     "reason": reason}
+            # A rejected group publishes no outcome: its trades are unknown, and
+            # unknown trades must not be counted as zero of anything.
+            entry.update(outcome or {"closed_trades": None, "winning_trades": None,
+                                     "losing_trades": None, "breakeven_trades": None,
+                                     "gross_profit": None, "gross_loss": None})
+            realized.append(entry)
+        # Counts carry no currency, so they aggregate across symbols. A group the
+        # replay rejected is excluded and downgrades the status to "partial" —
+        # "some of this strategy's trades are not in these numbers" is a different
+        # claim from "these are all of them", and the caller must be able to tell.
+        scored = [g for g in realized if g["closed_trades"] is not None]
+        counted = [g for g in scored if g["closed_trades"] > 0]
+        if not scored:
+            trade_status, trade_reason = "unavailable", (
+                "futures_fifo_not_monetary" if self.product == "overseas_futures"
+                else "no_scorable_fifo_basis")
+            closed_total = winning_total = losing_total = breakeven_total = None
+        else:
+            trade_status = "available" if len(scored) == len(realized) else "partial"
+            trade_reason = None if trade_status == "available" else "some_groups_unscorable"
+            closed_total = sum(g["closed_trades"] for g in scored)
+            winning_total = sum(g["winning_trades"] for g in scored)
+            losing_total = sum(g["losing_trades"] for g in scored)
+            breakeven_total = sum(g["breakeven_trades"] for g in scored)
+
+        # The ratio is money, and money needs a unit. One group means one symbol,
+        # hence one currency — the only case where the unit is provable without
+        # currency evidence. Anything else stays per group.
+        ratio = None
+        ratio_status = "unavailable"
+        if len(counted) != 1:
+            ratio_reason = ("no_closed_trades" if not counted
+                            else "multi_symbol_currency_unknown")
+        else:
+            group = counted[0]
+            if group["gross_loss"] > 0:
+                candidate = group["gross_profit"] / group["gross_loss"]
+                if Decimal(str(candidate)).is_finite():
+                    ratio, ratio_status, ratio_reason = candidate, "available", None
+                else:
+                    ratio_reason = "non_finite_ratio"
+            else:
+                # No losing trade means no denominator. Publishing gross profit
+                # here (the server's day-based metric does) reads as a ratio of
+                # that size and overstates the strategy.
+                ratio_reason = "no_losing_trades"
+
         return {
-            "version": 1,
+            "version": 2,
             "scope": {"kind": "local_workflow_ledger", "product": self.product,
                       "provider": self.provider, "trading_mode": self.trading_mode},
             "as_of": datetime.now(timezone.utc).isoformat(),
@@ -1131,6 +1215,15 @@ class WorkflowPositionTracker:
             "executed_order_count_status": "unavailable" if invalid_count else "available",
             "executed_order_count_reason": "invalid_execution_identity" if invalid_count else None,
             "realized_pnl": realized,
+            "closed_trade_count": closed_total,
+            "winning_trade_count": winning_total,
+            "losing_trade_count": losing_total,
+            "breakeven_trade_count": breakeven_total,
+            "closed_trade_status": trade_status,
+            "closed_trade_reason": trade_reason,
+            "profit_loss_ratio": ratio,
+            "profit_loss_ratio_status": ratio_status,
+            "profit_loss_ratio_reason": ratio_reason,
             "max_drawdown": None,
             "max_drawdown_status": "unavailable",
             "max_drawdown_reason": "equity_history_unavailable",

--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -97,6 +97,34 @@ class ExecutionIdentityConflictError(ValueError):
     """An explicit execution identity was replayed with different fill facts."""
 
 
+# LS 통신매체코드(CommdaCode / MdaCode) — 출처: src/finance/docs/cidbq02400_contract.md:74-77
+# "The published media map is 00=branch, 22=iPhone, 23=Android, 41=API, 43=Robo API,
+#  85=HTS, 96=final settlement, LP=loss cut, SK=CashCall and SO=conditional order.
+#  The example uses 40, which the table does not map. Preserve it as returned;
+#  do not classify it by guessing a nearby code."
+# '40' 은 표에 없지만 우리 OPEN API 주문이 실제로 받는 값이다(dev verified_fills 실측 4건) —
+# 표의 41/43 과 함께 API 묶음으로 둔다. 표에 없는 값은 추측하지 않고 "other" 로 남긴다.
+MEDIA_CODES_HUMAN = frozenset({"85", "22", "23", "00"})   # HTS · iPhone · Android · 지점
+MEDIA_CODES_API = frozenset({"40", "41", "43"})           # OPEN API(실측) · API · Robo API
+
+
+def media_channel(commda_code: str | None) -> str:
+    """Map a broker media code to "human" | "api" | "unknown" | "other".
+
+    unknown = blank/None (the frame said nothing); other = a code the published
+    table does not attribute to a person or an API client (96/LP/SK/SO …) or one
+    the table does not list at all. Neither is ever asserted to be a person.
+    """
+    code = (commda_code or "").strip()
+    if not code:
+        return "unknown"
+    if code in MEDIA_CODES_HUMAN:
+        return "human"
+    if code in MEDIA_CODES_API:
+        return "api"
+    return "other"
+
+
 class WorkflowPositionTracker:
     """
     워크플로우 포지션 FIFO 추적기
@@ -440,7 +468,7 @@ class WorkflowPositionTracker:
         This is a persistence prerequisite, not broker-history/TC3 integration.
             
         Returns:
-            분류 결과: "workflow" | "manual" | "unknown_api" | "pending"
+            분류 결과: "workflow" | "manual" | "unknown_api" | "other" | "pending"
         """
         fill = PendingFill(
             order_no=order_no, order_date=order_date, symbol=symbol,
@@ -468,14 +496,19 @@ class WorkflowPositionTracker:
             # old media-first ordering would then misfile them as manual.)
             if self._is_workflow_fill(fill):
                 return await self._process_fill_internal(fill, "workflow")
-            # No matching order. A definite, non-'40' media code identifies a
-            # trade placed on this account through another channel (HTS/web) —
-            # a person, classified "manual".
-            if commda_code and commda_code != "40":
+            # No matching order. Classify by the published media table
+            # (MEDIA_CODES_* above) — never by "not 40":
+            #   human (85 HTS / 22 iPhone / 23 Android / 00 branch) → "manual"
+            #   other (96/LP/SK/SO or unlisted)                    → "other"
+            #   api (40/41/43) or blank                            → buffer below
+            channel = media_channel(commda_code)
+            if channel == "human":
                 return await self._process_fill_internal(fill, "manual")
+            if channel == "other":
+                return await self._process_fill_internal(fill, "other")
 
-            # '40' (OPEN API) or an empty/None media code ("medium unknown"):
-            # buffer to give a lagging order record a chance to arrive, then
+            # An API code or an empty media code ("medium unknown"): buffer to
+            # give a lagging order record a chance to arrive, then
             # _process_timeout_fill files it as workflow (matched) or unknown_api
             # (unmatched). An unknown medium is never asserted to be a person's
             # HTS trade, so it floors to unknown_api rather than manual.
@@ -1356,11 +1389,12 @@ class WorkflowPositionTracker:
                                        else "measured")
 
         # Fills on this same account placed outside this strategy, by classification:
-        # manual (a person via HTS/web) → hts, unknown_api (another OPEN-API
-        # client) → other_api. Futures fill frames carry no communication-media
-        # field, so HTS vs OPEN-API cannot be told apart for them — unavailable.
+        # manual (a person via HTS/app/branch) → hts, unknown_api (another API
+        # client) → other_api, other (broker-side codes 96/LP/SK/SO or unlisted)
+        # → other. Futures fill frames carry no communication-media field, so
+        # the channels cannot be told apart for them — unavailable.
         if self.product == "overseas_futures":
-            off_strategy_fills = {"hts": None, "other_api": None,
+            off_strategy_fills = {"hts": None, "other_api": None, "other": None,
                                   "status": "unavailable",
                                   "reason": "futures_fills_have_no_media_code"}
         else:
@@ -1369,6 +1403,7 @@ class WorkflowPositionTracker:
             off_strategy_fills = {
                 "hts": sum(1 for r in in_scope if r["classification"] == "manual"),
                 "other_api": sum(1 for r in in_scope if r["classification"] == "unknown_api"),
+                "other": sum(1 for r in in_scope if r["classification"] == "other"),
                 "status": "available", "reason": None,
             }
 

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -4567,6 +4567,25 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 
                 async def record_and_refresh():
                     """체결 기록 후 AccountTracker refresh"""
+                    tracker_key = f"{context.job_id}_{node_id}"
+                    tracker_info = self._active_trackers.get(tracker_key)
+
+                    # 매도 잔량 추정용 계좌 평균매입가 — record 전에(그래서 refresh
+                    # 전에) StockAccountTracker 캐시(_positions[symbol].buy_price)에서
+                    # 읽는다. 캐시는 아직 이번 매도가 반영되기 전이라 '매도 직전 평단'.
+                    # 캐시에 없으면 None → 추정 없음(오늘처럼 unavailable).
+                    account_avg_price = None
+                    if tracker_info and "tracker" in tracker_info:
+                        acct_tracker = tracker_info["tracker"]
+                        positions = getattr(acct_tracker, "_positions", None)
+                        pos = positions.get(symbol) if isinstance(positions, dict) else None
+                        buy_price = getattr(pos, "buy_price", None) if pos is not None else None
+                        if buy_price is not None:
+                            try:
+                                account_avg_price = float(buy_price)
+                            except (TypeError, ValueError):
+                                account_avg_price = None
+
                     await context.record_workflow_fill(
                         order_no=order_no,
                         order_date=order_date,
@@ -4576,19 +4595,21 @@ class BrokerNodeExecutor(NodeExecutorBase):
                         quantity=exec_qty,
                         price=exec_price,
                         fill_time=fill_time,
-                        commda_code='40',  # OPEN API
+                        # 프레임의 통신매체코드를 그대로 넘긴다(하드코딩 '40' 폐기).
+                        # 우리 주문과 일치하면 매체코드 무관하게 workflow 로 분류되고,
+                        # 일치하지 않는 계좌 내 타 체결만 이 코드로 HTS/타 API 를 가른다.
+                        commda_code=getattr(body, 'sCommdaCode', ''),
                         execution_id=execution_id,
+                        account_avg_price=account_avg_price,
                     )
-                    
+
                     # AccountTracker refresh로 PnL 이벤트 강제 트리거
-                    tracker_key = f"{context.job_id}_{node_id}"
-                    tracker_info = self._active_trackers.get(tracker_key)
                     if tracker_info and "tracker" in tracker_info:
                         tracker = tracker_info["tracker"]
                         if hasattr(tracker, 'refresh_now'):
                             await tracker.refresh_now()
                             logger.debug(f"📊 AccountTracker refreshed after fill")
-                
+
                 asyncio.run_coroutine_threadsafe(record_and_refresh(), loop)
                 logger.info(f"📌 Workflow fill recorded: {symbol} {side} {exec_qty}@{exec_price}")
                     
@@ -4742,6 +4763,9 @@ class BrokerNodeExecutor(NodeExecutorBase):
                                 quantity=quantity,
                                 price=price,
                                 fill_time=fill_time,
+                                # 선물 체결 프레임(TC3)에는 통신매체코드 필드가 없다
+                                # (blocks.py 에 commda/media 없음). 이 경로는 우리
+                                # 주문의 체결이므로 OPEN API 기본값 '40' 을 유지한다.
                                 commda_code='40',
                             ),
                             loop
@@ -4815,6 +4839,8 @@ class BrokerNodeExecutor(NodeExecutorBase):
                     side = 'buy' if bns_tp == '2' else 'sell'
                     fill_time = getattr(body, 'exectime', datetime.now().strftime('%H%M%S000'))
 
+                    media_code = getattr(body, 'commdacode', '')
+
                     async def record_and_refresh():
                         """체결 기록 후 AccountTracker refresh"""
                         await context.record_workflow_fill(
@@ -4826,7 +4852,10 @@ class BrokerNodeExecutor(NodeExecutorBase):
                             quantity=exec_qty,
                             price=exec_price,
                             fill_time=fill_time,
-                            commda_code='40',
+                            # SC1 프레임의 통신매체코드(commdacode)를 그대로 넘긴다.
+                            # 우리 주문과 일치하면 workflow, 아니면 이 코드로
+                            # HTS(manual)/타 API(unknown_api)를 가른다.
+                            commda_code=media_code,
                         )
 
                         # AccountTracker refresh로 PnL 이벤트 강제 트리거

--- a/src/programgarden/tests/test_execution_identity_ledger.py
+++ b/src/programgarden/tests/test_execution_identity_ledger.py
@@ -79,7 +79,7 @@ async def test_padded_order_and_execution_replay_keeps_original_evidence(tmp_pat
 @pytest.mark.asyncio
 async def test_distinct_opaque_ids_do_not_collapse_identical_fill_facts(tmp_path):
     target = tracker(tmp_path)
-    args = fill(commda_code="10")
+    args = fill(commda_code="85")
     for identity in (" 000A ", "A", "a"):
         assert await target.record_fill(**args, execution_id=identity) == "manual"
     assert await target.record_fill(**args, execution_id="000A") == "manual"
@@ -90,7 +90,7 @@ async def test_distinct_opaque_ids_do_not_collapse_identical_fill_facts(tmp_path
 @pytest.mark.asyncio
 @pytest.mark.parametrize("changed", [
     {"symbol": "OTHER"}, {"exchange": "OTHER"}, {"side": "sell"},
-    {"quantity": 3}, {"price": 101}, {"fill_time": "100000002"}, {"commda_code": "10"},
+    {"quantity": 3}, {"price": 101}, {"fill_time": "100000002"}, {"commda_code": "85"},
 ])
 async def test_conflicting_committed_identity_never_mutates_facts(tmp_path, changed):
     target = tracker(tmp_path)
@@ -192,7 +192,7 @@ async def test_identity_domain_separates_dates_orders_modes_products_and_provide
     ]
     for target in targets:
         for date, number in [("20260909", "123"), ("20260910", "123"), ("20260909", "124")]:
-            args = fill(order_date=date, order_no=number, commda_code="10")
+            args = fill(order_date=date, order_no=number, commda_code="85")
             assert await target.record_fill(**args, execution_id="same") == "manual"
             assert await target.record_fill(**args, execution_id="same") == "manual"
     assert len(rows(targets[0], "trade_history")) == 12
@@ -204,7 +204,7 @@ def test_concurrent_connections_gate_before_fifo_mutation(tmp_path):
 
     def write(target):
         barrier.wait(timeout=5)
-        return asyncio.run(target.record_fill(**fill(commda_code="10"), execution_id="race"))
+        return asyncio.run(target.record_fill(**fill(commda_code="85"), execution_id="race"))
 
     with ThreadPoolExecutor(max_workers=2) as pool:
         futures = [pool.submit(write, target) for target in (first, second)]
@@ -220,7 +220,7 @@ def test_concurrent_conflicting_identity_accepts_only_one_payload(tmp_path):
     def write(target, quantity):
         barrier.wait(timeout=5)
         try:
-            return asyncio.run(target.record_fill(**fill(commda_code="10", quantity=quantity), execution_id="race"))
+            return asyncio.run(target.record_fill(**fill(commda_code="85", quantity=quantity), execution_id="race"))
         except ExecutionIdentityConflictError:
             return "conflict"
 
@@ -238,8 +238,8 @@ def test_concurrent_conflicting_identity_accepts_only_one_payload(tmp_path):
 async def test_history_write_failure_rolls_back_fifo_and_identity(tmp_path, side):
     target = tracker(tmp_path)
     if side == "sell":
-        await target.record_fill(**fill(commda_code="10"), execution_id="opening")
-    args = fill(commda_code="10", side=side, quantity=1 if side == "sell" else 2)
+        await target.record_fill(**fill(commda_code="85"), execution_id="opening")
+    args = fill(commda_code="85", side=side, quantity=1 if side == "sell" else 2)
     before = rows(target, "trade_history"), rows(target, "workflow_position_lots")
     with sqlite3.connect(target.db_path) as conn:
         conn.execute("CREATE TRIGGER reject_history BEFORE INSERT ON trade_history BEGIN SELECT RAISE(ABORT, 'synthetic failure'); END")
@@ -270,7 +270,7 @@ async def test_existing_schema_rows_are_preserved_without_inferred_identity(tmp_
                 exchange, side, quantity, price, fill_datetime, classification, commda_code,
                 realized_pnl, trading_mode, created_at)
             VALUES ('overseas_stock', 'ls', '000123', '20260909', 'SYNTH', 'TEST',
-                'buy', 2, 100, '20260909_100000001', 'manual', '10', 0, 'live', 'original')
+                'buy', 2, 100, '20260909_100000001', 'manual', '85', 0, 'live', 'original')
         """)
         old = conn.execute("SELECT * FROM trade_history").fetchone()
     target = tracker(tmp_path)
@@ -280,7 +280,7 @@ async def test_existing_schema_rows_are_preserved_without_inferred_identity(tmp_
     # identity columns plus the four account-avg-price estimate columns
     # (unmatched_qty, estimate_basis_price, estimate_source, estimated_pnl).
     assert migrated[len(old):] == (None, None, None, None, None, None, None)
-    await target.record_fill(**fill(commda_code="10"), execution_id="new-evidence")
+    await target.record_fill(**fill(commda_code="85"), execution_id="new-evidence")
     assert len(rows(target, "trade_history")) == 2
     assert rows(target, "trade_history")[0] == migrated
     assert len(rows(tracker(tmp_path), "trade_history")) == 2

--- a/src/programgarden/tests/test_execution_identity_ledger.py
+++ b/src/programgarden/tests/test_execution_identity_ledger.py
@@ -276,7 +276,10 @@ async def test_existing_schema_rows_are_preserved_without_inferred_identity(tmp_
     target = tracker(tmp_path)
     migrated = rows(target, "trade_history")[0]
     assert migrated[:len(old)] == old
-    assert migrated[len(old):] == (None, None, None)
+    # Additive columns backfill to NULL, never inferred: the three execution
+    # identity columns plus the four account-avg-price estimate columns
+    # (unmatched_qty, estimate_basis_price, estimate_source, estimated_pnl).
+    assert migrated[len(old):] == (None, None, None, None, None, None, None)
     await target.record_fill(**fill(commda_code="10"), execution_id="new-evidence")
     assert len(rows(target, "trade_history")) == 2
     assert rows(target, "trade_history")[0] == migrated

--- a/src/programgarden/tests/test_personal_monitoring_metrics.py
+++ b/src/programgarden/tests/test_personal_monitoring_metrics.py
@@ -26,7 +26,7 @@ async def fill(ledger, order, side, quantity, price, execution, *, symbol="SYNTH
     if not manual:
         ledger.record_order(order, date, symbol, "SYNTH_EXCHANGE", side, quantity, price, "job", "node")
     return await ledger.record_fill(order, date, symbol, "SYNTH_EXCHANGE", side,
-                                   quantity, price, "100000000", "10" if manual else "40", execution_id=execution)
+                                   quantity, price, "100000000", "85" if manual else "40", execution_id=execution)
 
 
 @pytest.mark.asyncio
@@ -410,18 +410,22 @@ async def test_off_strategy_fills_counts_hts_and_other_api(tmp_path):
     ledger = tracker(tmp_path, provider="ls-sec.co.kr")
     ledger.FILL_BUFFER_TIMEOUT = 0.05
     await fill(ledger, "1", "buy", 1, 100, "11")   # 우리 workflow 체결
-    # 사람의 HTS 거래: 실제 비-'40' 매체코드 + 일치 주문 없음 → manual
+    # 사람의 HTS 거래: 표의 인간 채널 코드(85=HTS) + 일치 주문 없음 → manual
     await ledger.record_fill("H1", "20260909", "SYNTH", "SYNTH_EXCHANGE", "buy", 1, 90,
-                             "100000000", "41", execution_id="21")
-    # 타 API 클라이언트: '40' + 일치 주문 없음 → 버퍼 → unknown_api
+                             "100000000", "85", execution_id="21")
+    # 타 API 클라이언트: 표의 API 코드(41) + 일치 주문 없음 → 버퍼 → unknown_api
     r = await ledger.record_fill("A1", "20260909", "SYNTH", "SYNTH_EXCHANGE", "buy", 1, 95,
-                                 "100000000", "40", execution_id="22")
+                                 "100000000", "41", execution_id="22")
     assert r == "pending"
+    # 증권사 발생 코드(96=최종결제): 사람도 API 도 아니다 → other
+    assert await ledger.record_fill("S1", "20260909", "SYNTH", "SYNTH_EXCHANGE", "sell", 1, 99,
+                                    "100000000", "96", execution_id="23") == "other"
     await asyncio.sleep(0.15)
     off = ledger.personal_metrics()["off_strategy_fills"]
     assert off["status"] == "available"
     assert off["hts"] == 1
     assert off["other_api"] == 1
+    assert off["other"] == 1
     assert off["reason"] is None
 
 
@@ -431,5 +435,5 @@ async def test_off_strategy_fills_unavailable_for_futures(tmp_path):
     await fill(ledger, "1", "buy", 1, 100, "11")
     off = ledger.personal_metrics()["off_strategy_fills"]
     assert off["status"] == "unavailable"
-    assert off["hts"] is None and off["other_api"] is None
+    assert off["hts"] is None and off["other_api"] is None and off["other"] is None
     assert off["reason"] == "futures_fills_have_no_media_code"

--- a/src/programgarden/tests/test_personal_monitoring_metrics.py
+++ b/src/programgarden/tests/test_personal_monitoring_metrics.py
@@ -207,3 +207,112 @@ async def test_nonfinite_history_and_inconsistent_realized_value_remain_unavaila
     result = ledger.personal_metrics()
     assert result["executed_order_count"] is None
     assert result["realized_pnl"][0]["amount"] is None
+
+
+# --- v2: closed-trade outcomes -------------------------------------------
+# One closed trade = one sell fill, scored from its *stored* realized amount.
+# Counts aggregate across symbols (a count has no currency); gross amounts do
+# not, so the ratio is published only when one group carries the whole ledger.
+
+
+@pytest.mark.asyncio
+async def test_closed_trades_are_scored_from_the_stored_amount(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 3, 100, "11")
+    await fill(ledger, "2", "sell", 1, 110, "12")   # +10
+    await fill(ledger, "3", "sell", 1, 90, "13")    # -10
+    await fill(ledger, "4", "sell", 1, 100, "14")   # 0
+    result = ledger.personal_metrics()
+    assert result["version"] == 2
+    assert result["closed_trade_count"] == 3
+    assert result["winning_trade_count"] == 1
+    assert result["losing_trade_count"] == 1
+    assert result["breakeven_trade_count"] == 1
+    assert result["closed_trade_status"] == "available"
+    group = result["realized_pnl"][0]
+    assert group["gross_profit"] == 10 and group["gross_loss"] == 10
+    assert result["profit_loss_ratio"] == 1.0
+    assert result["profit_loss_ratio_status"] == "available"
+
+
+@pytest.mark.asyncio
+async def test_open_position_has_no_closed_trade(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11")
+    result = ledger.personal_metrics()
+    assert result["closed_trade_count"] == 0
+    assert result["closed_trade_status"] == "available"
+    # Nothing has been closed, so there is no ratio to speak of — and saying so
+    # is different from saying the ratio is zero.
+    assert result["profit_loss_ratio"] is None
+    assert result["profit_loss_ratio_reason"] == "no_closed_trades"
+
+
+@pytest.mark.asyncio
+async def test_winning_only_ledger_does_not_publish_profit_as_a_ratio(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11")
+    await fill(ledger, "2", "sell", 1, 130, "12")
+    result = ledger.personal_metrics()
+    assert result["winning_trade_count"] == 1 and result["losing_trade_count"] == 0
+    assert result["realized_pnl"][0]["gross_profit"] == 30
+    # The server's day-based metric returns gross profit here and the screen
+    # reads it as "ratio 30.00". No denominator means no ratio.
+    assert result["profit_loss_ratio"] is None
+    assert result["profit_loss_ratio_reason"] == "no_losing_trades"
+
+
+@pytest.mark.asyncio
+async def test_two_symbols_count_together_but_publish_no_ratio(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11", symbol="AAA")
+    await fill(ledger, "2", "sell", 1, 110, "12", symbol="AAA")
+    await fill(ledger, "3", "buy", 1, 200, "13", symbol="BBB")
+    await fill(ledger, "4", "sell", 1, 180, "14", symbol="BBB")
+    result = ledger.personal_metrics()
+    assert result["closed_trade_count"] == 2
+    assert result["winning_trade_count"] == 1 and result["losing_trade_count"] == 1
+    # Two symbols may settle in two currencies, and the ledger holds no currency
+    # evidence — so the amounts stay in their groups.
+    assert result["profit_loss_ratio"] is None
+    assert result["profit_loss_ratio_reason"] == "multi_symbol_currency_unknown"
+    assert {g["symbol"] for g in result["realized_pnl"]} == {"AAA", "BBB"}
+
+
+@pytest.mark.asyncio
+async def test_unscorable_group_downgrades_the_total_instead_of_shrinking_it(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11", symbol="AAA")
+    await fill(ledger, "2", "sell", 1, 110, "12", symbol="AAA")
+    await fill(ledger, "3", "sell", 1, 50, "13", symbol="BBB")   # unmatched
+    result = ledger.personal_metrics()
+    assert result["closed_trade_count"] == 1
+    assert result["closed_trade_status"] == "partial"
+    assert result["closed_trade_reason"] == "some_groups_unscorable"
+    rejected = [g for g in result["realized_pnl"] if g["symbol"] == "BBB"][0]
+    # An unknown group contributes no trades, not zero trades.
+    assert rejected["closed_trades"] is None and rejected["gross_profit"] is None
+
+
+@pytest.mark.asyncio
+async def test_futures_ledger_scores_no_trades(tmp_path):
+    ledger = tracker(tmp_path, product="overseas_futures", trading_mode="paper")
+    await fill(ledger, "1", "buy", 1, 100, "11")
+    await fill(ledger, "2", "sell", 1, 110, "12")
+    result = ledger.personal_metrics()
+    assert result["closed_trade_count"] is None
+    assert result["closed_trade_status"] == "unavailable"
+    assert result["closed_trade_reason"] == "futures_fifo_not_monetary"
+    assert result["profit_loss_ratio"] is None
+
+
+@pytest.mark.asyncio
+async def test_mixed_ownership_keeps_its_trades_out_of_the_count(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11", manual=True)
+    await fill(ledger, "2", "sell", 1, 110, "12")
+    result = ledger.personal_metrics()
+    assert result["realized_pnl"][0]["reason"] == "mixed_fifo_ownership"
+    assert result["closed_trade_count"] is None
+    assert result["closed_trade_status"] == "unavailable"
+    assert result["closed_trade_reason"] == "no_scorable_fifo_basis"

--- a/src/programgarden/tests/test_personal_monitoring_metrics.py
+++ b/src/programgarden/tests/test_personal_monitoring_metrics.py
@@ -1,5 +1,6 @@
 """Retained personal execution evidence using synthetic SQLite fills only."""
 from types import SimpleNamespace
+import asyncio
 import sqlite3
 
 import pytest
@@ -172,7 +173,10 @@ async def test_manual_fifo_basis_never_becomes_workflow_realized_money(tmp_path)
     result = ledger.personal_metrics()
     assert result["executed_order_count"] == 1
     assert result["realized_pnl"][0]["amount"] is None
-    assert result["realized_pnl"][0]["reason"] == "mixed_fifo_ownership"
+    # A workflow sell now consumes only workflow lots, so it never realizes the
+    # manual buy's basis (no account_avg_price was supplied, so no estimate
+    # either). The residual with no estimate is rejected as an incomplete basis.
+    assert result["realized_pnl"][0]["reason"] == "incomplete_fifo_basis"
 
 
 @pytest.mark.asyncio
@@ -312,7 +316,120 @@ async def test_mixed_ownership_keeps_its_trades_out_of_the_count(tmp_path):
     await fill(ledger, "1", "buy", 1, 100, "11", manual=True)
     await fill(ledger, "2", "sell", 1, 110, "12")
     result = ledger.personal_metrics()
-    assert result["realized_pnl"][0]["reason"] == "mixed_fifo_ownership"
+    # The workflow sell consumes only workflow lots, so the manual buy's basis is
+    # never claimed; its residual (no estimate) is an incomplete basis, and the
+    # rejected group keeps its trades out of the count exactly as before.
+    assert result["realized_pnl"][0]["reason"] == "incomplete_fifo_basis"
     assert result["closed_trade_count"] is None
     assert result["closed_trade_status"] == "unavailable"
     assert result["closed_trade_reason"] == "no_scorable_fifo_basis"
+
+
+# --- v2 확장: 계좌 평균매입가 추정 + off_strategy_fills ------------------------
+# 워크플로우 매도가 자기 로트를 다 소진하고도 남는 잔량은, 계좌에 같은 종목을 다른
+# 경로로 사둔 것으로 보고 계좌 평균매입가 기준으로 추정 표기한다(basis includes_estimates).
+
+
+async def sell_with_estimate(ledger, order, quantity, price, execution, account_avg_price,
+                             *, symbol="SYNTH", date="20260909"):
+    """워크플로우 매도 + 계좌 평균매입가 추정 인자."""
+    ledger.record_order(order, date, symbol, "SYNTH_EXCHANGE", "sell", quantity, price, "job", "node")
+    return await ledger.record_fill(order, date, symbol, "SYNTH_EXCHANGE", "sell",
+                                    quantity, price, "120000000", "40",
+                                    execution_id=execution, account_avg_price=account_avg_price)
+
+
+@pytest.mark.asyncio
+async def test_estimated_tail_makes_the_group_estimated(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11")           # workflow 매수 1
+    await sell_with_estimate(ledger, "2", 3, 110, "12", 105)  # 3 매도, 잔량 2 추정 @105
+    result = ledger.personal_metrics()
+    group = result["realized_pnl"][0]
+    assert group["status"] == "estimated"
+    assert group["basis"] == "fifo_with_account_avg_price_estimate"
+    assert group["estimated_quantity"] == 2
+    # amount = FIFO 매칭분(1 @ +10) + 추정분((110-105)*2 = +10) = 20
+    assert group["amount"] == 20
+    assert group["closed_trades"] == 1 and group["winning_trades"] == 1
+    # 상위: 추정 그룹 1개, 합계 basis 는 includes_estimates
+    assert result["estimated_group_count"] == 1
+    assert result["closed_trade_status"] == "available"
+    assert result["closed_trade_basis"] == "includes_estimates"
+    assert result["closed_trade_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_estimated_group_ratio_basis_includes_estimates(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 2, 100, "11")           # workflow 매수 2
+    await fill(ledger, "2", "sell", 1, 90, "12")           # 매도 1 @90 → 손실 -10 (매칭)
+    await sell_with_estimate(ledger, "3", 3, 110, "13", 105)  # 매도 3: 매칭 1(+10) + 추정 2(+10)=+20
+    result = ledger.personal_metrics()
+    group = result["realized_pnl"][0]
+    assert group["status"] == "estimated"
+    assert group["winning_trades"] == 1 and group["losing_trades"] == 1
+    assert group["gross_profit"] == 20 and group["gross_loss"] == 10
+    # 한 그룹만 닫힌 거래가 있으니 손익비 발행 — basis 는 includes_estimates
+    assert result["profit_loss_ratio"] == 2.0
+    assert result["profit_loss_ratio_status"] == "available"
+    assert result["profit_loss_ratio_basis"] == "includes_estimates"
+
+
+@pytest.mark.asyncio
+async def test_residual_without_estimate_stays_unavailable(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11")   # workflow 매수 1
+    # 3 매도인데 workflow 로트 1뿐 + 계좌 평단 미제공 → 추정 없음 → 거부
+    ledger.record_order("2", "20260909", "SYNTH", "SYNTH_EXCHANGE", "sell", 3, 110, "job", "node")
+    await ledger.record_fill("2", "20260909", "SYNTH", "SYNTH_EXCHANGE", "sell", 3, 110,
+                             "120000000", "40", execution_id="12")
+    result = ledger.personal_metrics()
+    group = result["realized_pnl"][0]
+    assert group["status"] == "unavailable"
+    assert group["reason"] == "incomplete_fifo_basis"
+    assert group["basis"] is None and group["estimated_quantity"] is None
+    assert result["closed_trade_status"] == "unavailable"
+
+
+@pytest.mark.asyncio
+async def test_fully_matched_group_basis_is_measured(tmp_path):
+    ledger = tracker(tmp_path)
+    await fill(ledger, "1", "buy", 1, 100, "11")
+    await fill(ledger, "2", "sell", 1, 110, "12")   # 완전 매칭, 추정 없음
+    result = ledger.personal_metrics()
+    group = result["realized_pnl"][0]
+    assert group["status"] == "available"
+    assert group["basis"] == "fifo" and group["estimated_quantity"] == 0
+    assert result["estimated_group_count"] == 0
+    assert result["closed_trade_basis"] == "measured"
+
+
+@pytest.mark.asyncio
+async def test_off_strategy_fills_counts_hts_and_other_api(tmp_path):
+    ledger = tracker(tmp_path, provider="ls-sec.co.kr")
+    ledger.FILL_BUFFER_TIMEOUT = 0.05
+    await fill(ledger, "1", "buy", 1, 100, "11")   # 우리 workflow 체결
+    # 사람의 HTS 거래: 실제 비-'40' 매체코드 + 일치 주문 없음 → manual
+    await ledger.record_fill("H1", "20260909", "SYNTH", "SYNTH_EXCHANGE", "buy", 1, 90,
+                             "100000000", "41", execution_id="21")
+    # 타 API 클라이언트: '40' + 일치 주문 없음 → 버퍼 → unknown_api
+    r = await ledger.record_fill("A1", "20260909", "SYNTH", "SYNTH_EXCHANGE", "buy", 1, 95,
+                                 "100000000", "40", execution_id="22")
+    assert r == "pending"
+    await asyncio.sleep(0.15)
+    off = ledger.personal_metrics()["off_strategy_fills"]
+    assert off["status"] == "available"
+    assert off["hts"] == 1
+    assert off["other_api"] == 1
+    assert off["reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_off_strategy_fills_unavailable_for_futures(tmp_path):
+    ledger = tracker(tmp_path, product="overseas_futures", trading_mode="paper")
+    await fill(ledger, "1", "buy", 1, 100, "11")
+    off = ledger.personal_metrics()["off_strategy_fills"]
+    assert off["status"] == "unavailable"
+    assert off["hts"] is None and off["other_api"] is None
+    assert off["reason"] == "futures_fills_have_no_media_code"

--- a/src/programgarden/tests/test_workflow_position_tracker.py
+++ b/src/programgarden/tests/test_workflow_position_tracker.py
@@ -1,5 +1,6 @@
 """WorkflowPositionTracker 테스트"""
 import asyncio
+import sqlite3
 import tempfile
 from decimal import Decimal
 import pytest
@@ -565,3 +566,117 @@ class TestRateEvidenceGate:
             )
             assert pnl['workflow_positions'], "포지션 명세는 그대로 실린다"
             assert pnl['workflow_positions'][0].pnl_rate is not None
+
+
+class TestMediaCodeClassification:
+    """E1: 프레임의 통신매체코드로 계좌 내 타 경로 체결을 가른다.
+
+    우리 주문과 일치하는 체결은 매체코드와 무관하게 workflow 이고(주문 기록이
+    권위 있는 소유 신호), 일치하지 않는 체결만 매체코드로 HTS(manual)/타 API 를
+    가른다. 빈 매체코드는 "모름"이라 사람의 HTS 로 단정하지 않고 버퍼→unknown_api.
+    """
+
+    @pytest.mark.asyncio
+    async def test_workflow_order_match_wins_over_non40_media(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('O1', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'n')
+            # 우리 체결이 '40' 이 아닌 매체코드로 와도 주문 일치가 우선 → workflow
+            result = await t.record_fill('O1', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, '100000000', '41')
+            assert result == 'workflow'
+
+    @pytest.mark.asyncio
+    async def test_non40_media_without_order_is_manual(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            # 일치하는 주문이 없고 매체코드가 '40' 이 아니면 사람(HTS) → manual
+            result = await t.record_fill('X1', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, '100000000', '41')
+            assert result == 'manual'
+
+    @pytest.mark.asyncio
+    async def test_empty_media_without_order_buffers_then_unknown_api(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            # 빈 매체코드는 사람의 HTS 로 단정하지 않는다 — 버퍼(늦게 도착할 우리
+            # 주문에 대비)했다가, 일치 주문이 없으면 unknown_api 로 접는다(manual 아님).
+            result = await t.record_fill('X2', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, '100000000', '')
+            assert result == 'pending'
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                rows = conn.execute("SELECT classification FROM trade_history").fetchall()
+            assert rows == [('unknown_api',)]
+
+
+class TestWorkflowLotOwnershipAndEstimate:
+    """E2: workflow 매도는 workflow 로트만 소진하고, 남는 잔량은 계좌 평균매입가로 추정."""
+
+    @pytest.mark.asyncio
+    async def test_workflow_sell_consumes_only_workflow_lots(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            # 같은 종목의 수동(HTS) 로트와 workflow 로트가 공존
+            await t.record_fill('M1', '20260123', 'AAPL', 'NASDAQ', 'buy', 5, 90.0, '100000000', '41')  # manual
+            t.record_order('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 3, 100.0, 'j', 'n')
+            await t.record_fill('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 3, 100.0, '110000000', '40')  # workflow
+            # workflow 매도 2주: workflow 로트(100)만 소진, 수동 로트는 그대로
+            t.record_order('W2', '20260123', 'AAPL', 'NASDAQ', 'sell', 2, 120.0, 'j', 'n')
+            await t.record_fill('W2', '20260123', 'AAPL', 'NASDAQ', 'sell', 2, 120.0, '120000000', '40')
+            positions = t.get_workflow_positions()
+            assert positions['AAPL'].quantity == 1  # workflow 3 중 2 소진 → 1 남음
+            with sqlite3.connect(t.db_path) as conn:
+                manual_remaining = conn.execute(
+                    "SELECT remaining_qty FROM workflow_position_lots WHERE classification='manual'"
+                ).fetchone()[0]
+            assert manual_remaining == 5  # 수동 로트는 손대지 않음
+
+    @pytest.mark.asyncio
+    async def test_workflow_sell_records_account_avg_estimate_for_tail(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'n')
+            await t.record_fill('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, '100000000', '40')
+            # 3 매도인데 workflow 로트는 1뿐 → 잔량 2를 계좌 평균매입가 105 로 추정
+            t.record_order('W2', '20260123', 'AAPL', 'NASDAQ', 'sell', 3, 110.0, 'j', 'n')
+            await t.record_fill('W2', '20260123', 'AAPL', 'NASDAQ', 'sell', 3, 110.0, '110000000', '40',
+                                account_avg_price=105.0)
+            with sqlite3.connect(t.db_path) as conn:
+                realized, unmatched, basis, source, est_pnl = conn.execute(
+                    "SELECT realized_pnl, unmatched_qty, estimate_basis_price, estimate_source, estimated_pnl "
+                    "FROM trade_history WHERE side='sell'"
+                ).fetchone()
+            assert realized == pytest.approx(10.0)   # FIFO 매칭분 1 @ (110-100)
+            assert unmatched == pytest.approx(2.0)
+            assert basis == pytest.approx(105.0)
+            assert source == 'account_balance_avg_price'
+            assert est_pnl == pytest.approx(10.0)     # (110-105)*2
+
+    @pytest.mark.asyncio
+    async def test_workflow_sell_without_account_avg_records_no_estimate(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'n')
+            await t.record_fill('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, '100000000', '40')
+            t.record_order('W2', '20260123', 'AAPL', 'NASDAQ', 'sell', 3, 110.0, 'j', 'n')
+            await t.record_fill('W2', '20260123', 'AAPL', 'NASDAQ', 'sell', 3, 110.0, '110000000', '40')
+            with sqlite3.connect(t.db_path) as conn:
+                row = conn.execute(
+                    "SELECT unmatched_qty, estimate_basis_price, estimate_source, estimated_pnl "
+                    "FROM trade_history WHERE side='sell'"
+                ).fetchone()
+            assert row == (None, None, None, None)  # 평단 없으면 추정 저장 없음
+
+    @pytest.mark.asyncio
+    async def test_non_workflow_sell_still_consumes_any_lot(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            # workflow 매수 로트
+            t.record_order('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 5, 100.0, 'j', 'n')
+            await t.record_fill('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 5, 100.0, '100000000', '40')
+            # 수동(HTS) 매도: 분류 무관 로트 소진(종전 동작 불변) → workflow 로트를 먹는다
+            await t.record_fill('M1', '20260123', 'AAPL', 'NASDAQ', 'sell', 2, 120.0, '110000000', '41')
+            with sqlite3.connect(t.db_path) as conn:
+                wf_remaining = conn.execute(
+                    "SELECT remaining_qty FROM workflow_position_lots WHERE classification='workflow'"
+                ).fetchone()[0]
+            assert wf_remaining == 3  # 수동 매도가 workflow 로트 2주를 소진

--- a/src/programgarden/tests/test_workflow_position_tracker.py
+++ b/src/programgarden/tests/test_workflow_position_tracker.py
@@ -589,8 +589,9 @@ class TestMediaCodeClassification:
     async def test_human_media_without_order_is_manual(self):
         with tempfile.TemporaryDirectory() as d:
             t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
-            # 일치하는 주문이 없고 매체코드가 표의 인간 채널(85=HTS, 22/23=앱, 00=지점)이면 → manual
-            for code in ('85', '22', '23', '00'):
+            # 일치하는 주문이 없고 매체코드가 사람 채널이면 → manual
+            #   표: 85=HTS, 22/23=앱, 00=지점 · 실측(2026-09-12 해외주식 AS1): 51=투혼앱, 03=투혼웹
+            for code in ('85', '22', '23', '00', '51', '03'):
                 result = await t.record_fill(f'X{code}', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, '100000000', code)
                 assert result == 'manual', code
 

--- a/src/programgarden/tests/test_workflow_position_tracker.py
+++ b/src/programgarden/tests/test_workflow_position_tracker.py
@@ -66,7 +66,7 @@ class TestWorkflowPositionTracker:
             tracker = WorkflowPositionTracker(f'{d}/t.db', 'job1', 'broker1')
             
             # CommdaCode != '40'이면 수동 주문
-            result = await tracker.record_fill('O2', '20260123', 'NVDA', 'NASDAQ', 'buy', 5, 500.0, '104000000', '10')
+            result = await tracker.record_fill('O2', '20260123', 'NVDA', 'NASDAQ', 'buy', 5, 500.0, '104000000', '85')
             assert result == 'manual'
 
     @pytest.mark.asyncio
@@ -586,12 +586,34 @@ class TestMediaCodeClassification:
             assert result == 'workflow'
 
     @pytest.mark.asyncio
-    async def test_non40_media_without_order_is_manual(self):
+    async def test_human_media_without_order_is_manual(self):
         with tempfile.TemporaryDirectory() as d:
             t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
-            # 일치하는 주문이 없고 매체코드가 '40' 이 아니면 사람(HTS) → manual
-            result = await t.record_fill('X1', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, '100000000', '41')
-            assert result == 'manual'
+            # 일치하는 주문이 없고 매체코드가 표의 인간 채널(85=HTS, 22/23=앱, 00=지점)이면 → manual
+            for code in ('85', '22', '23', '00'):
+                result = await t.record_fill(f'X{code}', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, '100000000', code)
+                assert result == 'manual', code
+
+    @pytest.mark.asyncio
+    async def test_api_media_without_order_is_never_manual(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            # 표의 API 코드(41, 43)와 실측 40 은 사람이 아니다 — 버퍼 후 unknown_api
+            for code in ('40', '41', '43'):
+                assert await t.record_fill(f'A{code}', '20260123', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, '100000000', code) == 'pending'
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                kinds = [r[0] for r in conn.execute("SELECT classification FROM trade_history")]
+            assert kinds == ['unknown_api'] * 3
+
+    @pytest.mark.asyncio
+    async def test_unlisted_or_broker_side_media_is_other(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            # 96=최종결제 / LP=로스컷 / 표에 없는 값: 추측 분류하지 않고 other
+            for code in ('96', 'LP', 'ZZ'):
+                assert await t.record_fill(f'O{code}', '20260123', 'AAPL', 'NASDAQ', 'sell', 1, 100.0, '100000000', code) == 'other', code
 
     @pytest.mark.asyncio
     async def test_empty_media_without_order_buffers_then_unknown_api(self):
@@ -616,7 +638,7 @@ class TestWorkflowLotOwnershipAndEstimate:
         with tempfile.TemporaryDirectory() as d:
             t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
             # 같은 종목의 수동(HTS) 로트와 workflow 로트가 공존
-            await t.record_fill('M1', '20260123', 'AAPL', 'NASDAQ', 'buy', 5, 90.0, '100000000', '41')  # manual
+            await t.record_fill('M1', '20260123', 'AAPL', 'NASDAQ', 'buy', 5, 90.0, '100000000', '85')  # manual (HTS)
             t.record_order('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 3, 100.0, 'j', 'n')
             await t.record_fill('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 3, 100.0, '110000000', '40')  # workflow
             # workflow 매도 2주: workflow 로트(100)만 소진, 수동 로트는 그대로
@@ -674,7 +696,7 @@ class TestWorkflowLotOwnershipAndEstimate:
             t.record_order('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 5, 100.0, 'j', 'n')
             await t.record_fill('W1', '20260123', 'AAPL', 'NASDAQ', 'buy', 5, 100.0, '100000000', '40')
             # 수동(HTS) 매도: 분류 무관 로트 소진(종전 동작 불변) → workflow 로트를 먹는다
-            await t.record_fill('M1', '20260123', 'AAPL', 'NASDAQ', 'sell', 2, 120.0, '110000000', '41')
+            await t.record_fill('M1', '20260123', 'AAPL', 'NASDAQ', 'sell', 2, 120.0, '110000000', '85')  # HTS 수동 매도
             with sqlite3.connect(t.db_path) as conn:
                 wf_remaining = conn.execute(
                     "SELECT remaining_qty FROM workflow_position_lots WHERE classification='workflow'"


### PR DESCRIPTION
## 무엇
개인/커뮤니티 지표를 "이 자동매매가 낸 주문 기준"으로 세우기 위한 엔진 쪽 세 가지 (PR #47 v2 봉투 위에 쌓임):

1. **매체코드 살리기** — AS1(`sCommdaCode`)·SC1(`commdacode`) 프레임 값을 원장에 그대로 전달(종전엔 `'40'` 하드코딩). 분류는 **공개 매체 표**(`src/finance/docs/cidbq02400_contract.md:74-77`) 기준: 우리 주문번호 → `workflow`(먼저) · 85/22/23/00 → `manual` · 40/41/43·빈 값 → `unknown_api` · 그 외(96/LP/SK/SO·미등재) → `other`(신설, 추측 분류 안 함). 선물 TC3 프레임엔 매체 필드가 없어 `'40'` 유지.
2. **계좌 평균매입가 기준 추정** — workflow 매도는 workflow 로트만 소진하고, 남는 수량은 매도 직전 잔고조회 평단(`StockAccountTracker._positions[symbol].buy_price`)으로 추정해 매도 행에 additive 컬럼(`unmatched_qty`·`estimate_basis_price`·`estimate_source`·`estimated_pnl`)으로 저장. `realized_pnl`은 FIFO 매칭분만(불변). 봉투 그룹 status `estimated` + `basis`/`estimated_quantity`, 상위 `estimated_group_count`·`closed_trade_basis`·`profit_loss_ratio_basis`.
3. **`off_strategy_fills`** `{hts, other_api, other, status, reason}` — 같은 계좌의 이 전략 밖 체결 수. 선물은 `unavailable`/`futures_fills_have_no_media_code`.

## 규율
개수는 종목 간 합산 OK(통화 없음), 금액은 합산 금지 — 기존 그대로. 추정은 별도 컬럼·별도 status 로만; 기존 판정(`incomplete_fifo_basis`)은 살아 있음. `mixed_fifo_ownership` 사전검사는 workflow 매도가 workflow 로트만 먹게 된 뒤 근거가 사라져 제거(docstring 에 이유).

## 검증
전체 `pytest tests/` → **1513 passed, 26 skipped, 3 xfailed**. 적대 리뷰 통과(cross-repo 키 정합 확인).
짝: 서버 programgarden_server(feat/community-metrics-separation) · 대시보드(feat/league-winrate-removal-personal-v2-ui).
🔴 배포 순서 dsl-api → 대시보드 → 이 엔진 릴리스.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jgvXMHMiFPHPEsadb6ydr
