### PR TITLE
release: core 1.27.0 + engine 1.35.1 (core lockstep 누락 수정)

### DIFF
--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-core"
-version = "1.26.0"
+version = "1.27.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 readme = "README.md"

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [1.35.1] - 2026-09-12
+
+### Fixed
+- 🔴 core lockstep 누락 — #46(1f7199b)이 `WorkflowPnLEvent` 에 `workflow_rate_unavailable_reason` 을 더하면서 core 버전을 안 올려,
+  PyPI `programgarden-core 1.26.0` 위에서 1.35.0 이 `WorkflowPnLEvent(**event_data)` 로 매 tick TypeError → pnl 리스너 전부 실패
+  (스냅샷·봉투 미발행; prod 파드 v1.26.0 실측). core **1.27.0** 으로 발행하고 엔진 의존성을 `^1.27.0` 으로 올린다.
+
+### Changed
+- deps: programgarden-core ^1.27.0
+
 ## [1.35.0] - 2026-09-12
 
 ### Added

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.35.0"
+version = "1.35.1"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
@@ -33,7 +33,7 @@ litellm = ">=1.40.0"
 # 무조건 실어 WorkflowPnLEvent(**event_data) 를 만드는데, 그 필드는 core 1.26.0 에서
 # 추가됐다. 하한을 낮게 두면 core 1.25.x 로 해석된 환경에서 생성이 TypeError 로 죽고,
 # 그 예외가 바로 위 except Exception 에 삼켜져 **PnL 이벤트가 통째로 조용히 멈춘다.**
-programgarden-core = "^1.26.0"
+programgarden-core = "^1.27.0"
 programgarden-finance = "^1.9.5"
 programgarden-community = "^1.15.0"
 


### PR DESCRIPTION
prod 파드 v1.26.0 실측: PyPI core 1.26.0 에 workflow_rate_unavailable_reason 이 없어 pnl 리스너 TypeError. core 1.27.0 발행 + 엔진 의존성 ^1.27.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jgvXMHMiFPHPEsadb6ydr