### PR TITLE
feat: C23 미해석 템플릿 심볼 차단 + C24 체결 확정 이벤트(on_order_fill) — core 1.28.0 / engine 1.36.0

### DIFF
--- a/src/core/CHANGELOG.md
+++ b/src/core/CHANGELOG.md
@@ -1,3 +1,30 @@
+## [1.28.0] - 2026-09-12
+
+### Added
+- 체결 확정 이벤트 계약 — `OrderFillEvent` 데이터클래스와 `ExecutionListener.on_order_fill`
+  훅(기본 no-op) 신설. 엔진 원장에 체결이 **새로** 확정될 때마다 정확히 1회 발화하는 사실
+  전용 이벤트다(금액/수익 계산 없음): job_id·node_id(우리 주문이면 값, 아니면 None)·
+  order_no·order_date·execution_id(opt)·symbol·exchange·side·quantity·price·fill_time·
+  product·provider·classification(workflow|manual|unknown_api|other)·commda_code·
+  trading_mode·received_at·timestamp. `BaseExecutionListener`/`ConsoleExecutionListener`
+  에도 대응 훅 추가.
+
+### Notes
+- 🔴 **engine lockstep** — `programgarden` 1.36.0 이 이 심볼을 import 시점에 하드 의존한다
+  (`context.py` 가 `OrderFillEvent` 를 eager import). 반드시 **이 core 1.28.0 을 먼저 발행**한
+  뒤 엔진을 발행해야 한다. 구 core(≤1.27.0) 위에서 엔진 1.36.0 을 설치하면 `import programgarden`
+  이 ImportError 로 통째 실패한다. finance 1.9.5 / community 1.15.x 와 동반.
+
+## [1.27.0] - 2026-09-12
+
+### Added
+- `WorkflowPnLEvent.workflow_rate_unavailable_reason` — 선물 등 수익률을 낼 수 없는 경우
+  그 사유를 이벤트에 실어 리스너가 "0%" 와 "산출 불가" 를 구분할 수 있게 한다.
+
+### Notes
+- 엔진 1.35.1 과 동반. 이 필드가 없는 core(≤1.26.0) 위에서 1.35.x 가 `WorkflowPnLEvent(**event_data)`
+  를 매 tick TypeError → pnl 리스너 전부 실패하므로 lockstep 필수.
+
 ## [1.26.0] - 2026-09-10
 
 ### Added

--- a/src/core/programgarden_core/bases/listener.py
+++ b/src/core/programgarden_core/bases/listener.py
@@ -592,6 +592,67 @@ class RestartEvent:
     timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 
+# ============================================================
+# 체결 확정 이벤트
+# ============================================================
+
+@dataclass
+class OrderFillEvent:
+    """
+    Event emitted when an order fill is confirmed and recorded to the ledger.
+
+    Facts only — no monetary computation. This mirrors what the broker reported
+    for one execution plus how the workflow ledger classified it. It fires once
+    per newly recorded fill, including a fill whose classification is only
+    resolved after the arrival-buffering timeout.
+
+    A fill whose ``classification`` is not "workflow" did not match one of our
+    recorded workflow orders, so ``node_id`` is None. Return/P&L interpretation
+    belongs to WorkflowPnLEvent and to broker-verified accounting, never to this
+    raw record — quantity/price are the reported execution facts, nothing is
+    summed or converted here.
+
+    Attributes:
+        job_id: Job identifier
+        node_id: OrderNode ID when this fill matches a recorded workflow order;
+            None for manual/unknown_api/other fills
+        order_no: Broker order number
+        order_date: Order date (YYYYMMDD)
+        execution_id: Broker execution identity when the frame reported one; else None
+        symbol: Symbol code
+        exchange: Exchange code
+        side: "buy" | "sell"
+        quantity: Filled quantity (reported, not aggregated)
+        price: Fill price (reported)
+        fill_time: Fill time (HHMMSSsss) as reported by the broker
+        product: "overseas_stock" | "overseas_futures" | "korea_stock"
+        provider: Broker provider (e.g. "ls")
+        classification: "workflow" | "manual" | "unknown_api" | "other"
+        commda_code: Broker communication-media code, preserved as reported
+        trading_mode: "live" | "paper"
+        received_at: ISO-8601 timestamp when the tracker received the fill
+        timestamp: Event emission timestamp
+    """
+    job_id: str
+    order_no: str
+    order_date: str
+    symbol: str
+    exchange: str
+    side: str  # "buy" | "sell"
+    quantity: Union[Decimal, float, int]
+    price: Union[Decimal, float]
+    fill_time: str
+    product: str
+    provider: str
+    classification: str  # "workflow" | "manual" | "unknown_api" | "other"
+    commda_code: str
+    trading_mode: str
+    received_at: str
+    node_id: Optional[str] = None
+    execution_id: Optional[Union[str, int]] = None
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
 @runtime_checkable
 class ExecutionListener(Protocol):
     """
@@ -746,6 +807,21 @@ class ExecutionListener(Protocol):
         """
         ...
 
+    async def on_order_fill(self, event: 'OrderFillEvent') -> None:
+        """
+        Called when an order fill is confirmed and recorded to the ledger.
+
+        Facts only — no monetary computation. Fires once per newly recorded
+        fill, including a fill whose classification resolves after the
+        arrival-buffering timeout. Servers may durably record the fill (symbol,
+        side, quantity, price, classification) without trusting it as a return.
+
+        Args:
+            event: OrderFillEvent with order/execution identifiers, symbol,
+                side, quantity, price, classification, and trading mode.
+        """
+        ...
+
 
 class BaseExecutionListener:
     """
@@ -826,6 +902,10 @@ class BaseExecutionListener:
         pass
 
     async def on_notification(self, event: 'NotificationEvent') -> None:
+        """Default implementation: do nothing"""
+        pass
+
+    async def on_order_fill(self, event: 'OrderFillEvent') -> None:
         """Default implementation: do nothing"""
         pass
 
@@ -966,3 +1046,9 @@ class ConsoleExecutionListener(BaseExecutionListener):
         print(f"{color}{emoji} NOTIFY {cat.upper()}{node_tag} {event.title}{reset}")
         if event.message:
             print(f"   {event.message}")
+
+    async def on_order_fill(self, event: 'OrderFillEvent') -> None:
+        """Print a confirmed order fill (facts only, no P&L)."""
+        node_tag = f" [{event.node_id}]" if event.node_id else ""
+        print(f"💵 FILL{node_tag} {event.symbol} {event.side} {event.quantity}@{event.price} "
+              f"[{event.classification}] order={event.order_no} ({event.trading_mode})")

--- a/src/core/programgarden_core/bases/listener.py
+++ b/src/core/programgarden_core/bases/listener.py
@@ -650,7 +650,7 @@ class OrderFillEvent:
     received_at: str
     node_id: Optional[str] = None
     execution_id: Optional[Union[str, int]] = None
-    timestamp: datetime = field(default_factory=datetime.utcnow)
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
 
 @runtime_checkable

--- a/src/core/pyproject.toml
+++ b/src/core/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-core"
-version = "1.27.0"
+version = "1.28.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 readme = "README.md"

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [1.36.0] - 2026-09-12
 
 ### Added
 - C24 체결 확정 이벤트 — 리스너 계약(core `ExecutionListener`)에 `on_order_fill(OrderFillEvent)` 훅과
@@ -8,11 +8,16 @@
   수익 계산 없음): job_id·node_id(우리 주문이면 workflow_orders 의 node_id, 아니면 None)·order_no·
   order_date·execution_id·symbol·exchange·side·quantity·price·fill_time·product·provider·
   classification(workflow|manual|unknown_api|other)·commda_code·trading_mode·received_at. 세 체결
-  경로(AS1/SC1/TC3)가 `record_workflow_fill` 을 거치므로 자동으로 이 이벤트를 낸다.
-- 🔴 **core lockstep** — 이 엔진은 import 시점에 `OrderFillEvent` 를 core 에서 끌어온다(`context.py`).
-  **core 1.28.0**(`OrderFillEvent` + `on_order_fill` 포함)을 먼저 발행하고 `programgarden-core`
-  의존성을 `^1.28.0` 으로 올려야 한다 — 구 core(≤1.27.0) 위에서는 context.py import 자체가 실패한다
-  (#46/1.35.1 의 조용한 TypeError 보다 강한, 모듈 로드 실패).
+  경로(AS1/SC1/TC3)가 `record_workflow_fill` 을 거치므로 자동으로 이 이벤트를 낸다. `on_order_fill`
+  발화는 tracker 의 `_buffer_lock` 밖에서 일어난다 — 리스너 체인이 네트워크 POST 를 await 해도 다른
+  브로커 체결 푸시가 락 뒤에서 직렬화되지 않는다(락 안에서는 확정분을 큐잉만 하고, 락을 놓은 뒤 emit).
+
+### Fixed / lockstep
+- 🔴 **core lockstep 완결** — 이 엔진은 import 시점에 `OrderFillEvent` 를 core 에서 eager import
+  한다(`context.py`). 그 심볼은 **core 1.28.0** 신설이므로 `programgarden-core` 의존성을 `^1.28.0`
+  으로 상향했다(1.35.1 의 `^1.27.0` 유지 시 구 core 위에서 `import programgarden` 이 ImportError 로
+  통째 실패 — #46/1.35.1 의 조용한 TypeError 보다 강한 모듈 로드 실패). **발행 순서**: core 1.28.0 을
+  먼저 PyPI 에 올린 뒤 이 엔진 1.36.0 을 올리고, pg-worker 이미지를 lockstep 재빌드해야 한다.
 
 ### Fixed
 - C23 미해석 템플릿 심볼 차단 — `_normalize_order` 가 symbol 또는 exchange 에 `{{` 가 있으면 주문을

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## [Unreleased]
 
+### Added
+- C24 체결 확정 이벤트 — 리스너 계약(core `ExecutionListener`)에 `on_order_fill(OrderFillEvent)` 훅과
+  `OrderFillEvent` 데이터클래스 신설. 원장에 체결이 **새로** 확정될 때마다 정확히 1회 발화한다 —
+  즉시(주문 매칭)·버퍼·pending→timeout 경로가 모두 원장 단일 지점(`_process_fill_internal`)을 거쳐
+  `context.notify_order_fill` 로 통지된다(리플레이는 조기 반환하므로 재발화 없음). 사실만 담는다(금액/
+  수익 계산 없음): job_id·node_id(우리 주문이면 workflow_orders 의 node_id, 아니면 None)·order_no·
+  order_date·execution_id·symbol·exchange·side·quantity·price·fill_time·product·provider·
+  classification(workflow|manual|unknown_api|other)·commda_code·trading_mode·received_at. 세 체결
+  경로(AS1/SC1/TC3)가 `record_workflow_fill` 을 거치므로 자동으로 이 이벤트를 낸다.
+- 🔴 **core lockstep** — 이 엔진은 import 시점에 `OrderFillEvent` 를 core 에서 끌어온다(`context.py`).
+  **core 1.28.0**(`OrderFillEvent` + `on_order_fill` 포함)을 먼저 발행하고 `programgarden-core`
+  의존성을 `^1.28.0` 으로 올려야 한다 — 구 core(≤1.27.0) 위에서는 context.py import 자체가 실패한다
+  (#46/1.35.1 의 조용한 TypeError 보다 강한, 모듈 로드 실패).
+
+### Fixed
+- C23 미해석 템플릿 심볼 차단 — `_normalize_order` 가 symbol 또는 exchange 에 `{{` 가 있으면 주문을
+  만들지 않고 None 을 반환한다(에러 로그 사유 `unresolved_template_symbol`). 매수·매도·시장가·지정가
+  전부, 세 상품(해외주식/국내주식/선물)이 공유하는 정규화 지점에서 막으므로 미해석 템플릿이 브로커
+  주문(IsuNo)으로 절대 나가지 않는다. 방어선으로 `_order_result` 도 symbol/exchange 가 템플릿이면 그
+  자리를 None 으로 비우고 error=`unresolved_template_symbol`, diagnostics 에 원문(raw_symbol/
+  raw_exchange)을 보존한다 — 원장/서버가 심볼 자리에 `{{ ... }}` 를 받지 않게(prod order_fills id=17
+  재발 차단).
+
 ## [1.35.1] - 2026-09-12
 
 ### Fixed

--- a/src/programgarden/programgarden/context.py
+++ b/src/programgarden/programgarden/context.py
@@ -38,6 +38,7 @@ from programgarden_core.bases.listener import (
     LLMStreamEvent,
     TokenUsageEvent,
     AIToolCallEvent,
+    OrderFillEvent,
 )
 from programgarden_core.models.resilience import RetryEvent
 
@@ -2413,6 +2414,12 @@ class ExecutionContext:
             # 거래 모드 메타데이터 기록 (데이터 초기화 없이 모드만 업데이트)
             self._workflow_position_tracker.update_trading_mode(trading_mode)
 
+            # 체결 확정 → on_order_fill 리스너 연결. 즉시/버퍼/타임아웃 경로가
+            # 모두 원장의 단일 지점을 거치므로 여기서 한 번만 연결한다.
+            self._workflow_position_tracker.set_fill_classified_callback(
+                self._on_tracker_fill_classified
+            )
+
             # PnL refresh용 정보 저장
             self._workflow_broker_node_id = broker_node_id
             self._workflow_product = product
@@ -2682,6 +2689,72 @@ class ExecutionContext:
         except Exception as e:
             logger.warning(f"Failed to record workflow fill: {e}")
             return "error"
+
+    async def _on_tracker_fill_classified(self, fill, classification: str) -> None:
+        """Bridge a newly recorded ledger fill to on_order_fill listeners.
+
+        The tracker invokes this exactly once per new fill — for immediate,
+        buffered, and timeout-resolved classifications alike — so notification
+        happens whether ``record_workflow_fill`` returned a final classification
+        or "pending" that only settled after the arrival-buffering timeout.
+        Facts only: no monetary computation. Manual/unknown_api/other fills have
+        no matching workflow order, so node_id stays None.
+        """
+        tracker = self._workflow_position_tracker
+        if tracker is None:
+            return
+
+        job_id = self.job_id
+        node_id = None
+        try:
+            identity = tracker.lookup_order_identity(fill.order_no, fill.order_date)
+            if identity is not None:
+                row_job_id, node_id = identity
+                if row_job_id:
+                    job_id = row_job_id
+        except Exception as e:
+            logger.warning(f"Failed to resolve order identity for fill: {e}")
+
+        received_at = getattr(fill, "received_at", None)
+        received_iso = (
+            received_at.isoformat() if hasattr(received_at, "isoformat")
+            else datetime.utcnow().isoformat()
+        )
+
+        event = OrderFillEvent(
+            job_id=job_id,
+            node_id=node_id,
+            order_no=fill.order_no,
+            order_date=fill.order_date,
+            execution_id=fill.execution_id,
+            symbol=fill.symbol,
+            exchange=fill.exchange,
+            side=fill.side,
+            quantity=fill.quantity,
+            price=fill.price,
+            fill_time=fill.fill_time,
+            product=tracker.product,
+            provider=tracker.provider,
+            classification=classification,
+            commda_code=fill.commda_code,
+            trading_mode=tracker.trading_mode,
+            received_at=received_iso,
+        )
+        await self.notify_order_fill(event)
+
+    async def notify_order_fill(self, event: OrderFillEvent) -> None:
+        """Notify all listeners about a confirmed order fill (facts only)."""
+        if not self._listeners:
+            return
+
+        for listener in self._listeners:
+            try:
+                await listener.on_order_fill(event)
+            except Exception as e:
+                logger.warning(f"Listener error on_order_fill: {e}")
+
+        # SSE 스트림 전송을 위해 이벤트 루프에 제어권 양보
+        await asyncio.sleep(0)
 
     async def cancel_workflow_order(
         self,

--- a/src/programgarden/programgarden/context.py
+++ b/src/programgarden/programgarden/context.py
@@ -11,7 +11,7 @@ Workflow execution context protocol
 
 from typing import Optional, Dict, Any, List, Protocol, runtime_checkable, Callable, Awaitable, TYPE_CHECKING, Tuple
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from collections import deque
 import asyncio
@@ -2718,7 +2718,7 @@ class ExecutionContext:
         received_at = getattr(fill, "received_at", None)
         received_iso = (
             received_at.isoformat() if hasattr(received_at, "isoformat")
-            else datetime.utcnow().isoformat()
+            else datetime.now(timezone.utc).isoformat()
         )
 
         event = OrderFillEvent(

--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -19,7 +19,7 @@ import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal, ROUND_HALF_UP
-from typing import Dict, List, Optional, Any, Tuple
+from typing import Dict, List, Optional, Any, Tuple, Callable, Awaitable
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -184,8 +184,69 @@ class WorkflowPositionTracker:
         # 역산 불가한 틱에서는 이 캐시(최근 성공값)로 폴백해 FIFO 산술을 스케일한다.
         self._multiplier_cache: Dict[str, Decimal] = {}
 
+        # 체결 확정 콜백. 원장에 **새로** 기록된 체결마다 정확히 1회 발화한다 —
+        # 즉시/버퍼/타임아웃 경로가 모두 _process_fill_internal 을 거치므로 한 곳에서
+        # 부른다. 리플레이(동일 execution identity 재도착)는 그 앞에서 조기 반환하므로
+        # 재발화하지 않는다. 컨텍스트가 이걸 on_order_fill 리스너로 연결한다.
+        self._on_fill_classified: Optional[
+            Callable[["PendingFill", str], Awaitable[None]]
+        ] = None
+
         # DB 초기화
         self._init_db()
+
+    def set_fill_classified_callback(
+        self,
+        callback: Optional[Callable[["PendingFill", str], Awaitable[None]]],
+    ) -> None:
+        """Register an async callback fired once per newly recorded fill.
+
+        The callback receives ``(fill: PendingFill, classification: str)`` where
+        classification is one of "workflow" | "manual" | "unknown_api" | "other".
+        It must not mutate ledger state; exceptions raised by it are caught and
+        logged so they never break FIFO recording.
+        """
+        self._on_fill_classified = callback
+
+    def lookup_order_identity(
+        self,
+        order_no: str,
+        order_date: str,
+    ) -> Optional[Tuple[Optional[str], Optional[str]]]:
+        """Return ``(job_id, node_id)`` for a recorded workflow order, else None.
+
+        Scoped to this ledger's product/provider/trading mode and the order date.
+        Matches the exact order number first, then the normalized form (so
+        zero-padding differences between the order ACK and the fill still map).
+        A fill that is not one of our workflow orders returns None (node_id then
+        stays None on the emitted event).
+        """
+        try:
+            norm = self._normalize_identifier(order_no)
+        except ValueError:
+            norm = None
+        try:
+            with sqlite3.connect(self.db_path) as conn:
+                rows = conn.execute(
+                    """
+                    SELECT order_no, job_id, node_id FROM workflow_orders
+                    WHERE product = ? AND provider = ? AND trading_mode = ? AND order_date = ?
+                    """,
+                    (self.product, self.provider, self.trading_mode, order_date),
+                ).fetchall()
+        except Exception as e:
+            logger.warning(f"lookup_order_identity failed: {e}")
+            return None
+        for row_order_no, job_id, node_id in rows:
+            if row_order_no == order_no:
+                return (job_id, node_id)
+            if norm is not None:
+                try:
+                    if self._normalize_identifier(row_order_no) == norm:
+                        return (job_id, node_id)
+                except ValueError:
+                    continue
+        return None
     
     def _init_db(self) -> None:
         """데이터베이스 테이블 초기화"""
@@ -681,6 +742,15 @@ class WorkflowPositionTracker:
         self.fill_revision += 1
 
         logger.debug(f"Processed fill: {fill.symbol} {fill.side} {fill.quantity}@{fill.price} [{classification}] ({self.trading_mode})")
+
+        # 새 체결이 원장에 확정됐다 → on_order_fill 리스너로 연결(1회 발화).
+        # 리플레이는 위에서 previous 반환으로 이미 걸러졌으므로 여기 오지 않는다.
+        if self._on_fill_classified is not None:
+            try:
+                await self._on_fill_classified(fill, classification)
+            except Exception as cb_err:
+                logger.warning(f"Fill-classified callback error: {cb_err}")
+
         return classification
     
     def _process_sell_fifo(

--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -471,6 +471,7 @@ class WorkflowPositionTracker:
     
     async def _process_buffered_fill(self, order_no: str, order_date: str) -> None:
         """Process all buffered partial fills after recording their order."""
+        notifications: list = []
         async with self._buffer_lock:
             for key, fill in list(self._pending_fills.items()):
                 if fill.order_date != order_date:
@@ -479,8 +480,9 @@ class WorkflowPositionTracker:
                 if self._normalize_identifier(fill.execution_id) is not None:
                     matches = self._normalize_identifier(fill.order_no) == self._normalize_identifier(order_no)
                 if matches:
-                    await self._process_fill_internal(fill, "workflow")
+                    await self._process_fill_internal(fill, "workflow", notifications)
                     self._pending_fills.pop(key)
+        await self._emit_fill_notifications(notifications)
     
     async def record_fill(
         self,
@@ -541,6 +543,8 @@ class WorkflowPositionTracker:
             execution_id=execution_id, account_avg_price=account_avg_price,
         )
         identity = self._execution_key(fill)
+        notifications: list = []
+        result: Optional[str] = None
         async with self._buffer_lock:
             if identity is not None:
                 for pending in self._pending_fills.values():
@@ -559,31 +563,36 @@ class WorkflowPositionTracker:
             # of a hardcoded '40', our own OPEN-API fills may not carry '40'; the
             # old media-first ordering would then misfile them as manual.)
             if self._is_workflow_fill(fill):
-                return await self._process_fill_internal(fill, "workflow")
-            # No matching order. Classify by the published media table
-            # (MEDIA_CODES_* above) — never by "not 40":
-            #   human (85 HTS / 22 iPhone / 23 Android / 00 branch) → "manual"
-            #   other (96/LP/SK/SO or unlisted)                    → "other"
-            #   api (40/41/43) or blank                            → buffer below
-            channel = media_channel(commda_code)
-            if channel == "human":
-                return await self._process_fill_internal(fill, "manual")
-            if channel == "other":
-                # A code the table does not attribute — more of these exist than
-                # we have measured (only 40/51/85/03 are live-observed so far).
-                # Log it so the table can grow from evidence, never from guesses.
-                logger.info("Unlisted media code %r on fill %s/%s — classified other",
-                            commda_code, order_date, order_no)
-                return await self._process_fill_internal(fill, "other")
-
-            # An API code or an empty media code ("medium unknown"): buffer to
-            # give a lagging order record a chance to arrive, then
-            # _process_timeout_fill files it as workflow (matched) or unknown_api
-            # (unmatched). An unknown medium is never asserted to be a person's
-            # HTS trade, so it floors to unknown_api rather than manual.
-            self._next_pending_fill += 1
-            key = self._next_pending_fill
-            self._pending_fills[key] = fill
+                result = await self._process_fill_internal(fill, "workflow", notifications)
+            else:
+                # No matching order. Classify by the published media table
+                # (MEDIA_CODES_* above) — never by "not 40":
+                #   human (85 HTS / 22 iPhone / 23 Android / 00 branch) → "manual"
+                #   other (96/LP/SK/SO or unlisted)                    → "other"
+                #   api (40/41/43) or blank                            → buffer below
+                channel = media_channel(commda_code)
+                if channel == "human":
+                    result = await self._process_fill_internal(fill, "manual", notifications)
+                elif channel == "other":
+                    # A code the table does not attribute — more of these exist than
+                    # we have measured (only 40/51/85/03 are live-observed so far).
+                    # Log it so the table can grow from evidence, never from guesses.
+                    logger.info("Unlisted media code %r on fill %s/%s — classified other",
+                                commda_code, order_date, order_no)
+                    result = await self._process_fill_internal(fill, "other", notifications)
+                else:
+                    # An API code or an empty media code ("medium unknown"): buffer to
+                    # give a lagging order record a chance to arrive, then
+                    # _process_timeout_fill files it as workflow (matched) or unknown_api
+                    # (unmatched). An unknown medium is never asserted to be a person's
+                    # HTS trade, so it floors to unknown_api rather than manual.
+                    self._next_pending_fill += 1
+                    key = self._next_pending_fill
+                    self._pending_fills[key] = fill
+        # Emit any confirmed-fill notifications now that _buffer_lock is released.
+        if result is not None:
+            await self._emit_fill_notifications(notifications)
+            return result
         asyncio.create_task(self._process_timeout_fill(key))
         logger.debug(f"Buffered fill (waiting for order): {key}")
         return "pending"
@@ -591,14 +600,16 @@ class WorkflowPositionTracker:
     async def _process_timeout_fill(self, key: int) -> None:
         """Expire one arrival, without consuming a later partial's timeout."""
         await asyncio.sleep(self.FILL_BUFFER_TIMEOUT)
+        notifications: list = []
         async with self._buffer_lock:
             if key in self._pending_fills:
                 fill = self._pending_fills[key]
                 classification = "workflow" if self._is_workflow_fill(fill) else "unknown_api"
                 if classification == "unknown_api":
                     logger.warning("Fill expired before its order was recorded; classifying as unknown_api")
-                await self._process_fill_internal(fill, classification)
+                await self._process_fill_internal(fill, classification, notifications)
                 self._pending_fills.pop(key)
+        await self._emit_fill_notifications(notifications)
 
     @staticmethod
     def _normalize_identifier(value: Optional[str | int]) -> Optional[str]:
@@ -674,8 +685,18 @@ class WorkflowPositionTracker:
             """, identity[:4])
             return any(self._normalize_identifier(row[0]) == identity[4] for row in rows)
 
-    async def _process_fill_internal(self, fill: PendingFill, classification: str) -> str:
-        """Gate explicit replay before atomically mutating FIFO and history."""
+    async def _process_fill_internal(
+        self, fill: PendingFill, classification: str, notifications: list
+    ) -> str:
+        """Gate explicit replay before atomically mutating FIFO and history.
+
+        A newly confirmed fill is *queued* into ``notifications`` (a caller-owned
+        list) instead of being emitted here — the caller emits it via
+        ``_emit_fill_notifications`` AFTER releasing ``_buffer_lock``. Emitting
+        under the lock would await the listener chain (a network POST in the
+        pg-worker forwarder, ``request_timeout`` seconds) while holding
+        ``_buffer_lock``, serializing every other broker fill push behind it.
+        Replays return early and queue nothing (no re-fire)."""
         fill_datetime = f"{fill.order_date}_{fill.fill_time}"
 
         with sqlite3.connect(self.db_path) as conn:
@@ -743,16 +764,30 @@ class WorkflowPositionTracker:
 
         logger.debug(f"Processed fill: {fill.symbol} {fill.side} {fill.quantity}@{fill.price} [{classification}] ({self.trading_mode})")
 
-        # 새 체결이 원장에 확정됐다 → on_order_fill 리스너로 연결(1회 발화).
+        # 새 체결이 원장에 확정됐다 → on_order_fill 통지를 큐잉한다(1회 발화).
+        # 실제 emit 은 caller 가 _buffer_lock 을 놓은 뒤 _emit_fill_notifications
+        # 로 수행한다(락 안에서 리스너 network POST 를 await 하지 않기 위함).
         # 리플레이는 위에서 previous 반환으로 이미 걸러졌으므로 여기 오지 않는다.
         if self._on_fill_classified is not None:
+            notifications.append((fill, classification))
+
+        return classification
+
+    async def _emit_fill_notifications(self, notifications: list) -> None:
+        """Emit queued on_order_fill notifications OUTSIDE ``_buffer_lock``.
+
+        Each caller collects confirmed fills into its own list under the lock
+        (via ``_process_fill_internal``) and drains them here once the lock is
+        released, so a slow listener never blocks other broker fill pushes.
+        """
+        if self._on_fill_classified is None:
+            return
+        for fill, classification in notifications:
             try:
                 await self._on_fill_classified(fill, classification)
             except Exception as cb_err:
                 logger.warning(f"Fill-classified callback error: {cb_err}")
 
-        return classification
-    
     def _process_sell_fifo(
         self,
         cursor: sqlite3.Cursor,

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -14484,7 +14484,7 @@ class NewOrderNodeExecutor(NodeExecutorBase):
         order_type = config.get("order_type", "limit")
 
         # order 정규화
-        normalized_order = self._normalize_order(order, config)
+        normalized_order = self._normalize_order(order, config, context, node_id)
 
         if not normalized_order:
             context.log("warning", f"{node_type}: 주문할 종목이 없습니다", node_id)
@@ -14677,12 +14677,18 @@ class NewOrderNodeExecutor(NodeExecutorBase):
         self,
         order_raw: Any,
         config: Dict[str, Any],
+        context: Optional["ExecutionContext"] = None,
+        node_id: Optional[str] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         order 객체를 정규화 (단일 종목)
 
         입력: {symbol, exchange, quantity, price}
         출력: {symbol, exchange, quantity, price} (검증된 객체) 또는 None
+
+        symbol 또는 exchange 가 미해석 템플릿('{{ ... }}')이면 주문을 만들지 않고
+        None 을 반환한다 — 상류 바인딩이 풀리지 않은 것이므로, 이 값이 브로커
+        주문(매수·매도·시장가·지정가 전부)이나 원장에 절대 실려선 안 된다(C23).
         """
         if not order_raw:
             return None
@@ -14695,6 +14701,28 @@ class NewOrderNodeExecutor(NodeExecutorBase):
             return None
 
         exchange = order_raw.get("exchange", "NASDAQ")
+
+        # C23: 미해석 템플릿 심볼/거래소 차단. 상류 노드가 실행되지 않았거나
+        # 포트가 없어 '{{ item.symbol }}' 같은 리터럴이 그대로 넘어온 경우다.
+        # 여기서 막지 않으면 매도 시장가·sizing price>0 분기에서 이 원문이 실제
+        # 브로커 주문(IsuNo)으로 나갈 수 있다.
+        if (isinstance(symbol, str) and "{{" in symbol) or (
+            isinstance(exchange, str) and "{{" in exchange
+        ):
+            if context is not None:
+                context.log(
+                    "error",
+                    f"주문 심볼/거래소가 미해석 템플릿입니다 — 주문을 만들지 않습니다 "
+                    f"(unresolved_template_symbol: symbol={symbol!r}, exchange={exchange!r})",
+                    node_id,
+                )
+            else:
+                logger.error(
+                    "_normalize_order: unresolved_template_symbol "
+                    "(symbol=%r, exchange=%r) — refusing to build order",
+                    symbol, exchange,
+                )
+            return None
         try:
             raw_quantity = float(order_raw.get("quantity", 0))
         except (ValueError, TypeError):
@@ -15838,6 +15866,31 @@ class NewOrderNodeExecutor(NodeExecutorBase):
         은 ``order_result.diagnostics`` 로 추가 동봉한다. AI 챗봇 소비자는
         ``diagnostics`` 로 자가수정/안내를 결정적으로 분기할 수 있다.
         """
+        diagnostics = reject_info.model_dump() if reject_info else None
+
+        # C23 방어선: 미해석 템플릿이 결과의 symbol/exchange 자리를 차지하면 안 된다.
+        # _normalize_order 가 이미 그런 주문 자체를 만들지 않지만, 그래도 실패 결과를
+        # 남기는 경로(예: 현재가 조회 실패)가 템플릿 값으로 _order_result 를 부르면
+        # 여기서 symbol/exchange 를 None 으로 비우고, error 코드를 고정하며, 원문은
+        # diagnostics 에 보존한다 — 원장/서버가 심볼 자리에 '{{ ... }}' 를 절대 받지
+        # 않게(prod 실측 order_fills id=17 재발 차단).
+        if (isinstance(symbol, str) and "{{" in symbol) or (
+            isinstance(exchange, str) and "{{" in exchange
+        ):
+            template_diag = {
+                "unresolved_template": True,
+                "raw_symbol": symbol,
+                "raw_exchange": exchange,
+            }
+            diagnostics = (
+                {**diagnostics, **template_diag}
+                if isinstance(diagnostics, dict) else template_diag
+            )
+            error = "unresolved_template_symbol"
+            success = False
+            symbol = None
+            exchange = None
+
         return {
             "order_result": {
                 "success": success,
@@ -15848,7 +15901,7 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                 "price": price,
                 "status": "submitted" if success else "failed",
                 "error": error,
-                "diagnostics": reject_info.model_dump() if reject_info else None,
+                "diagnostics": diagnostics,
             },
             "order_id": order_id,
         }

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.35.1"
+version = "1.36.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
@@ -29,11 +29,14 @@ lxml = "^6.0.2"
 pytickersymbols = {version = ">=1.17.5", python = ">=3.12,<4.0"}
 aiosqlite = "^0.20.0"
 litellm = ">=1.40.0"
-# 🔴 core 하한은 1.26.0 이어야 한다 — context.py 가 event_data 에 personal_metrics 를
-# 무조건 실어 WorkflowPnLEvent(**event_data) 를 만드는데, 그 필드는 core 1.26.0 에서
-# 추가됐다. 하한을 낮게 두면 core 1.25.x 로 해석된 환경에서 생성이 TypeError 로 죽고,
-# 그 예외가 바로 위 except Exception 에 삼켜져 **PnL 이벤트가 통째로 조용히 멈춘다.**
-programgarden-core = "^1.27.0"
+# 🔴 core 하한은 1.28.0 이어야 한다 — 이 엔진은 import 시점에 context.py 가
+# `from programgarden_core.bases.listener import OrderFillEvent` 를 eager import
+# 한다(C24). OrderFillEvent 는 core 1.28.0 에서 신설됐으므로, 하한을 낮게 두면
+# 구 core(≤1.27.0)로 resolve 된 환경에서 `import programgarden` 자체가 ImportError
+# 로 통째 실패한다(1.35.1 의 조용한 TypeError 보다 강한 모듈 로드 실패).
+# (1.26.0 이후로도 context.py 는 WorkflowPnLEvent(**event_data) 에 personal_metrics
+#  를 무조건 실으므로 그 하한 근거도 이 상한에 포함된다.)
+programgarden-core = "^1.28.0"
 programgarden-finance = "^1.9.5"
 programgarden-community = "^1.15.0"
 

--- a/src/programgarden/tests/test_order_fill_events.py
+++ b/src/programgarden/tests/test_order_fill_events.py
@@ -1,0 +1,221 @@
+"""C24: 체결 확정 이벤트(on_order_fill) 발화 검증.
+
+원장에 체결이 새로 확정될 때마다 ExecutionListener.on_order_fill 이 정확히 1회
+발화하는지 확인한다 — 즉시(주문과 매칭) 경로와 pending→timeout(주문 미매칭)
+경로 모두. 리스너가 없어도 무해해야 한다.
+"""
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.database.workflow_position_tracker import WorkflowPositionTracker
+from programgarden_core.bases.listener import BaseExecutionListener, OrderFillEvent
+
+
+class _RecordingListener(BaseExecutionListener):
+    """on_order_fill 이벤트를 수집하는 리스너."""
+
+    def __init__(self):
+        super().__init__()
+        self.fills = []
+
+    async def on_order_fill(self, event: OrderFillEvent) -> None:
+        self.fills.append(event)
+
+
+def _make_context_with_tracker(tmp_path, product="overseas_stock", provider="ls",
+                               trading_mode="live", buffer_timeout=None):
+    """실제 tracker 를 임시 DB 로 만들고 콜백을 연결한 컨텍스트 반환."""
+    db_path = str(tmp_path / f"{product}_{trading_mode}_workflow.db")
+    tracker = WorkflowPositionTracker(
+        db_path=db_path,
+        job_id="job-c24",
+        broker_node_id="broker-1",
+        product=product,
+        provider=provider,
+        trading_mode=trading_mode,
+    )
+    if buffer_timeout is not None:
+        tracker.FILL_BUFFER_TIMEOUT = buffer_timeout
+
+    ctx = ExecutionContext(job_id="job-c24", workflow_id="wf-c24")
+    ctx._workflow_position_tracker = tracker
+    ctx._workflow_product = product
+    ctx._workflow_broker_node_id = "broker-1"
+    # PnL refresh 는 이 테스트의 관심사가 아니므로 우회 (on_order_fill 은 독립 경로).
+    ctx.notify_workflow_pnl = AsyncMock()
+    tracker.set_fill_classified_callback(ctx._on_tracker_fill_classified)
+    return ctx, tracker
+
+
+class TestImmediateWorkflowFill:
+    @pytest.mark.asyncio
+    async def test_matched_fill_emits_once_with_identity(self, tmp_path):
+        ctx, tracker = _make_context_with_tracker(tmp_path)
+        listener = _RecordingListener()
+        ctx.add_listener(listener)
+
+        # 우리 주문을 먼저 기록 → 체결이 즉시 workflow 로 분류된다.
+        tracker.record_order(
+            order_no="123", order_date="20260912", symbol="AAPL",
+            exchange="NASDAQ", side="buy", quantity=10, price=190.0,
+            job_id="job-c24", node_id="order_node_1",
+        )
+
+        result = await ctx.record_workflow_fill(
+            order_no="123", order_date="20260912", symbol="AAPL",
+            exchange="NASDAQ", side="buy", quantity=10, price=190.0,
+            fill_time="093000000", commda_code="40",
+        )
+
+        assert result == "workflow"
+        assert len(listener.fills) == 1
+        ev = listener.fills[0]
+        assert ev.classification == "workflow"
+        assert ev.node_id == "order_node_1"
+        assert ev.job_id == "job-c24"
+        assert ev.order_no == "123"
+        assert ev.order_date == "20260912"
+        assert ev.symbol == "AAPL"
+        assert ev.exchange == "NASDAQ"
+        assert ev.side == "buy"
+        assert ev.quantity == 10
+        assert ev.price == 190.0
+        assert ev.product == "overseas_stock"
+        assert ev.provider == "ls"
+        assert ev.trading_mode == "live"
+        assert ev.commda_code == "40"
+        assert ev.fill_time == "093000000"
+        # facts only — 금액/수익 계산 필드는 존재하지 않는다.
+        assert not hasattr(ev, "pnl_amount")
+
+    @pytest.mark.asyncio
+    async def test_manual_human_media_fill_has_no_node_id(self, tmp_path):
+        ctx, tracker = _make_context_with_tracker(tmp_path)
+        listener = _RecordingListener()
+        ctx.add_listener(listener)
+
+        # 주문 미기록 + HTS(85) 매체코드 → manual 로 즉시 분류(버퍼 없음).
+        result = await ctx.record_workflow_fill(
+            order_no="777", order_date="20260912", symbol="MSFT",
+            exchange="NASDAQ", side="buy", quantity=3, price=400.0,
+            fill_time="100000000", commda_code="85",
+        )
+
+        assert result == "manual"
+        assert len(listener.fills) == 1
+        ev = listener.fills[0]
+        assert ev.classification == "manual"
+        assert ev.node_id is None
+
+
+class TestPendingTimeoutFill:
+    @pytest.mark.asyncio
+    async def test_pending_resolves_to_unknown_api_and_emits(self, tmp_path):
+        # 짧은 버퍼로 timeout 경로를 빠르게 확정.
+        ctx, tracker = _make_context_with_tracker(tmp_path, buffer_timeout=0.05)
+        listener = _RecordingListener()
+        ctx.add_listener(listener)
+
+        # 주문 미기록 + API(40) 매체코드 → 버퍼링(pending) 후 timeout 확정.
+        result = await ctx.record_workflow_fill(
+            order_no="999", order_date="20260912", symbol="TSLA",
+            exchange="NASDAQ", side="buy", quantity=1, price=200.0,
+            fill_time="093000000", commda_code="40",
+        )
+        assert result == "pending"
+        # pending 시점엔 아직 발화 전.
+        assert listener.fills == []
+
+        await asyncio.sleep(0.05 + 0.25)
+
+        assert len(listener.fills) == 1
+        ev = listener.fills[0]
+        assert ev.classification == "unknown_api"
+        assert ev.node_id is None
+        assert ev.symbol == "TSLA"
+        assert ev.order_no == "999"
+
+    @pytest.mark.asyncio
+    async def test_pending_resolves_to_workflow_when_order_arrives(self, tmp_path):
+        ctx, tracker = _make_context_with_tracker(tmp_path, buffer_timeout=0.05)
+        listener = _RecordingListener()
+        ctx.add_listener(listener)
+
+        result = await ctx.record_workflow_fill(
+            order_no="555", order_date="20260912", symbol="NVDA",
+            exchange="NASDAQ", side="buy", quantity=2, price=120.0,
+            fill_time="093000000", commda_code="40",
+        )
+        assert result == "pending"
+        assert listener.fills == []
+
+        await asyncio.sleep(0.05 + 0.25)
+
+        assert len(listener.fills) == 1
+        ev = listener.fills[0]
+        # 버퍼 동안 주문이 안 왔으므로 unknown_api 로 확정(node_id None).
+        assert ev.classification == "unknown_api"
+        assert ev.node_id is None
+
+
+class TestNoListenerHarmless:
+    @pytest.mark.asyncio
+    async def test_fill_without_listeners_does_not_raise(self, tmp_path):
+        ctx, tracker = _make_context_with_tracker(tmp_path)
+        # 리스너 없음.
+        assert ctx._listeners == []
+
+        tracker.record_order(
+            order_no="1", order_date="20260912", symbol="AAPL",
+            exchange="NASDAQ", side="buy", quantity=1, price=1.0,
+            job_id="job-c24", node_id="n1",
+        )
+        result = await ctx.record_workflow_fill(
+            order_no="1", order_date="20260912", symbol="AAPL",
+            exchange="NASDAQ", side="buy", quantity=1, price=1.0,
+            fill_time="093000000", commda_code="40",
+        )
+        assert result == "workflow"
+
+    @pytest.mark.asyncio
+    async def test_tracker_without_callback_still_records(self, tmp_path):
+        # 콜백을 연결하지 않은 독립 tracker(서버/컨텍스트 밖 사용)도 무해.
+        db_path = str(tmp_path / "standalone_workflow.db")
+        tracker = WorkflowPositionTracker(
+            db_path=db_path, job_id="j", broker_node_id="b",
+            product="overseas_stock", provider="ls", trading_mode="live",
+        )
+        tracker.record_order(
+            order_no="42", order_date="20260912", symbol="AAPL",
+            exchange="NASDAQ", side="buy", quantity=1, price=10.0,
+            job_id="j", node_id="n",
+        )
+        result = await tracker.record_fill(
+            order_no="42", order_date="20260912", symbol="AAPL",
+            exchange="NASDAQ", side="buy", quantity=1, price=10.0,
+            fill_time="093000000", commda_code="40",
+        )
+        assert result == "workflow"
+
+
+class TestOrderIdentityLookup:
+    def test_lookup_matches_normalized_order_no(self, tmp_path):
+        db_path = str(tmp_path / "lookup_workflow.db")
+        tracker = WorkflowPositionTracker(
+            db_path=db_path, job_id="jid", broker_node_id="b",
+            product="overseas_stock", provider="ls", trading_mode="live",
+        )
+        tracker.record_order(
+            order_no="0000123", order_date="20260912", symbol="AAPL",
+            exchange="NASDAQ", side="buy", quantity=1, price=10.0,
+            job_id="jid", node_id="node-x",
+        )
+        # 정확 일치
+        assert tracker.lookup_order_identity("0000123", "20260912") == ("jid", "node-x")
+        # 정규화(zero-strip) 일치
+        assert tracker.lookup_order_identity("123", "20260912") == ("jid", "node-x")
+        # 없는 주문
+        assert tracker.lookup_order_identity("999", "20260912") is None

--- a/src/programgarden/tests/test_order_fill_events.py
+++ b/src/programgarden/tests/test_order_fill_events.py
@@ -140,10 +140,13 @@ class TestPendingTimeoutFill:
 
     @pytest.mark.asyncio
     async def test_pending_resolves_to_workflow_when_order_arrives(self, tmp_path):
-        ctx, tracker = _make_context_with_tracker(tmp_path, buffer_timeout=0.05)
+        # 체결이 주문보다 먼저 도착해 버퍼링된 뒤, timeout 전에 우리 주문이 도착하면
+        # _process_buffered_fill 이 workflow 로 확정하고 on_order_fill 을 1회 발화한다.
+        ctx, tracker = _make_context_with_tracker(tmp_path, buffer_timeout=0.3)
         listener = _RecordingListener()
         ctx.add_listener(listener)
 
+        # 1) 체결 먼저 → 버퍼링(pending).
         result = await ctx.record_workflow_fill(
             order_no="555", order_date="20260912", symbol="NVDA",
             exchange="NASDAQ", side="buy", quantity=2, price=120.0,
@@ -152,13 +155,26 @@ class TestPendingTimeoutFill:
         assert result == "pending"
         assert listener.fills == []
 
-        await asyncio.sleep(0.05 + 0.25)
+        # 2) 버퍼 동안 우리 주문이 도착 → 버퍼된 체결이 workflow 로 확정.
+        tracker.record_order(
+            order_no="555", order_date="20260912", symbol="NVDA",
+            exchange="NASDAQ", side="buy", quantity=2, price=120.0,
+            job_id="job-c24", node_id="order_node_arr",
+        )
+        # record_order 가 스케줄한 _process_buffered_fill task 가 돌 시간을 준다
+        # (timeout 0.3 보다 충분히 짧다).
+        await asyncio.sleep(0.15)
 
         assert len(listener.fills) == 1
         ev = listener.fills[0]
-        # 버퍼 동안 주문이 안 왔으므로 unknown_api 로 확정(node_id None).
-        assert ev.classification == "unknown_api"
-        assert ev.node_id is None
+        assert ev.classification == "workflow"
+        assert ev.node_id == "order_node_arr"
+        assert ev.order_no == "555"
+        assert ev.symbol == "NVDA"
+
+        # timeout task 를 깨끗이 소진(키는 이미 제거됨 → no-op, 재발화 없음).
+        await asyncio.sleep(0.3)
+        assert len(listener.fills) == 1
 
 
 class TestNoListenerHarmless:
@@ -199,6 +215,40 @@ class TestNoListenerHarmless:
             fill_time="093000000", commda_code="40",
         )
         assert result == "workflow"
+
+
+class TestReplayIdempotency:
+    @pytest.mark.asyncio
+    async def test_same_execution_id_replay_does_not_reemit(self, tmp_path):
+        """동일 execution_id 재도착(at-least-once 재전송)은 원장을 바꾸지 않고
+        on_order_fill 도 재발화하지 않는다 — 정확히 1회 유지."""
+        ctx, tracker = _make_context_with_tracker(tmp_path)
+        listener = _RecordingListener()
+        ctx.add_listener(listener)
+
+        tracker.record_order(
+            order_no="321", order_date="20260912", symbol="AMD",
+            exchange="NASDAQ", side="buy", quantity=5, price=100.0,
+            job_id="job-c24", node_id="node-replay",
+        )
+        first = await ctx.record_workflow_fill(
+            order_no="321", order_date="20260912", symbol="AMD",
+            exchange="NASDAQ", side="buy", quantity=5, price=100.0,
+            fill_time="093000000", commda_code="40", execution_id="EXEC-1",
+        )
+        assert first == "workflow"
+        assert len(listener.fills) == 1
+        assert listener.fills[0].node_id == "node-replay"
+        assert listener.fills[0].execution_id == "EXEC-1"
+
+        # 같은 execution_id 로 재도착 → 스토어드 분류만 돌려주고 재발화 없음.
+        again = await ctx.record_workflow_fill(
+            order_no="321", order_date="20260912", symbol="AMD",
+            exchange="NASDAQ", side="buy", quantity=5, price=100.0,
+            fill_time="093000000", commda_code="40", execution_id="EXEC-1",
+        )
+        assert again == "workflow"
+        assert len(listener.fills) == 1  # 여전히 1회 — 리플레이는 미발화
 
 
 class TestOrderIdentityLookup:

--- a/src/programgarden/tests/test_order_template_symbol_guard.py
+++ b/src/programgarden/tests/test_order_template_symbol_guard.py
@@ -1,0 +1,122 @@
+"""C23: 미해석 템플릿 심볼 차단 + 결과 오염 방지.
+
+상류 바인딩이 풀리지 않아 order.symbol 이 '{{ item.symbol }}' 리터럴로 넘어오면:
+  1) _normalize_order 가 주문 자체를 만들지 않는다(None) — 브로커로 안 나간다.
+  2) 그래도 _order_result 를 부르는 실패 경로는 symbol/exchange 를 None 으로 비우고
+     error='unresolved_template_symbol', diagnostics 에 원문을 남긴다.
+prod 실측 order_fills id=17(symbol='{{ item.symbol }}') 재발 차단.
+"""
+from unittest.mock import AsyncMock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import NewOrderNodeExecutor
+
+
+def _executor() -> NewOrderNodeExecutor:
+    return NewOrderNodeExecutor.__new__(NewOrderNodeExecutor)
+
+
+class TestNormalizeOrderTemplateGuard:
+    def test_template_symbol_returns_none(self):
+        out = _executor()._normalize_order(
+            {"symbol": "{{ item.symbol }}", "exchange": "NASDAQ",
+             "quantity": 1, "price": 10.0}, {},
+        )
+        assert out is None
+
+    def test_template_exchange_returns_none(self):
+        out = _executor()._normalize_order(
+            {"symbol": "AAPL", "exchange": "{{ item.exchange }}",
+             "quantity": 1, "price": 10.0}, {},
+        )
+        assert out is None
+
+    def test_valid_symbol_still_normalizes(self):
+        out = _executor()._normalize_order(
+            {"symbol": "AAPL", "exchange": "NASDAQ", "quantity": 1, "price": 10.0}, {},
+        )
+        assert out is not None
+        assert out["symbol"] == "AAPL"
+
+    def test_template_symbol_logs_error_reason(self):
+        ctx = ExecutionContext(job_id="j", workflow_id="w")
+        out = _executor()._normalize_order(
+            {"symbol": "{{ item.symbol }}", "exchange": "NASDAQ",
+             "quantity": 1, "price": 10.0}, {}, ctx, "order_node",
+        )
+        assert out is None
+        error_logs = [l for l in ctx.get_logs() if l["level"] == "error"]
+        assert any("unresolved_template_symbol" in l["message"] for l in error_logs)
+
+
+class TestOrderResultTemplateGuard:
+    def test_template_symbol_nulled_with_error_code(self):
+        # 현재가 조회 실패 경로가 템플릿 심볼로 _order_result 를 부르는 상황 재현.
+        result = _executor()._order_result(
+            False, "{{ item.symbol }}", "NASDAQ", "buy", 1, 0, "현재가 조회 실패",
+        )
+        inner = result["order_result"]
+        assert inner["symbol"] is None
+        assert inner["error"] == "unresolved_template_symbol"
+        assert inner["success"] is False
+        assert inner["status"] == "failed"
+        assert inner["diagnostics"]["unresolved_template"] is True
+        assert inner["diagnostics"]["raw_symbol"] == "{{ item.symbol }}"
+
+    def test_template_exchange_nulled(self):
+        result = _executor()._order_result(
+            True, "AAPL", "{{ item.exchange }}", "sell", 2, 100.0, None, "ord-9",
+        )
+        inner = result["order_result"]
+        assert inner["symbol"] is None
+        assert inner["exchange"] is None
+        assert inner["error"] == "unresolved_template_symbol"
+        assert inner["diagnostics"]["raw_exchange"] == "{{ item.exchange }}"
+
+    def test_normal_result_unchanged(self):
+        result = _executor()._order_result(
+            True, "AAPL", "NASDAQ", "buy", 1, 190.0, None, "ord-1",
+        )
+        inner = result["order_result"]
+        assert inner["symbol"] == "AAPL"
+        assert inner["exchange"] == "NASDAQ"
+        assert inner["success"] is True
+        assert inner["status"] == "submitted"
+        assert inner["diagnostics"] is None
+
+
+class TestBrokerNotCalledOnTemplateSymbol:
+    @pytest.mark.asyncio
+    async def test_execute_order_never_dispatches_to_broker(self):
+        ex = _executor()
+        # 세 상품 주문 경로를 스파이 — 하나라도 불리면 실패.
+        ex._execute_overseas_stock = AsyncMock()
+        ex._execute_korea_stock = AsyncMock()
+        ex._execute_overseas_futures = AsyncMock()
+
+        ctx = ExecutionContext(job_id="j", workflow_id="w")
+        config = {
+            "connection": {
+                "appkey": "x", "appsecret": "y", "product": "overseas_stock",
+            },
+            "order": {
+                "symbol": "{{ item.symbol }}", "exchange": "NASDAQ",
+                "quantity": 1, "price": 10.0,
+            },
+            "side": "buy",
+            "order_type": "limit",
+        }
+
+        result = await ex._execute_order("node1", "StockNewOrderNode", config, ctx)
+
+        # 브로커 주문 메서드 0회 호출.
+        ex._execute_overseas_stock.assert_not_awaited()
+        ex._execute_korea_stock.assert_not_awaited()
+        ex._execute_overseas_futures.assert_not_awaited()
+
+        # 결과는 성공이 아니며, 로그에 unresolved_template_symbol 사유가 남는다.
+        assert result["order_result"]["success"] is False
+        error_logs = [l for l in ctx.get_logs() if l["level"] == "error"]
+        assert any("unresolved_template_symbol" in l["message"] for l in error_logs)


### PR DESCRIPTION
- C23: _normalize_order 가 \"{{\" 심볼/거래소를 거부(브로커로 절대 안 나감) + 실패 결과에 템플릿 원문 대신 error=unresolved_template_symbol(원문은 diagnostics).
- C24: core OrderFillEvent + ExecutionListener.on_order_fill(기본 no-op); record_workflow_fill 이 원장 확정 후 _buffer_lock 밖에서 정확히 1회 발화(pending→timeout 포함). AS1/SC1/TC3 공통.
- 릴리스: core 1.28.0 → engine 1.36.0 순서 발행 필수(eager import). 적대 리뷰 반영. 전체 1529 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jgvXMHMiFPHPEsadb6ydr