### PR TITLE
release: 1.37.0 — 브로커 필드 사실 반영, 체결 분류·체결번호·체결시각·정정·소수점 결함 수정

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "programgarden"
-version = "1.34.0"
+version = "1.37.0"
 description = "LS증권 API을 메인으로 제작된 노코딩 시스템 트레이딩 DSL 오픈소스"
 authors = [
     {name = "장용준",email = "coding@programgarden.com"}

--- a/src/community/CHANGELOG.md
+++ b/src/community/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [1.15.2] - 2026-09-12
+### Fixed
+- **포지션 값 강제(coercion) 전수 정리** — 12개 플러그인(beta_hedge / correlation_guard / drawdown_protection /
+  dynamic_stop_loss / max_position_limit / partial_take_profit / profit_target / roll_management / stop_loss /
+  time_based_exit / trailing_stop / var_cvar_monitor)이 `pos_data` 의 `current_price`·`qty`·`pnl_rate` 등
+  원값을 강제 없이 산술·비교에 넣어 문자열/None 이면 예외로 죽거나(예: `'150.0' * 100` → 문자열 반복 뒤
+  `float()` ValueError) 0 으로 뭉개던 결함. 공용 헬퍼 `_position_qty.py`(`coerce_qty`/`coerce_number`/
+  `preserve_qty`)로 연산 전에 읽고, 못 읽으면 값을 지어내지 않고 `action='skip'` + 사유(필드·원값)를 남긴다.
+  디렉토리에서 플러그인을 자동 발견하는 파라미터화 회귀 테스트 추가.
+- **절반 축소 수량** — `drawdown_protection`·`var_cvar_monitor` 의 `max(1, int(qty)//2)` 가 소수점 포지션에서
+  보유 초과 매도(0.532 보유 → 1주)를, 1주 포지션에서 전량 매도를 내던 결함. `min(qty/2, qty)`, 바닥올림 제거.
+  1주/소수 보유에서 절반 축소가 주문 송신부의 정수 내림으로 무동작이 되는 경우 사유를 남긴다(정책 선택은 후속).
+- `trailing_stop` 이 보존된 Decimal 수량을 다시 `int()` 로 자르던 결함, `profit_target` 의 소수 포지션 부분
+  익절이 사유 없이 건너뛰어지던 결함, `var_cvar_monitor` 의 `var_dollar`/`position_value` 가 소수 포지션에서
+  0 으로 접히던 결함 수정.
+- `partial_take_profit` 상태 저장·복원 경로는 **라이브에서 동작하지 않는다**(실제 `WorkflowRiskTracker` 에
+  `get_state`/`set_state` 없음, executor 가 positions 플러그인에 context 를 넘기지 않음) — 코드는 바꾸지 않고
+  주석·테스트가 사실(목 계약 검증)을 말하도록 정정. 근본 수정은 후속.
+
 ## [1.15.0] - 2026-08-15
 ### Changed
 - **StopLoss/ProfitTarget 임계값 부호 검증** (`stop_loss`, `profit_target`,

--- a/src/community/programgarden_community/plugins/_position_qty.py
+++ b/src/community/programgarden_community/plugins/_position_qty.py
@@ -1,0 +1,159 @@
+"""
+Shared position-quantity helpers for the position/risk plugins (stdlib only).
+
+Leading-underscore module name → not a plugin package; ``register_all_plugins``
+imports concrete ``<name>/__init__.py`` packages by an explicit list, so this
+module is never registered as a plugin (same convention as ``_ta_common.py``).
+
+왜 공용인가
+----------
+청산·축소 수량을 만드는 플러그인들이 **같은 식을 각자 복사**해 갖고 있었고, 그
+식이 동시에 두 가지로 깨졌다:
+
+1. ``int(qty)`` 절단 — LS 는 해외주식 소수점 주식을 지원한다(출처: 오너 진술
+   2026-09-12). 0.532주 포지션에서 ``int(0.532) = 0`` 이라 수량이 0 으로 접히고,
+   포지션 금액(``current_price * int(qty)``)도 0.0 으로 보고된다.
+2. 바닥 올림 ``max(1, ...)`` — 0 으로 접힌 값을 1 로 되살려 **보유량을 초과하는
+   1주 매도**를 실어 보낸다(0.532 보유 → 1주 매도).
+
+그래서 절단·바닥올림을 없앤 계산을 여기 한 곳에 두고, 각 플러그인은 이 함수만
+쓴다.
+
+정수화는 여기서 하지 않는다
+--------------------------
+브로커 송신부 ``NewOrderNodeExecutor._normalize_order``
+(``programgarden/executor.py``) 가 이미 명시적 규약을 갖고 있다: 정수부만
+주문하고 잘린 잔량을 ``fractional_remainder`` 로 결과에 남기며, 정수부가 0 인
+소수-only 주문은 ``EmptyOrderReason.FRACTIONAL_ONLY`` 로 사유를 밝힌다.
+플러그인이 먼저 잘라 버리면 그 진단이 통째로 사라지므로 원값을 넘긴다.
+
+Decimal 을 그대로 싣지 않는 이유는 ``passed_symbols`` 가 JSON 직렬화/템플릿
+바인딩을 거치기 때문이다. 정수로 떨어지는 값은 ``int`` 로 돌려 직렬화 모양을
+유지한다.
+
+No-silent-failure 규약
+---------------------
+'값이 0' 과 '값을 못 읽음' 을 구분한다. 못 읽으면 ``None`` 을 돌려주고, 호출부는
+수량을 지어내는 대신 **왜 못 실었는지**를 결과에 남긴다
+("안 보낸 필드는 안 보냈다고 표시" 규약).
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import Decimal
+from typing import Any, Optional, Union
+
+Qty = Union[int, float]
+
+__all__ = [
+    "Qty",
+    "coerce_qty",
+    "coerce_number",
+    "preserve_qty",
+    "half_position_qty",
+    "partial_sell_qty",
+    "below_broker_lot",
+]
+
+
+def coerce_qty(value: Any) -> Optional[float]:
+    """수량/비율 값을 유한 float 로 읽는다. 읽을 수 없으면 ``None`` ('0' 과 구분).
+
+    ``Decimal`` 을 따로 받는 이유: HWM 트래커의 ``position_qty`` 와 strategy_state
+    복원값이 ``Decimal`` 이고(``workflow_risk_tracker._to_qty_decimal`` /
+    ``_deserialize_state_value``), ``Decimal * float`` 는 ``TypeError`` 다.
+    """
+    if isinstance(value, Decimal):
+        return float(value) if value.is_finite() else None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return f if math.isfinite(f) else None
+
+
+def coerce_number(value: Any) -> Optional[float]:
+    """가격·수익률·금액 등 **수량이 아닌** 숫자 필드를 유한 float 로 읽는다. 못 읽으면 ``None``.
+
+    규약은 ``coerce_qty`` 와 같다(Decimal 허용, NaN/inf/문자열 쓰레기/None → ``None``,
+    '0' 과 '못 읽음' 을 구분). 이름을 따로 두는 이유는 호출부에서 '이 값은 수량이
+    아니라 가격/비율' 임을 드러내기 위해서다 — 수량 규약(절단 금지·정수화는 송신부)이
+    가격에까지 적용되는 것으로 오독되지 않게 한다.
+
+    숫자 문자열('150.0')은 그 숫자로 읽는다. 문자열 원값을 그대로 곱셈에 넣으면
+    ``'150.0' * 100`` 이 문자열 반복이 되어 뒤따르는 ``float()`` 에서 ValueError 로
+    죽는다 — 정상값으로도 죽는 경로였다(max_position_limit, 관측 2026-09-12).
+    """
+    return coerce_qty(value)
+
+
+def preserve_qty(value: Any) -> Optional[Qty]:
+    """수량을 절단 없이 정규화한다 — 정수면 ``int``, 소수면 ``float``, 못 읽으면 ``None``.
+
+    부호·0 은 거르지 않는다(그건 호출부의 도메인 판단이다).
+    """
+    f = coerce_qty(value)
+    if f is None:
+        return None
+    return int(f) if f.is_integer() else f
+
+
+def half_position_qty(value: Any) -> Optional[Qty]:
+    """보유 수량의 **절반**을 절단·바닥올림 없이 계산한다. 읽을 수 없거나 0 이하면 ``None``.
+
+    구 코드는 ``max(1, int(qty) // 2)`` 였다. 0.532주 보유에서
+    ``int(0.532) // 2 = 0`` → ``max(1, 0) = 1`` 이라 보유량을 초과한 1주 매도가
+    나갔고, 1주 보유에서도 1 이 나와 '절반 축소' 가 사실상 전량 매도가 됐다.
+
+    상한은 ``min(half, qty)`` 로 명시해 어떤 입력에서도 보유량을 넘지 않게 한다.
+    """
+    qty = coerce_qty(value)
+    if qty is None or qty <= 0:
+        return None
+    half = min(qty / 2, qty)  # 상한: 보유량 초과 금지
+    return int(half) if half.is_integer() else half
+
+
+def partial_sell_qty(
+    original_qty: Any, sell_pct: Any, held_qty: Any
+) -> Optional[Qty]:
+    """부분 익절 수량(기준 수량 × 비율, 보유량 상한)을 절단 없이 계산한다.
+
+    읽을 수 없으면 ``None``, 계산 결과가 0 이하면 ``0`` — 둘은 다른 사건이다.
+
+    구 코드는 ``int(original_qty * sell_pct / 100)`` 이라 소수 포지션에서 수량이
+    0 으로 잘렸고(0.532주 × 50% = 0.266 → 0), 그 값이 ``if sell_quantity > 0``
+    게이트에 걸려 단계가 통째로 건너뛰어졌다.
+    """
+    base = coerce_qty(original_qty)
+    pct = coerce_qty(sell_pct)
+    held = coerce_qty(held_qty)
+    if base is None or pct is None or held is None:
+        return None
+
+    qty = min(base * pct / 100, held)  # 보유량 초과 방지
+    if qty <= 0:
+        return 0
+    return int(qty) if float(qty).is_integer() else qty
+
+
+def below_broker_lot(value: Any) -> bool:
+    """이 수량이 **주문으로 이어지지 못하는** 구간(0 < qty < 1)인가.
+
+    주문 송신부 ``NewOrderNodeExecutor._normalize_order``
+    (``programgarden/executor.py``) 는 ``quantity = int(raw_quantity)`` 로 정수부만
+    주문하고, 정수부가 0 이면 ``return None`` 으로 **주문 자체를 만들지 않는다**
+    (관측: executor.py 의 해당 블록 — ``if quantity <= 0: ... return None``,
+    2026-09-12). 즉 0 < qty < 1 인 수량은 조용히 아무 일도 일으키지 않는다.
+
+    이 함수는 그 사실을 **판정만** 한다 — 수량을 바꾸거나 올림하지 않는다. 호출부는
+    이 값이 True 일 때 결과에 사유를 남겨 '조용한 무동작' 을 드러낸다.
+
+    읽을 수 없는 값(``None``)은 여기서 False 다 — 그건 별개의 사건이고 호출부가
+    이미 '수량을 못 읽었다' 사유로 따로 보고한다.
+    """
+    f = coerce_qty(value)
+    if f is None:
+        return False
+    return 0 < f < 1

--- a/src/community/programgarden_community/plugins/beta_hedge/__init__.py
+++ b/src/community/programgarden_community/plugins/beta_hedge/__init__.py
@@ -16,6 +16,8 @@ from typing import List, Dict, Any, Optional, Set
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
+from .._position_qty import coerce_qty
+
 
 # risk_features 선언
 risk_features: Set[str] = {"state", "events"}
@@ -86,8 +88,10 @@ BETA_HEDGE_SCHEMA = PluginSchema(
     tags=["beta", "hedge", "market_neutral", "risk_management"],
     output_fields={
         "beta": {"type": "float", "description": "Calculated beta of this symbol relative to the market benchmark"},
-        "beta_contribution": {"type": "float", "description": "This symbol's contribution to portfolio beta"},
-        "weight": {"type": "float", "description": "Position market value (available when positions are provided)"},
+        "beta_contribution": {"type": "float", "description": "This symbol's contribution to portfolio beta (beta x position market value when positions are provided, otherwise the equal-weight share)"},
+        "beta_contribution_unavailable_reason": {"type": "str", "description": "Present instead of beta_contribution when the held quantity or current price could not be read (same values weight depends on)"},
+        "weight": {"type": "float", "description": "Position market value (available when positions are provided; fractional share counts are kept, not truncated)"},
+        "weight_unavailable_reason": {"type": "str", "description": "Present instead of weight when the held quantity or current price could not be read"},
     },
     locales={
         "ko": {
@@ -267,27 +271,55 @@ async def beta_hedge_condition(
         }
 
     # 포트폴리오 베타 계산
+    portfolio_beta: Optional[float] = None
+    portfolio_beta_unavailable_reason: Optional[str] = None
     if position_map:
-        total_value = 0
-        weighted_beta = 0
+        total_value = 0.0
+        weighted_beta = 0.0
+        unreadable_symbols: List[str] = []
         for bd in beta_data:
             sym = bd["symbol"]
             if sym in position_map:
                 pos = position_map[sym]
-                qty = int(pos.get("qty", pos.get("quantity", 0)))
-                pos_value = float(pos.get("current_price", 0)) * qty
+                # 수량/가격을 int()·float() 로 직접 자르지 않는다 — int(0.532)=0 이라
+                # 소수점 주식 포지션이 가중치 0 으로 빠져 포트폴리오 베타를 왜곡했고,
+                # 문자열 쓰레기 값에는 ValueError 로 죽었다. 공용 헬퍼는 못 읽으면
+                # None 을 준다(_position_qty.coerce_qty).
+                qty = coerce_qty(pos.get("qty", pos.get("quantity", 0)))
+                price = coerce_qty(pos.get("current_price", 0))
+                if qty is None or price is None:
+                    unreadable_symbols.append(sym)
+                    continue  # 읽을 수 없는 포지션은 가중치에서 제외(0 으로 뭉개지 않음)
+                pos_value = price * qty
                 weighted_beta += bd["beta"] * pos_value
                 total_value += pos_value
-        portfolio_beta = weighted_beta / total_value if total_value > 0 else 0
+        if total_value > 0:
+            portfolio_beta = round(weighted_beta / total_value, 4)
+        else:
+            # 가중평균의 분모가 0 이다 — '베타가 0' 이 아니라 **값이 없다**.
+            # 구 코드는 여기서 0 을 지어냈고, 그 0 이 그대로 beta_deviation 을 지나
+            # hedge_needed=True 라는 거짓 신호(target_beta 와의 거리)까지 만들었다.
+            # 심볼 수준 weight 와 같은 규약으로 값을 싣지 않고 사유를 남긴다.
+            portfolio_beta_unavailable_reason = (
+                "포지션 가중 포트폴리오 베타를 계산할 수 없음 — 가중치 합(총 포지션 금액)이 0"
+            )
+            if unreadable_symbols:
+                portfolio_beta_unavailable_reason += (
+                    f" (수량/가격을 읽을 수 없는 종목: {', '.join(unreadable_symbols)})"
+                )
     else:
         # 동일 비중 가정
-        portfolio_beta = sum(bd["beta"] for bd in beta_data) / len(beta_data)
-
-    portfolio_beta = round(portfolio_beta, 4)
+        portfolio_beta = round(sum(bd["beta"] for bd in beta_data) / len(beta_data), 4)
 
     # 헷지 필요 여부
-    beta_deviation = portfolio_beta - target_beta
-    hedge_needed = abs(beta_deviation) > beta_tolerance
+    if portfolio_beta is None:
+        # 판정 불가다. '헷지 불필요' 라는 결론을 지어내지 않기 위해 deviation 도
+        # 싣지 않고, 아래 analysis 에 왜 판정을 못 했는지를 남긴다.
+        beta_deviation = None
+        hedge_needed = False
+    else:
+        beta_deviation = portfolio_beta - target_beta
+        hedge_needed = abs(beta_deviation) > beta_tolerance
 
     # 헷지 추천
     hedge_recommendation = None
@@ -313,7 +345,8 @@ async def beta_hedge_condition(
 
     # state 저장
     has_risk_tracker = context and hasattr(context, "risk_tracker") and context.risk_tracker
-    if has_risk_tracker:
+    if has_risk_tracker and portfolio_beta is not None:
+        # 계산되지 않은 베타를 상태에 저장하면 다음 회차가 그 거짓값을 읽는다.
         try:
             context.risk_tracker.set_state("portfolio_beta", portfolio_beta)
         except Exception:
@@ -322,6 +355,10 @@ async def beta_hedge_condition(
     # risk_event 기록
     if hedge_needed and has_risk_tracker:
         try:
+            # 🔴 record_event 는 실제 트래커에 없는 메서드다 (관측 2026-09-12):
+            #    WorkflowRiskTracker 의 실제 이름은 record_risk_event 다. 아래 except 가
+            #    AttributeError 를 삼키므로 이 위험 이벤트는 **한 건도 기록되지 않는다**.
+            #    메서드명 정렬은 이 플러그인 밖(엔진) 수정이라 여기서 고치지 않는다 — 미검증.
             context.risk_tracker.record_event(
                 event_type="beta_deviation",
                 symbol="PORTFOLIO",
@@ -341,26 +378,35 @@ async def beta_hedge_condition(
         exchange = bd["exchange"]
         sym_dict = {"symbol": symbol, "exchange": exchange}
 
-        # 포트폴리오 내 비중 기반 기여도
-        if symbol in position_map:
-            pos = position_map[symbol]
-            qty = int(pos.get("qty", pos.get("quantity", 0)))
-            pos_value = float(pos.get("current_price", 0)) * qty
-            beta_contribution = round(bd["beta"] * pos_value, 2) if pos_value > 0 else 0
-        else:
-            beta_contribution = round(bd["beta"] / len(beta_data), 4)
-
         result_info = {
             "symbol": symbol, "exchange": exchange,
             "beta": bd["beta"],
-            "beta_contribution": beta_contribution,
         }
+        # 포트폴리오 내 비중(weight)과 그 비중으로 만든 기여도(beta_contribution)는
+        # **같은 두 값(수량·가격)에서 나온다** — 그래서 가용성도 같이 간다. 구 코드는
+        # weight 만 '못 읽으면 사유' 로 바꾸고 기여도는 옆에서 0 을 지어내, 같은
+        # 회차 안에서 "금액은 못 읽었는데 기여도는 0" 이라는 모순을 냈다.
         if symbol in position_map:
             pos = position_map[symbol]
-            qty = int(pos.get("qty", pos.get("quantity", 0)))
-            result_info["weight"] = round(
-                float(pos.get("current_price", 0)) * qty, 2
-            )
+            qty = coerce_qty(pos.get("qty", pos.get("quantity", 0)))
+            price = coerce_qty(pos.get("current_price", 0))
+            if qty is None or price is None:
+                unavailable_reason = (
+                    "포지션 금액을 계산할 수 없음 "
+                    f"(current_price={pos.get('current_price')!r}, "
+                    f"qty={pos.get('qty', pos.get('quantity'))!r})"
+                )
+                result_info["weight_unavailable_reason"] = unavailable_reason
+                result_info["beta_contribution_unavailable_reason"] = unavailable_reason
+            else:
+                pos_value = price * qty
+                result_info["weight"] = round(pos_value, 2)
+                # pos_value 가 0 이면(수량 0 · 가격 0) 기여도 0 은 **읽은 값에서 나온
+                # 계산 결과**다 — 지어낸 값이 아니므로 그대로 싣는다.
+                result_info["beta_contribution"] = round(bd["beta"] * pos_value, 2)
+        else:
+            # positions 에 없는 종목: 포트폴리오 베타와 같은 '동일 비중' 가정을 쓴다.
+            result_info["beta_contribution"] = round(bd["beta"] / len(beta_data), 4)
 
         symbol_results.append(result_info)
 
@@ -375,28 +421,38 @@ async def beta_hedge_condition(
         else:
             failed.append(sym_dict)
 
-        time_series = [{
+        ts_row = {
             "beta": bd["beta"],
-            "portfolio_beta": portfolio_beta,
             "signal": "sell" if hedge_needed else None,
             "side": "short" if hedge_needed else None,
-        }]
+        }
+        if portfolio_beta is not None:
+            ts_row["portfolio_beta"] = portfolio_beta
+        time_series = [ts_row]
         values.append({"symbol": symbol, "exchange": exchange, "time_series": time_series})
+
+    analysis: Dict[str, Any] = {
+        "indicator": "BetaHedge",
+        "market_symbol": market_symbol,
+        "target_beta": target_beta,
+        "beta_tolerance": beta_tolerance,
+        "hedge_needed": hedge_needed,
+        "hedge_method": hedge_method,
+        "total_symbols": len(beta_data),
+    }
+    if portfolio_beta is None:
+        # 값을 지어내는 대신 왜 없는지를 싣는다. hedge_needed=False 는 '헷지가
+        # 필요 없다' 가 아니라 '판정하지 못했다' 는 뜻임을 여기서 읽을 수 있다.
+        analysis["portfolio_beta_unavailable_reason"] = portfolio_beta_unavailable_reason
+        analysis["hedge_needed_undetermined"] = True
+    else:
+        analysis["portfolio_beta"] = portfolio_beta
 
     result_dict = {
         "passed_symbols": passed, "failed_symbols": failed,
         "symbol_results": symbol_results, "values": values,
         "result": hedge_needed,
-        "analysis": {
-            "indicator": "BetaHedge",
-            "market_symbol": market_symbol,
-            "portfolio_beta": portfolio_beta,
-            "target_beta": target_beta,
-            "beta_tolerance": beta_tolerance,
-            "hedge_needed": hedge_needed,
-            "hedge_method": hedge_method,
-            "total_symbols": len(beta_data),
-        },
+        "analysis": analysis,
     }
 
     if hedge_recommendation:

--- a/src/community/programgarden_community/plugins/correlation_guard/__init__.py
+++ b/src/community/programgarden_community/plugins/correlation_guard/__init__.py
@@ -267,6 +267,14 @@ async def correlation_guard_condition(
     has_risk_tracker = context and hasattr(context, "risk_tracker") and context.risk_tracker
 
     if has_risk_tracker:
+        # 🔴 이 히스테리시스 상태 읽기/쓰기는 실제로 동작하지 않는다 (관측 2026-09-12):
+        #    실제 트래커 programgarden.database.workflow_risk_tracker.WorkflowRiskTracker
+        #    에는 get_state/set_state 가 없다(save_state/load_state/delete_state 뿐).
+        #    아래 except 가 그 AttributeError 를 삼키므로 prev_regime 은 언제나
+        #    "normal" 이고, 경계 구간(recovery_threshold < corr < corr_threshold)의
+        #    '이전 상태 유지' 는 사실상 '항상 normal' 로 동작한다.
+        #    메서드명 정렬은 이 플러그인 밖(엔진) 수정이라 여기서 고치지 않는다 —
+        #    미검증 분기로 남긴다.
         try:
             state = context.risk_tracker.get_state("correlation_guard_regime")
             if state:
@@ -293,6 +301,10 @@ async def correlation_guard_condition(
     # risk_event 기록
     if triggered and has_risk_tracker:
         try:
+            # 🔴 record_event 는 실제 트래커에 없는 메서드다 (관측 2026-09-12):
+            #    WorkflowRiskTracker 의 실제 이름은 record_risk_event 다. 아래 except 가
+            #    AttributeError 를 삼키므로 이 위험 이벤트는 **한 건도 기록되지 않는다**.
+            #    메서드명 정렬은 이 플러그인 밖(엔진) 수정이라 여기서 고치지 않는다 — 미검증.
             context.risk_tracker.record_event(
                 event_type="high_correlation",
                 symbol="PORTFOLIO",

--- a/src/community/programgarden_community/plugins/drawdown_protection/__init__.py
+++ b/src/community/programgarden_community/plugins/drawdown_protection/__init__.py
@@ -15,9 +15,12 @@ from typing import Any, Dict, List, Optional, Set
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
+from .._position_qty import below_broker_lot, coerce_number, half_position_qty
+
 
 # risk_features 선언
 risk_features: Set[str] = {"hwm", "events"}
+
 
 DRAWDOWN_PROTECTION_SCHEMA = PluginSchema(
     id="DrawdownProtection",
@@ -59,11 +62,17 @@ DRAWDOWN_PROTECTION_SCHEMA = PluginSchema(
         "drawdown": {"type": "float", "description": "Current drawdown from peak (%)"},
         "max_drawdown_pct": {"type": "float", "description": "Configured maximum allowed drawdown threshold (%)"},
         "triggered": {"type": "bool", "description": "Whether drawdown exceeded the threshold"},
-        "action": {"type": "str", "description": "Action taken: 'exit_all', 'reduce_half', 'stop_new_orders', or 'hold'"},
-        "current_price": {"type": "float", "description": "Current market price"},
-        "pnl_rate": {"type": "float", "description": "Current P&L rate (%)"},
+        "action": {"type": "str", "description": "Action taken: 'exit_all', 'reduce_half', 'stop_new_orders', 'hold', or 'skip' (drawdown could not be determined because pnl_rate was unreadable and no HWM was available)"},
+        "reason": {"type": "str", "description": "Why the position was skipped: names the unreadable field and its raw value (present on the 'skip' action)"},
+        "current_price": {"type": "float", "description": "Current market price (absent when it could not be read; see current_price_unavailable_reason)"},
+        "current_price_unavailable_reason": {"type": "str", "description": "Present when the position's current_price could not be read as a number (display only)"},
+        "pnl_rate": {"type": "float", "description": "Current P&L rate (%) (absent when it could not be read; see pnl_rate_unavailable_reason)"},
+        "pnl_rate_unavailable_reason": {"type": "str", "description": "Present when pnl_rate could not be read but the drawdown was still determined from the risk_tracker HWM"},
         "hwm_price": {"type": "float", "description": "High-water mark price (available when risk_tracker is active)"},
         "hwm_drawdown_pct": {"type": "float", "description": "Drawdown from HWM tracked by risk_tracker (available when active)"},
+        "sell_quantity": {"type": "float", "description": "Quantity to sell for the 'reduce_half' action: exactly half of the held quantity, never rounded up and never above the held quantity (fractional halves are kept; the order node truncates to the broker lot and reports the remainder)"},
+        "sell_quantity_unavailable_reason": {"type": "str", "description": "Present only when 'reduce_half' triggered but the held quantity could not be read, so no sell quantity was emitted"},
+        "reduce_skipped_reason": {"type": "str", "description": "Present when the 'reduce_half' quantity is below 1 share: the order node truncates to the integer part (0) and builds no order, so the reduction silently does nothing this round"},
     },
     locales={
         "ko": {
@@ -107,20 +116,40 @@ async def drawdown_protection_condition(
         symbol = pos_data.get("symbol")
         if not symbol:
             continue
-        pnl_rate = pos_data.get("pnl_rate", 0)
-        current_price = pos_data.get("current_price", 0)
         exchange = pos_data.get("exchange") or pos_data.get("market_code", "UNKNOWN")
 
         exchange_map = {"81": "NYSE", "82": "NASDAQ", "83": "AMEX"}
         exchange_name = exchange_map.get(str(exchange), exchange)
         sym_dict = {"symbol": symbol, "exchange": exchange_name}
 
+        # 수익률·현재가는 **비교보다 먼저** 읽는다. 구 코드는 pos_data 원값을 그대로
+        # ``drawdown <= max_drawdown_pct`` / ``round(pnl_rate, 2)`` 에 넣어, 값이
+        # 숫자가 아니면('n/a'·None) TypeError 로 플러그인 전체가 죽었다. 못 읽은 값은
+        # 0 으로 뭉개지 않고 그렇다고 표시한다(_position_qty 참조).
+        raw_pnl_rate = pos_data.get("pnl_rate", 0)
+        raw_current_price = pos_data.get("current_price", 0)
+        pnl_rate = coerce_number(raw_pnl_rate)
+        current_price = coerce_number(raw_current_price)
+
         # risk_tracker HWM 기반 drawdown (우선)
-        drawdown = pnl_rate  # fallback
+        drawdown = pnl_rate  # fallback (읽을 수 없으면 None)
         if has_risk_tracker:
             hwm = context.risk_tracker.get_hwm(symbol)
             if hwm and hwm.hwm_price > 0:
                 drawdown = -float(hwm.drawdown_pct)  # drawdown_pct는 양수, 여기선 음수로 변환
+
+        if drawdown is None:
+            # pnl_rate 도 못 읽었고 HWM 도 없다 — 낙폭을 지어내지 않는다.
+            failed.append(sym_dict)
+            symbol_results.append({
+                "symbol": symbol, "exchange": exchange_name,
+                "max_drawdown_pct": max_drawdown_pct,
+                "action": "skip",
+                "reason": (
+                    f"수익률을 읽을 수 없어 낙폭을 판정하지 못함 (pnl_rate={raw_pnl_rate!r})"
+                ),
+            })
+            continue
 
         triggered = drawdown <= max_drawdown_pct
 
@@ -130,9 +159,20 @@ async def drawdown_protection_condition(
             "max_drawdown_pct": max_drawdown_pct,
             "triggered": triggered,
             "action": action if triggered else "hold",
-            "current_price": current_price,
-            "pnl_rate": round(pnl_rate, 2),
         }
+        if current_price is None:
+            result_info["current_price_unavailable_reason"] = (
+                f"현재가를 읽을 수 없음 (current_price={raw_current_price!r})"
+            )
+        else:
+            result_info["current_price"] = current_price
+        if pnl_rate is None:
+            # HWM 으로 낙폭은 판정했지만 pnl_rate 자체는 못 읽은 경우.
+            result_info["pnl_rate_unavailable_reason"] = (
+                f"수익률을 읽을 수 없음 (pnl_rate={raw_pnl_rate!r}) — 낙폭은 HWM 기준"
+            )
+        else:
+            result_info["pnl_rate"] = round(pnl_rate, 2)
 
         if has_risk_tracker:
             hwm = context.risk_tracker.get_hwm(symbol)
@@ -140,16 +180,37 @@ async def drawdown_protection_condition(
                 result_info["hwm_price"] = float(hwm.hwm_price)
                 result_info["hwm_drawdown_pct"] = float(hwm.drawdown_pct)
 
-        symbol_results.append(result_info)
-
         if triggered:
             # action에 따라 sell_quantity 설정
             if action == "reduce_half":
                 qty = pos_data.get("qty", pos_data.get("quantity", 0))
-                sym_dict["sell_quantity"] = max(1, int(qty) // 2)
+                half = half_position_qty(qty)
+                if half is None:
+                    # 수량을 읽을 수 없으면(없음·문자열 쓰레기·NaN·0 이하) 임의의 수량을
+                    # 지어내지 않는다. 왜 안 실었는지를 결과에 남긴다
+                    # ('안 보낸 필드는 안 보냈다고 표시' 규약).
+                    result_info["sell_quantity_unavailable_reason"] = (
+                        f"보유 수량을 읽을 수 없어 절반 수량을 싣지 않음 (qty={qty!r})"
+                    )
+                else:
+                    sym_dict["sell_quantity"] = half
+                    result_info["sell_quantity"] = half
+                    # 0 < 절반 < 1 이면 주문 송신부가 정수부 0 으로 접어 주문 자체를
+                    # 만들지 않는다(_position_qty.below_broker_lot). 1주 보유의
+                    # reduce_half 가 정확히 이 구간이다(0.5주). 수량은 그대로 둔다 —
+                    # 정수화·올림은 송신부의 규약이다. 다만 '절반 축소했다고 보고했는데
+                    # 아무 일도 없었다' 를 없애기 위해 사유를 드러낸다.
+                    if below_broker_lot(half):
+                        result_info["reduce_skipped_reason"] = (
+                            f"절반 축소 수량 {half!r} 주는 1주 미만이라 주문 송신부가 정수부(0)로 "
+                            f"접어 주문을 만들지 않는다 — 보유 {qty!r} 주에서 실제 축소가 "
+                            "일어나지 않는다"
+                        )
             passed.append(sym_dict)
         else:
             failed.append(sym_dict)
+
+        symbol_results.append(result_info)
 
     return {
         "passed_symbols": passed,

--- a/src/community/programgarden_community/plugins/dynamic_stop_loss/__init__.py
+++ b/src/community/programgarden_community/plugins/dynamic_stop_loss/__init__.py
@@ -15,6 +15,8 @@ from typing import List, Dict, Any, Optional
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
+from .._position_qty import coerce_number, preserve_qty
+
 
 DYNAMIC_STOP_LOSS_SCHEMA = PluginSchema(
     id="DynamicStopLoss",
@@ -59,7 +61,10 @@ DYNAMIC_STOP_LOSS_SCHEMA = PluginSchema(
     tags=["stop_loss", "atr", "dynamic", "volatility", "exit"],
     output_fields={
         "current_price": {"type": "float", "description": "Current market price"},
-        "avg_price": {"type": "float", "description": "Average entry price from position data"},
+        "avg_price": {"type": "float", "description": "Average entry price from position data (absent when the position carried no avg_price; see avg_price_unavailable_reason)"},
+        "avg_price_unavailable_reason": {"type": "str", "description": "Present when the position had no avg_price, so the current price was used as the reference price instead"},
+        "action": {"type": "str", "description": "'skip' when a position value (current_price / avg_price / quantity) could not be read and the stop was not evaluated (present only on skipped positions)"},
+        "reason": {"type": "str", "description": "Why the position was skipped: names the unreadable field(s) and their raw values (present on the 'skip' action)"},
         "reference_price": {"type": "float", "description": "Reference price used for stop calculation (entry or trailing high)"},
         "atr": {"type": "float", "description": "Current ATR value"},
         "stop_distance": {"type": "float", "description": "Stop distance in price units (ATR × multiplier)"},
@@ -157,17 +162,54 @@ async def dynamic_stop_loss_condition(
         symbol = pos_data.get("symbol")
         if not symbol:
             continue
-        current_price = pos_data.get("current_price", 0)
-        avg_price = pos_data.get("avg_price", current_price)
         exchange = pos_data.get("exchange") or pos_data.get("market_code", "UNKNOWN")
 
         exchange_map = {"81": "NYSE", "82": "NASDAQ", "83": "AMEX"}
         exchange_name = exchange_map.get(str(exchange), exchange)
+        close_side = pos_data.get("close_side", "sell")
 
+        # 가격·수량은 **연산보다 먼저** 읽는다. 구 코드는 pos_data 원값을 그대로
+        # ``atr = current_price * 0.02`` / ``current_price <= stop_price`` 에 넣어,
+        # 값이 숫자가 아니면('n/a'·None) TypeError 로 플러그인 전체가 죽었다
+        # (실측 2026-09-12: 'n/a' → TypeError, None → TypeError). 못 읽은 값은 0 으로
+        # 뭉개지 않고 어느 필드가 어떤 원값이었는지를 남긴 뒤 건너뛴다
+        # ('안 보낸 필드는 안 보냈다고 표시' 규약, _position_qty 참조).
+        raw_current_price = pos_data.get("current_price", 0)
+        raw_avg_price = pos_data.get("avg_price")
         # 하위 주문 노드가 {{ item.quantity }} / {{ item.close_side }} 로 소비하므로
         # 전량 청산 수량과 청산 방향을 passed_symbols 에 함께 실어야 한다.
-        quantity = pos_data.get("quantity", pos_data.get("qty", 0))
-        close_side = pos_data.get("close_side", "sell")
+        raw_qty = pos_data.get("quantity", pos_data.get("qty", 0))
+
+        current_price = coerce_number(raw_current_price)
+        quantity = preserve_qty(raw_qty)
+        # avg_price 가 아예 없으면(키 없음·None) 현재가를 기준가로 쓴다 — 구 코드의
+        # ``pos_data.get("avg_price", current_price)`` 폴백을 유지하되, 폴백했다는
+        # 사실을 결과에 남긴다. 값이 있는데 못 읽는 경우는 폴백이 아니라 skip 이다.
+        avg_price_fallback = raw_avg_price is None
+        avg_price = current_price if avg_price_fallback else coerce_number(raw_avg_price)
+
+        unreadable = []
+        if current_price is None:
+            unreadable.append(f"current_price={raw_current_price!r}")
+        if not avg_price_fallback and avg_price is None:
+            unreadable.append(f"avg_price={raw_avg_price!r}")
+        if quantity is None:
+            unreadable.append(f"quantity={raw_qty!r}")
+        if unreadable:
+            skipped_dict = {"symbol": symbol, "exchange": exchange_name, "close_side": close_side}
+            if quantity is not None:
+                skipped_dict["quantity"] = quantity
+            failed.append(skipped_dict)
+            symbol_results.append({
+                "symbol": symbol, "exchange": exchange_name,
+                "action": "skip",
+                "reason": (
+                    "포지션 값을 읽을 수 없어 동적 손절을 평가하지 못함 ("
+                    + ", ".join(unreadable) + ")"
+                ),
+            })
+            continue
+
         sym_dict = {
             "symbol": symbol,
             "exchange": exchange_name,
@@ -225,7 +267,6 @@ async def dynamic_stop_loss_condition(
         result_info = {
             "symbol": symbol, "exchange": exchange_name,
             "current_price": current_price,
-            "avg_price": avg_price,
             "reference_price": round(reference_price, 4),
             "atr": round(atr, 4),
             "stop_distance": round(stop_distance, 4),
@@ -233,6 +274,14 @@ async def dynamic_stop_loss_condition(
             "stop_pct": round(stop_pct, 2),
             "triggered": triggered,
         }
+        if avg_price_fallback:
+            # 없는 값을 '현재가와 같은 평단' 으로 실지 않는다 — 폴백했음을 밝힌다.
+            result_info["avg_price_unavailable_reason"] = (
+                f"포지션에 avg_price 가 없어 현재가 {current_price!r} 를 기준가로 사용 "
+                f"(avg_price={raw_avg_price!r})"
+            )
+        else:
+            result_info["avg_price"] = avg_price
         symbol_results.append(result_info)
 
         if triggered:

--- a/src/community/programgarden_community/plugins/max_position_limit/__init__.py
+++ b/src/community/programgarden_community/plugins/max_position_limit/__init__.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, List, Optional, Set
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
+from .._position_qty import coerce_number, coerce_qty
+
 
 MAX_POSITION_LIMIT_SCHEMA = PluginSchema(
     id="MaxPositionLimit",
@@ -60,11 +62,13 @@ MAX_POSITION_LIMIT_SCHEMA = PluginSchema(
     optional_fields=[],
     tags=["position", "limit", "risk", "weight", "portfolio"],
     output_fields={
-        "current_price": {"type": "float", "description": "Current market price of this position"},
-        "market_value": {"type": "float", "description": "Total market value of this position"},
+        "current_price": {"type": "float", "description": "Current market price of this position (absent when it could not be read; see current_price_unavailable_reason)"},
+        "current_price_unavailable_reason": {"type": "str", "description": "Present when the position's current_price could not be read as a number (the raw value is quoted)"},
+        "market_value": {"type": "float", "description": "Total market value of this position (market_value from the position, or current_price x qty when market_value is missing or 0; fractional share counts are kept)"},
         "weight_pct": {"type": "float", "description": "Position weight as percentage of total portfolio (%)"},
         "is_overweight": {"type": "bool", "description": "Whether this position exceeds the single position weight limit"},
-        "action_taken": {"type": "str", "description": "Action taken: 'exit', 'reduce', 'block_new', 'warn', or 'hold'"},
+        "action_taken": {"type": "str", "description": "Action taken: 'exit', 'reduce', 'block_new', 'warn', 'hold', or 'skip' (position value could not be read, so it was excluded from the value/weight checks)"},
+        "reason": {"type": "str", "description": "Why the position was skipped: names the unreadable field(s) and their raw values (present on the 'skip' action)"},
     },
     locales={
         "ko": {
@@ -109,16 +113,37 @@ async def max_position_limit_condition(
     position_count = len(valid_positions)
     total_value = 0.0
     symbol_values: Dict[str, float] = {}
+    # 금액을 읽을 수 없는 포지션 → 사유. 이 포지션은 종목 수(position_count)에는
+    # 들어가지만(포지션인 건 사실이다) 총액·비중 계산에서는 빠진다 — 0 으로 뭉개면
+    # '비중 0%' 라는 거짓 사실이 되기 때문이다.
+    unreadable_reasons: Dict[str, str] = {}
 
     for pos_data in valid_positions:
         symbol = pos_data["symbol"]
-        market_value = pos_data.get("market_value", 0)
-        if not market_value:
-            current_price = pos_data.get("current_price", 0)
-            qty = pos_data.get("qty", pos_data.get("quantity", 0))
-            market_value = current_price * qty
-        symbol_values[symbol] = float(market_value)
-        total_value += float(market_value)
+        # 원값을 곱셈·float() 에 그대로 넣지 않는다. 구 코드는
+        # ``market_value = current_price * qty`` 뒤 ``float(market_value)`` 였는데,
+        # current_price 가 **정상 숫자 문자열**('150.0')이면 곱셈이 문자열 반복
+        # ('150.0150.0…' × qty)이 되고 float() 에서 ValueError 로 죽었다
+        # (실측 2026-09-12: current_price='150.0', qty=100). 'n/a'·None 은 곱셈에서
+        # TypeError. 공용 코어서로 읽고, 못 읽으면 사유를 남긴다(_position_qty).
+        raw_market_value = pos_data.get("market_value")
+        market_value = coerce_number(raw_market_value)
+        if market_value is None or market_value == 0:
+            # market_value 가 없거나 0 이면 현재가 × 수량으로 계산한다(종전 폴백).
+            raw_price = pos_data.get("current_price", 0)
+            raw_qty = pos_data.get("qty", pos_data.get("quantity", 0))
+            price = coerce_number(raw_price)
+            qty = coerce_qty(raw_qty)
+            if price is None or qty is None:
+                unreadable_reasons[symbol] = (
+                    "포지션 금액을 계산할 수 없음 "
+                    f"(market_value={raw_market_value!r}, current_price={raw_price!r}, "
+                    f"qty={raw_qty!r})"
+                )
+                continue
+            market_value = price * qty
+        symbol_values[symbol] = market_value
+        total_value += market_value
 
     # 위반 확인
     violations = []
@@ -147,13 +172,25 @@ async def max_position_limit_condition(
 
     for pos_data in valid_positions:
         symbol = pos_data["symbol"]
-        current_price = pos_data.get("current_price", 0)
+        raw_current_price = pos_data.get("current_price", 0)
+        current_price = coerce_number(raw_current_price)
         exchange = pos_data.get("exchange") or pos_data.get("market_code", "UNKNOWN")
         exchange_map = {"81": "NYSE", "82": "NASDAQ", "83": "AMEX"}
         exchange_name = exchange_map.get(str(exchange), exchange)
         sym_dict = {"symbol": symbol, "exchange": exchange_name}
 
-        value = symbol_values.get(symbol, 0)
+        if symbol in unreadable_reasons:
+            # 금액을 못 읽은 포지션은 한도 판정에 넣지 않는다 — 어느 필드가 어떤
+            # 원값이었는지를 남기고 넘어간다.
+            failed.append(sym_dict)
+            symbol_results.append({
+                "symbol": symbol, "exchange": exchange_name,
+                "action_taken": "skip",
+                "reason": unreadable_reasons[symbol],
+            })
+            continue
+
+        value = symbol_values[symbol]
         weight_pct = (value / total_value * 100) if total_value > 0 else 0
         is_overweight = weight_pct > max_single_weight_pct
 
@@ -174,14 +211,21 @@ async def max_position_limit_condition(
                 action_taken = "warn"
                 is_passed = True  # flagged
 
-        symbol_results.append({
+        entry = {
             "symbol": symbol, "exchange": exchange_name,
-            "current_price": current_price,
             "market_value": round(value, 2),
             "weight_pct": round(weight_pct, 2),
             "is_overweight": is_overweight,
             "action_taken": action_taken,
-        })
+        }
+        if current_price is None:
+            # market_value 로 금액은 읽었지만 현재가는 못 읽은 경우 — 0 으로 싣지 않는다.
+            entry["current_price_unavailable_reason"] = (
+                f"현재가를 읽을 수 없음 (current_price={raw_current_price!r})"
+            )
+        else:
+            entry["current_price"] = current_price
+        symbol_results.append(entry)
 
         if is_passed:
             passed.append(sym_dict)
@@ -204,6 +248,7 @@ async def max_position_limit_condition(
             "count_exceeded": count_exceeded,
             "value_exceeded": value_exceeded,
             "overweight_count": len(overweight_symbols),
+            "unreadable_count": len(unreadable_reasons),
             "violations": violations,
             "action": action,
         },

--- a/src/community/programgarden_community/plugins/partial_take_profit/__init__.py
+++ b/src/community/programgarden_community/plugins/partial_take_profit/__init__.py
@@ -3,14 +3,41 @@ PartialTakeProfit (분할 익절) 플러그인
 
 여러 단계에서 분할 매도하여 리스크를 줄이면서 수익 확보.
 - levels: [{pnl_pct: 5, sell_pct: 50}, {pnl_pct: 10, sell_pct: 30}, {pnl_pct: 20, sell_pct: 20}]
-- strategy_state로 완료된 단계 추적
-- 포지션 청산 시 상태 자동 삭제
+- strategy_state로 완료된 단계 추적 (⚠️ 의도일 뿐 — 아래 '상태 경로는 라이브에서
+  동작하지 않는다' 절 참조)
+- 포지션 청산 시 상태 자동 삭제 (같은 이유로 미검증)
 
 입력 형식:
 - positions: RealAccountNode의 positions 출력 (list[dict])
   예: [{"symbol": "AAPL", "pnl_rate": 6.5, "qty": 100, ...}, ...]
 - fields: {levels}
 - context: strategy_state 접근용 (선택)
+
+🔴 상태(strategy_state) 경로는 현재 **라이브에서 동작하지 않는다** (관측 2026-09-12)
+--------------------------------------------------------------------------------
+아래 ``get_state``/``set_state``/``delete_state`` 헬퍼는 두 가지 이유로 실행기
+경로에서 실제로 돌지 않는다. 둘 다 이 파일 밖(엔진 쪽)의 문제이며 여기서 고치지
+않는다 — 아래 분기는 **미검증**이다.
+
+1. 메서드 이름이 실제 트래커와 다르다. 실제 클래스
+   ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 에는
+   ``get_state``/``set_state`` 가 **없다** — 있는 것은 ``save_state`` /
+   ``load_state`` / ``load_states`` / ``delete_state`` / ``delete_states`` 뿐이다
+   (그리고 이것들은 async 가 아니라 동기 메서드다). 실제 트래커를 가진 context 를
+   넘기면 이 경로는 ``AttributeError: 'WorkflowRiskTracker' object has no
+   attribute 'get_state'`` 로 즉사한다(실제 트래커 인스턴스로 재현 확인).
+2. 애초에 context 가 오지 않는다. 이 플러그인은 ``required_data=["positions"]``
+   라 실행기의 **positions 기반 분기**로 도는데, 그 분기
+   (``ConditionNodeExecutor.execute``, programgarden/executor.py — plugin_kwargs 가
+   ``{"positions": positions, "fields": evaluated_fields}`` 로 고정)는 ``context``
+   를 넘기지 않는다. 그래서 라이브에서는 항상 ``has_state`` 가 False 이고 상태는
+   저장·복원되지 않는다(context 없이 연속 호출하면 매번 같은 단계가 재발동하는
+   것으로 재현 확인).
+
+따라서 위 docstring 의 "strategy_state 로 ... 추적/저장" 은 **의도**이지 현재
+동작이 아니다. 이 경로를 되살리려면 (a) 메서드명을 실제 트래커에 맞추고,
+(b) 실행기의 positions 분기가 context 를 넘기게 하고, (c) 동기/비동기 호출 규약을
+맞춰야 한다 — 전부 이 플러그인 파일 밖의 수정이다.
 """
 
 import json
@@ -18,6 +45,14 @@ from typing import Any, Dict, List, Optional, Set
 
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
+
+from .._position_qty import (
+    below_broker_lot,
+    coerce_number,
+    coerce_qty,
+    partial_sell_qty,
+    preserve_qty,
+)
 
 
 # risk_features: strategy_state 사용
@@ -44,12 +79,14 @@ PARTIAL_TAKE_PROFIT_SCHEMA = PluginSchema(
     tags=["exit", "profit", "partial", "scaling"],
     output_fields={
         "pnl_rate": {"type": "float", "description": "Current P&L rate (%)"},
-        "qty": {"type": "int", "description": "Current position quantity"},
-        "sell_quantity": {"type": "int", "description": "Quantity to sell at this partial take profit level"},
+        "qty": {"type": "float", "description": "Current position quantity (fractional share counts are kept, not truncated; the raw unparsed value is echoed here on the 'skip' action that reports an unreadable quantity)"},
+        "sell_quantity": {"type": "float", "description": "Quantity to sell at this partial take profit level (original quantity x sell_pct, capped at the held quantity; fractional results are kept, not truncated - the order node truncates to the broker lot and reports the remainder)"},
+        "reason": {"type": "str", "description": "Why this level was skipped or cleared (present on 'skip' and 'cleared' actions)"},
         "sell_pct": {"type": "float", "description": "Percentage of position to sell (%)"},
         "level_index": {"type": "int", "description": "Index of the triggered profit level"},
         "remaining_levels": {"type": "int", "description": "Number of remaining profit levels not yet triggered"},
         "action": {"type": "str", "description": "Action taken: 'sell', 'hold', 'skip', or 'cleared'"},
+        "reduce_skipped_reason": {"type": "str", "description": "Present on a 'sell' action whose sell quantity is below 1 share: the order node truncates to the integer part (0) and builds no order, so no sell actually happens this round"},
     },
     locales={
         "ko": {
@@ -109,7 +146,12 @@ async def partial_take_profit_condition(
             "analysis": {"error": "No positions data"},
         }
 
-    # strategy_state 접근 헬퍼
+    # strategy_state 접근 헬퍼.
+    # 🔴 아래 세 함수는 라이브 실행기 경로에서 돌지 않는다 — 실행기의 positions 분기
+    #    (ConditionNodeExecutor.execute)가 context 를 넘기지 않아 has_state 가 항상
+    #    False 이고, 설령 실제 트래커를 넘겨도 WorkflowRiskTracker 에는
+    #    get_state/set_state 가 없어 AttributeError 로 죽는다. 모듈 docstring 의
+    #    '상태 경로는 라이브에서 동작하지 않는다' 절 참조. 미검증 분기.
     has_state = context and hasattr(context, "risk_tracker") and context.risk_tracker
 
     async def get_state(key: str) -> Any:
@@ -131,8 +173,8 @@ async def partial_take_profit_condition(
         symbol = pos_data.get("symbol")
         if not symbol:
             continue
-        pnl_rate = pos_data.get("pnl_rate", 0)
-        qty = pos_data.get("qty", pos_data.get("quantity", 0))
+        raw_pnl_rate = pos_data.get("pnl_rate", 0)
+        raw_qty = pos_data.get("qty", pos_data.get("quantity", 0))
         exchange = pos_data.get("exchange") or pos_data.get("market_code", "UNKNOWN")
         exchange_map = {"81": "NYSE", "82": "NASDAQ", "83": "AMEX"}
         exchange_name = exchange_map.get(str(exchange), exchange)
@@ -143,15 +185,56 @@ async def partial_take_profit_condition(
         close_side = pos_data.get("close_side", "sell")
         sym_dict = {"symbol": symbol, "exchange": exchange_name, "close_side": close_side}
 
+        # 수량은 **비교보다 먼저** 읽는다. 구 코드는 pos_data 원값을 그대로
+        # ``qty <= 0`` 에 넣어, 수량이 숫자가 아니면('100'·'n/a'·None) 거기서
+        # TypeError 로 플러그인 전체가 죽었다. 그래서 아래 '수량을 못 읽었다'
+        # 사유 분기는 수량에 대해서는 **도달할 수 없었다**.
+        qty = preserve_qty(raw_qty)
+        if qty is None:
+            failed.append(sym_dict)
+            skipped = {
+                "symbol": symbol, "exchange": exchange_name,
+                "qty": raw_qty,
+                "action": "skip",
+                "reason": (
+                    f"보유 수량을 읽을 수 없어 분할 익절을 평가하지 못함 (qty={raw_qty!r})"
+                ),
+            }
+            # pnl_rate 는 읽힐 때만 싣는다(못 읽은 값을 0 으로 지어내지 않는다).
+            pnl_display = coerce_number(raw_pnl_rate)
+            if pnl_display is not None:
+                skipped["pnl_rate"] = round(pnl_display, 2)
+            symbol_results.append(skipped)
+            continue
+
         # 수량 0이면 청산 완료 → 상태 삭제
         if qty <= 0:
             await delete_state(f"partial_tp.{symbol}.completed_levels")
             await delete_state(f"partial_tp.{symbol}.original_qty")
             failed.append(sym_dict)
-            symbol_results.append({
-                "symbol": symbol, "exchange": exchange_name,
-                "pnl_rate": round(pnl_rate, 2), "qty": qty,
+            cleared = {
+                "symbol": symbol, "exchange": exchange_name, "qty": qty,
                 "action": "cleared", "reason": "Position closed",
+            }
+            pnl_display = coerce_number(raw_pnl_rate)
+            if pnl_display is not None:
+                cleared["pnl_rate"] = round(pnl_display, 2)
+            symbol_results.append(cleared)
+            continue
+
+        # 수익률도 **비교보다 먼저** 읽는다. 구 코드는 원값을 그대로
+        # ``pnl_rate >= level["pnl_pct"]`` / ``round(pnl_rate, 2)`` 에 넣어 값이 숫자가
+        # 아니면('n/a'·None) TypeError 로 죽었다. 수익률 없이는 어느 단계도 판정할 수
+        # 없으므로 상태를 건드리지 않고 사유만 남긴다.
+        pnl_rate = coerce_number(raw_pnl_rate)
+        if pnl_rate is None:
+            failed.append(sym_dict)
+            symbol_results.append({
+                "symbol": symbol, "exchange": exchange_name, "qty": qty,
+                "action": "skip",
+                "reason": (
+                    f"수익률을 읽을 수 없어 분할 익절을 평가하지 못함 (pnl_rate={raw_pnl_rate!r})"
+                ),
             })
             continue
 
@@ -160,7 +243,18 @@ async def partial_take_profit_condition(
         completed_levels = completed_raw if isinstance(completed_raw, list) else []
 
         original_qty_raw = await get_state(f"partial_tp.{symbol}.original_qty")
-        original_qty = original_qty_raw if isinstance(original_qty_raw, (int, float)) and original_qty_raw > 0 else qty
+        # Decimal 로 복원되는 저장값도 받아들인다(구 isinstance(int, float) 검사는
+        # Decimal 을 놓쳐 매 단계 '현재 수량' 기준으로 되돌아갔다).
+        # ⚠️ 이 분기는 **라이브에서 도달하지 않는다** — get_state 가 항상 None 을
+        #    돌려주므로(모듈 docstring 의 '상태 경로' 절) original_qty 는 늘 아래
+        #    폴백인 현재 qty 가 된다. Decimal 복원 자체는 목(MockRiskTracker)에서만
+        #    검증됐다.
+        original_qty_state = coerce_qty(original_qty_raw)
+        original_qty = (
+            original_qty_state
+            if original_qty_state is not None and original_qty_state > 0
+            else qty
+        )
 
         # 아직 실행 안 된 단계 중 조건 충족하는 것 찾기
         triggered_level = None
@@ -174,10 +268,25 @@ async def partial_take_profit_condition(
         if triggered_level:
             level_idx, level = triggered_level
             sell_pct = level.get("sell_pct", 0)
-            sell_quantity = int(original_qty * sell_pct / 100)
-            sell_quantity = min(sell_quantity, qty)  # 보유량 초과 방지
+            # 소수 잔량 보존 — int() 절단은 0.532주 포지션의 부분 익절을 0 으로
+            # 만들어 아래 게이트에서 통째로 스킵시켰다(_position_qty.partial_sell_qty).
+            sell_quantity = partial_sell_qty(original_qty, sell_pct, qty)
 
-            if sell_quantity > 0:
+            if sell_quantity is None:
+                # 수량/비율을 읽을 수 없으면 지어내지 않는다. 왜 못 실었는지를 남긴다
+                # ('안 보낸 필드는 안 보냈다고 표시' 규약).
+                failed.append(sym_dict)
+                symbol_results.append({
+                    "symbol": symbol, "exchange": exchange_name,
+                    "pnl_rate": round(pnl_rate, 2), "qty": qty,
+                    "sell_pct": sell_pct, "level_index": level_idx,
+                    "action": "skip",
+                    "reason": (
+                        "수량을 읽을 수 없어 부분 익절 수량을 계산하지 못함 "
+                        f"(original_qty={original_qty!r}, sell_pct={sell_pct!r}, qty={qty!r})"
+                    ),
+                })
+            elif sell_quantity > 0:
                 # 완료 단계 업데이트
                 new_completed = completed_levels + [level_idx]
                 await set_state(f"partial_tp.{symbol}.completed_levels", new_completed)
@@ -188,19 +297,36 @@ async def partial_take_profit_condition(
 
                 # 부분 청산 수량을 quantity 로 실어 주문 노드가 부분 매도하도록 한다.
                 passed.append({**sym_dict, "quantity": sell_quantity})
-                symbol_results.append({
+                sold = {
                     "symbol": symbol, "exchange": exchange_name,
                     "pnl_rate": round(pnl_rate, 2), "qty": qty,
                     "sell_quantity": sell_quantity, "sell_pct": sell_pct,
                     "level_index": level_idx, "remaining_levels": remaining_levels,
                     "action": "sell",
-                })
+                }
+                # 0 < 수량 < 1 이면 주문 송신부가 정수부 0 으로 접어 **주문을 만들지
+                # 않는다** (_position_qty.below_broker_lot 참조). 수량은 그대로 두되
+                # (정수화·올림은 송신부의 규약이다) 조용한 무동작이 되지 않도록
+                # 사유를 드러낸다.
+                if below_broker_lot(sell_quantity):
+                    sold["reduce_skipped_reason"] = (
+                        f"부분 익절 수량 {sell_quantity!r} 주는 1주 미만이라 주문 송신부가 "
+                        "정수부(0)로 접어 주문을 만들지 않는다 — 이번 회차에는 실제 매도가 "
+                        "일어나지 않는다"
+                    )
+                symbol_results.append(sold)
             else:
                 failed.append(sym_dict)
                 symbol_results.append({
                     "symbol": symbol, "exchange": exchange_name,
                     "pnl_rate": round(pnl_rate, 2), "qty": qty,
-                    "action": "skip", "reason": "Sell quantity is 0",
+                    "sell_quantity": sell_quantity, "sell_pct": sell_pct,
+                    "level_index": level_idx,
+                    "action": "skip",
+                    "reason": (
+                        f"부분 익절 수량이 0 — 매도 비율 {sell_pct!r}% × 기준 수량 "
+                        f"{original_qty!r} (보유 {qty!r})"
+                    ),
                 })
         else:
             remaining_levels = len(levels) - len(completed_levels)

--- a/src/community/programgarden_community/plugins/profit_target/__init__.py
+++ b/src/community/programgarden_community/plugins/profit_target/__init__.py
@@ -14,6 +14,8 @@ from typing import Any, Dict, List, Optional
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
+from .._position_qty import coerce_number, preserve_qty
+
 
 PROFIT_TARGET_SCHEMA = PluginSchema(
     id="ProfitTarget",
@@ -38,9 +40,12 @@ PROFIT_TARGET_SCHEMA = PluginSchema(
     tags=["exit", "profit", "realtime"],
     output_fields={
         "pnl_rate": {"type": "float", "description": "Current P&L rate (%)"},
-        "current_price": {"type": "float", "description": "Current market price"},
+        "current_price": {"type": "float", "description": "Current market price (absent when it could not be read; see current_price_unavailable_reason)"},
+        "current_price_unavailable_reason": {"type": "str", "description": "Present when the position's current_price could not be read as a number (display only - the target decision does not use it)"},
         "target_percent": {"type": "float", "description": "Profit target threshold (%)"},
         "reached": {"type": "bool", "description": "Whether profit target was reached (pnl_rate >= target_percent)"},
+        "action": {"type": "str", "description": "'skip' when pnl_rate or the held quantity could not be read, so the target was not evaluated (present only on skipped positions)"},
+        "reason": {"type": "str", "description": "Why the position was skipped: names the unreadable field(s) and their raw values (present on the 'skip' action)"},
     },
     locales={
         "ko": {
@@ -110,19 +115,50 @@ async def profit_target_condition(
         symbol = pos_data.get("symbol")
         if not symbol:
             continue
-        # positions에서 직접 pnl_rate 사용 (이미 계산되어 있음)
-        pnl_rate = pos_data.get("pnl_rate", 0)
-        current_price = pos_data.get("current_price", 0)
         exchange = pos_data.get("exchange") or pos_data.get("market_code", "UNKNOWN")
 
         exchange_map = {"81": "NYSE", "82": "NASDAQ", "83": "AMEX"}
         exchange_name = exchange_map.get(str(exchange), exchange)
+        close_side = pos_data.get("close_side", "sell")
 
+        # 수익률·수량은 **비교보다 먼저** 읽는다. 구 코드는 pos_data 원값을 그대로
+        # ``round(pnl_rate, 2)`` / ``pnl_rate >= target_percent`` 에 넣어, 값이 숫자가
+        # 아니면('n/a'·None) TypeError 로 플러그인 전체가 죽었다. 못 읽은 값은 0 으로
+        # 뭉개지 않고 어느 필드가 어떤 원값이었는지를 남긴 뒤 건너뛴다
+        # ('안 보낸 필드는 안 보냈다고 표시' 규약, _position_qty 참조).
+        # positions에서 직접 pnl_rate 사용 (이미 계산되어 있음)
+        raw_pnl_rate = pos_data.get("pnl_rate", 0)
+        raw_current_price = pos_data.get("current_price", 0)
         # 하위 주문 노드가 {{ item.quantity }} / {{ item.close_side }} 로 소비하므로
         # 전량 청산 수량과 청산 방향을 passed_symbols 에 함께 실어야 한다.
         # (누락 시 order 정규화가 quantity<=0 으로 주문을 조용히 버린다.)
-        quantity = pos_data.get("quantity", pos_data.get("qty", 0))
-        close_side = pos_data.get("close_side", "sell")
+        raw_qty = pos_data.get("quantity", pos_data.get("qty", 0))
+
+        pnl_rate = coerce_number(raw_pnl_rate)
+        current_price = coerce_number(raw_current_price)
+        # 수량은 절단하지 않는다 — 정수화는 주문 송신부(_normalize_order)의 규약이다.
+        quantity = preserve_qty(raw_qty)
+
+        unreadable = []
+        if pnl_rate is None:
+            unreadable.append(f"pnl_rate={raw_pnl_rate!r}")
+        if quantity is None:
+            # 수량 없이는 청산 주문을 실을 수 없다(송신부가 quantity<=0 으로 조용히
+            # 버린다) — 지어내지 않고 여기서 사유를 남긴다.
+            unreadable.append(f"quantity={raw_qty!r}")
+        if unreadable:
+            failed.append({"exchange": exchange_name, "symbol": symbol, "close_side": close_side})
+            symbol_results.append({
+                "symbol": symbol,
+                "exchange": exchange_name,
+                "target_percent": target_percent,
+                "action": "skip",
+                "reason": (
+                    "포지션 값을 읽을 수 없어 익절을 평가하지 못함 ("
+                    + ", ".join(unreadable) + ")"
+                ),
+            })
+            continue
 
         sym_dict = {
             "exchange": exchange_name,
@@ -131,16 +167,25 @@ async def profit_target_condition(
             "close_side": close_side,
         }
 
-        symbol_results.append({
+        reached = pnl_rate >= target_percent
+        entry = {
             "symbol": symbol,
             "exchange": exchange_name,
             "pnl_rate": round(pnl_rate, 2),
-            "current_price": current_price,
             "target_percent": target_percent,
-            "reached": pnl_rate >= target_percent,
-        })
+            "reached": reached,
+        }
+        if current_price is None:
+            # 현재가는 표시용이다(익절 판정은 pnl_rate 만 쓴다) — 못 읽었으면 0 으로
+            # 싣지 않고 그렇다고 표시한다.
+            entry["current_price_unavailable_reason"] = (
+                f"현재가를 읽을 수 없음 (current_price={raw_current_price!r})"
+            )
+        else:
+            entry["current_price"] = current_price
+        symbol_results.append(entry)
 
-        if pnl_rate >= target_percent:
+        if reached:
             passed.append(sym_dict)
         else:
             failed.append(sym_dict)

--- a/src/community/programgarden_community/plugins/roll_management/__init__.py
+++ b/src/community/programgarden_community/plugins/roll_management/__init__.py
@@ -16,6 +16,8 @@ from datetime import datetime, timedelta
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
+from .._position_qty import coerce_number, preserve_qty
+
 
 # risk_features 선언
 risk_features: Set[str] = {"state"}
@@ -54,8 +56,10 @@ ROLL_MANAGEMENT_SCHEMA = PluginSchema(
         "should_roll": {"type": "bool", "description": "Whether it is time to roll to the next contract"},
         "next_contract": {"type": "str", "description": "Symbol of the next contract to roll into"},
         "roll_strategy": {"type": "str", "description": "Roll strategy applied: 'calendar', 'volume', or 'spread_optimal'"},
-        "current_price": {"type": "float", "description": "Current market price of the position"},
-        "qty": {"type": "int", "description": "Current position quantity"},
+        "current_price": {"type": "float", "description": "Current market price of the position (absent when it could not be read; see current_price_unavailable_reason)"},
+        "current_price_unavailable_reason": {"type": "str", "description": "Present when the position's current_price could not be read as a number (display only - the roll decision does not use it)"},
+        "qty": {"type": "float", "description": "Current position quantity (fractional counts are kept; absent when it could not be read; see qty_unavailable_reason)"},
+        "qty_unavailable_reason": {"type": "str", "description": "Present when the position's quantity could not be read as a number (display only - the roll decision does not use it)"},
     },
     locales={
         "ko": {
@@ -183,9 +187,26 @@ async def roll_management_condition(
             "should_roll": should_roll,
             "next_contract": next_contract,
             "roll_strategy": roll_strategy,
-            "current_price": pos_data.get("current_price", 0),
-            "qty": pos_data.get("qty", pos_data.get("quantity", 0)),
         }
+        # 현재가·수량은 표시용이다(롤 판정은 만기일만 쓴다). 원값을 그대로 싣지 않고
+        # 숫자로 읽어 싣되, 못 읽으면 0 으로 뭉개지 않고 그렇다고 표시한다
+        # ('안 보낸 필드는 안 보냈다고 표시' 규약, _position_qty 참조).
+        raw_current_price = pos_data.get("current_price", 0)
+        raw_qty = pos_data.get("qty", pos_data.get("quantity", 0))
+        current_price = coerce_number(raw_current_price)
+        qty = preserve_qty(raw_qty)
+        if current_price is None:
+            result_info["current_price_unavailable_reason"] = (
+                f"현재가를 읽을 수 없음 (current_price={raw_current_price!r})"
+            )
+        else:
+            result_info["current_price"] = current_price
+        if qty is None:
+            result_info["qty_unavailable_reason"] = (
+                f"보유 수량을 읽을 수 없음 (qty={raw_qty!r})"
+            )
+        else:
+            result_info["qty"] = qty
 
         # state 저장 (롤오버 이력)
         if should_roll and context and hasattr(context, "risk_tracker") and context.risk_tracker:

--- a/src/community/programgarden_community/plugins/stop_loss/__init__.py
+++ b/src/community/programgarden_community/plugins/stop_loss/__init__.py
@@ -14,6 +14,8 @@ from typing import Any, Dict, List, Optional
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
+from .._position_qty import coerce_number, preserve_qty
+
 
 STOP_LOSS_SCHEMA = PluginSchema(
     id="StopLoss",
@@ -38,9 +40,12 @@ STOP_LOSS_SCHEMA = PluginSchema(
     tags=["exit", "risk", "realtime"],
     output_fields={
         "pnl_rate": {"type": "float", "description": "Current P&L rate (%)"},
-        "current_price": {"type": "float", "description": "Current market price"},
+        "current_price": {"type": "float", "description": "Current market price (absent when it could not be read; see current_price_unavailable_reason)"},
+        "current_price_unavailable_reason": {"type": "str", "description": "Present when the position's current_price could not be read as a number (display only - the stop decision does not use it)"},
         "stop_percent": {"type": "float", "description": "Stop loss threshold (%)"},
         "triggered": {"type": "bool", "description": "Whether stop loss was triggered (pnl_rate <= stop_percent)"},
+        "action": {"type": "str", "description": "'skip' when pnl_rate or the held quantity could not be read, so the stop was not evaluated (present only on skipped positions)"},
+        "reason": {"type": "str", "description": "Why the position was skipped: names the unreadable field(s) and their raw values (present on the 'skip' action)"},
     },
     locales={
         "ko": {
@@ -110,20 +115,51 @@ async def stop_loss_condition(
         symbol = pos_data.get("symbol")
         if not symbol:
             continue
-        # positions에서 직접 pnl_rate 사용 (이미 계산되어 있음)
-        pnl_rate = pos_data.get("pnl_rate", 0)
-        current_price = pos_data.get("current_price", 0)
         exchange = pos_data.get("exchange") or pos_data.get("market_code", "UNKNOWN")
 
         # market_code를 거래소명으로 변환 (숫자 코드일 때만)
         exchange_map = {"81": "NYSE", "82": "NASDAQ", "83": "AMEX"}
         exchange_name = exchange_map.get(str(exchange), exchange)
+        close_side = pos_data.get("close_side", "sell")
 
+        # 수익률·수량은 **비교보다 먼저** 읽는다. 구 코드는 pos_data 원값을 그대로
+        # ``round(pnl_rate, 2)`` / ``pnl_rate <= stop_percent`` 에 넣어, 값이 숫자가
+        # 아니면('n/a'·None) TypeError 로 플러그인 전체가 죽었다. 못 읽은 값은 0 으로
+        # 뭉개지 않고 어느 필드가 어떤 원값이었는지를 남긴 뒤 건너뛴다
+        # ('안 보낸 필드는 안 보냈다고 표시' 규약, _position_qty 참조).
+        # positions에서 직접 pnl_rate 사용 (이미 계산되어 있음)
+        raw_pnl_rate = pos_data.get("pnl_rate", 0)
+        raw_current_price = pos_data.get("current_price", 0)
         # 하위 주문 노드가 {{ item.quantity }} / {{ item.close_side }} 로 소비하므로
         # 전량 청산 수량과 청산 방향을 passed_symbols 에 함께 실어야 한다.
         # (누락 시 order 정규화가 quantity<=0 으로 주문을 조용히 버린다.)
-        quantity = pos_data.get("quantity", pos_data.get("qty", 0))
-        close_side = pos_data.get("close_side", "sell")
+        raw_qty = pos_data.get("quantity", pos_data.get("qty", 0))
+
+        pnl_rate = coerce_number(raw_pnl_rate)
+        current_price = coerce_number(raw_current_price)
+        # 수량은 절단하지 않는다 — 정수화는 주문 송신부(_normalize_order)의 규약이다.
+        quantity = preserve_qty(raw_qty)
+
+        unreadable = []
+        if pnl_rate is None:
+            unreadable.append(f"pnl_rate={raw_pnl_rate!r}")
+        if quantity is None:
+            # 수량 없이는 청산 주문을 실을 수 없다(송신부가 quantity<=0 으로 조용히
+            # 버린다) — 지어내지 않고 여기서 사유를 남긴다.
+            unreadable.append(f"quantity={raw_qty!r}")
+        if unreadable:
+            failed.append({"exchange": exchange_name, "symbol": symbol, "close_side": close_side})
+            symbol_results.append({
+                "symbol": symbol,
+                "exchange": exchange_name,
+                "stop_percent": stop_percent,
+                "action": "skip",
+                "reason": (
+                    "포지션 값을 읽을 수 없어 손절을 평가하지 못함 ("
+                    + ", ".join(unreadable) + ")"
+                ),
+            })
+            continue
 
         sym_dict = {
             "exchange": exchange_name,
@@ -132,17 +168,26 @@ async def stop_loss_condition(
             "close_side": close_side,
         }
 
-        symbol_results.append({
+        triggered = pnl_rate <= stop_percent
+        entry = {
             "symbol": symbol,
             "exchange": exchange_name,
             "pnl_rate": round(pnl_rate, 2),
-            "current_price": current_price,
             "stop_percent": stop_percent,
-            "triggered": pnl_rate <= stop_percent,
-        })
+            "triggered": triggered,
+        }
+        if current_price is None:
+            # 현재가는 표시용이다(손절 판정은 pnl_rate 만 쓴다) — 못 읽었으면 0 으로
+            # 싣지 않고 그렇다고 표시한다.
+            entry["current_price_unavailable_reason"] = (
+                f"현재가를 읽을 수 없음 (current_price={raw_current_price!r})"
+            )
+        else:
+            entry["current_price"] = current_price
+        symbol_results.append(entry)
 
         # 손절 조건: pnl_rate가 stop_percent 이하 (예: -21.95 <= -3.0)
-        if pnl_rate <= stop_percent:
+        if triggered:
             passed.append(sym_dict)
         else:
             failed.append(sym_dict)

--- a/src/community/programgarden_community/plugins/time_based_exit/__init__.py
+++ b/src/community/programgarden_community/plugins/time_based_exit/__init__.py
@@ -2,8 +2,9 @@
 TimeBasedExit (시간 기반 청산) 플러그인
 
 보유 기간이 설정된 일수를 초과하면 자동 청산 시그널 발생.
-- strategy_state에 진입일 저장
-- 포지션 청산 시 상태 자동 삭제
+- strategy_state에 진입일 저장 (⚠️ 의도일 뿐 — 아래 '상태 경로는 라이브에서
+  동작하지 않는다' 절 참조)
+- 포지션 청산 시 상태 자동 삭제 (같은 이유로 미검증)
 - 포지션이 사라진 종목의 상태도 자동 정리
 
 입력 형식:
@@ -11,6 +12,32 @@ TimeBasedExit (시간 기반 청산) 플러그인
   예: [{"symbol": "AAPL", "qty": 100, ...}, ...]
 - fields: {max_hold_days, warn_days}
 - context: strategy_state 접근용 (선택)
+
+🔴 상태(strategy_state) 경로는 현재 **라이브에서 동작하지 않는다** (관측 2026-09-12)
+--------------------------------------------------------------------------------
+아래 ``get_state``/``set_state``/``delete_state`` 헬퍼는 두 가지 이유로 실행기
+경로에서 실제로 돌지 않는다. 둘 다 이 파일 밖(엔진 쪽)의 문제이며 여기서 고치지
+않는다 — 아래 분기는 **미검증**이다.
+
+1. 메서드 이름이 실제 트래커와 다르다. 실제 클래스
+   ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 에는
+   ``get_state``/``set_state`` 가 **없다** — 있는 것은 ``save_state`` /
+   ``load_state`` / ``load_states`` / ``delete_state`` / ``delete_states`` 뿐이다
+   (그리고 이것들은 async 가 아니라 동기 메서드다). 실제 트래커를 가진 context 를
+   넘기면 이 경로는 ``AttributeError: 'WorkflowRiskTracker' object has no
+   attribute 'get_state'`` 로 즉사한다(실제 트래커 인스턴스로 재현 확인).
+2. 애초에 context 가 오지 않는다. 이 플러그인은 ``required_data=["positions"]``
+   라 실행기의 **positions 기반 분기**로 도는데, 그 분기
+   (``ConditionNodeExecutor.execute``, programgarden/executor.py — plugin_kwargs 가
+   ``{"positions": positions, "fields": evaluated_fields}`` 로 고정)는 ``context``
+   를 넘기지 않는다. 그래서 라이브에서는 항상 ``has_state`` 가 False 이고 상태는
+   저장·복원되지 않는다(context 없이 연속 호출하면 매번 같은 단계가 재발동하는
+   것으로 재현 확인).
+
+따라서 위 docstring 의 "strategy_state 로 ... 추적/저장" 은 **의도**이지 현재
+동작이 아니다. 이 경로를 되살리려면 (a) 메서드명을 실제 트래커에 맞추고,
+(b) 실행기의 positions 분기가 context 를 넘기게 하고, (c) 동기/비동기 호출 규약을
+맞춰야 한다 — 전부 이 플러그인 파일 밖의 수정이다.
 """
 
 from datetime import date, timedelta
@@ -18,6 +45,8 @@ from typing import Any, Dict, List, Optional, Set
 
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
+
+from .._position_qty import preserve_qty
 
 
 # risk_features: strategy_state 사용
@@ -57,7 +86,8 @@ TIME_BASED_EXIT_SCHEMA = PluginSchema(
         "hold_days": {"type": "int", "description": "Number of days position has been held"},
         "max_hold_days": {"type": "int", "description": "Maximum allowed holding days"},
         "warn": {"type": "bool", "description": "Whether the warning threshold has been crossed"},
-        "action": {"type": "str", "description": "Recommended action: 'exit', 'warn', 'hold', or 'cleared'"},
+        "action": {"type": "str", "description": "Recommended action: 'exit', 'warn', 'hold', 'cleared', or 'skip'"},
+        "reason": {"type": "str", "description": "Why the position was cleared or skipped (present on the 'cleared' and 'skip' actions)"},
     },
     locales={
         "ko": {
@@ -102,6 +132,12 @@ async def time_based_exit_condition(
             "analysis": {"error": "No positions data"},
         }
 
+    # strategy_state 접근 헬퍼.
+    # 🔴 아래 세 함수는 라이브 실행기 경로에서 돌지 않는다 — 실행기의 positions 분기
+    #    (ConditionNodeExecutor.execute)가 context 를 넘기지 않아 has_state 가 항상
+    #    False 이고, 설령 실제 트래커를 넘겨도 WorkflowRiskTracker 에는
+    #    get_state/set_state 가 없어 AttributeError 로 죽는다. 모듈 docstring 의
+    #    '상태 경로는 라이브에서 동작하지 않는다' 절 참조. 미검증 분기.
     has_state = context and hasattr(context, "risk_tracker") and context.risk_tracker
 
     async def get_state(key: str) -> Any:
@@ -126,11 +162,29 @@ async def time_based_exit_condition(
         symbol = pos_data.get("symbol")
         if not symbol:
             continue
-        qty = pos_data.get("qty", pos_data.get("quantity", 0))
+        raw_qty = pos_data.get("qty", pos_data.get("quantity", 0))
         exchange = pos_data.get("exchange") or pos_data.get("market_code", "UNKNOWN")
         exchange_map = {"81": "NYSE", "82": "NASDAQ", "83": "AMEX"}
         exchange_name = exchange_map.get(str(exchange), exchange)
         sym_dict = {"symbol": symbol, "exchange": exchange_name}
+
+        # 수량은 **비교보다 먼저** 읽는다. 구 코드는 pos_data 원값을 그대로
+        # ``qty <= 0`` 에 넣어, 수량이 숫자가 아니면('100'·'n/a'·None) 거기서
+        # TypeError 로 플러그인 전체가 죽었다 — '수량을 못 읽었다' 는 사실이
+        # 결과에 남을 기회조차 없었다.
+        qty = preserve_qty(raw_qty)
+        if qty is None:
+            # 읽을 수 없는 수량으로 보유일수를 판정하지 않는다. 상태(진입일)도
+            # 건드리지 않는다 — 청산된 것인지 알 수 없기 때문이다.
+            failed.append(sym_dict)
+            symbol_results.append({
+                "symbol": symbol, "exchange": exchange_name,
+                "action": "skip",
+                "reason": (
+                    f"보유 수량을 읽을 수 없어 보유 기간을 판정하지 못함 (qty={raw_qty!r})"
+                ),
+            })
+            continue
 
         # 수량 0이면 청산 완료 → 상태 삭제
         if qty <= 0:

--- a/src/community/programgarden_community/plugins/trailing_stop/__init__.py
+++ b/src/community/programgarden_community/plugins/trailing_stop/__init__.py
@@ -18,9 +18,12 @@ from typing import Any, ClassVar, Dict, List, Optional, Set
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
+from .._position_qty import Qty, preserve_qty
+
 
 # risk_features 선언: HWM 추적이 필요함
 risk_features: Set[str] = {"hwm"}
+
 
 TRAILING_STOP_SCHEMA = PluginSchema(
     id="TrailingStop",
@@ -117,7 +120,8 @@ async def trailing_stop_condition(
         # 종목별 최신 close 를 추출해 HWM 을 직접 갱신한다.
         # P&L 틱 리스너가 없는 스케줄 폴링 구성에서도 HWM 이 전진하도록 보장.
         latest_close: Dict[str, float] = {}
-        latest_qty: Dict[str, int] = {}  # data 행(라이브 포지션 스냅샷)의 권위 수량
+        # data 행(라이브 포지션 스냅샷)의 권위 수량 — 소수 잔량도 보존한다.
+        latest_qty: Dict[str, Qty] = {}
         for row in data or []:
             if not isinstance(row, dict):
                 continue
@@ -127,10 +131,9 @@ async def trailing_stop_condition(
             # 라이브 포지션 수량(권위값) 캡처 — close 유효성과 무관하게 잡는다.
             row_qty = row.get("quantity", row.get("qty"))
             if row_qty is not None:
-                try:
-                    latest_qty[row_sym] = int(float(row_qty))
-                except (TypeError, ValueError):
-                    pass
+                qty_val = preserve_qty(row_qty)
+                if qty_val is not None:
+                    latest_qty[row_sym] = qty_val
             row_close = row.get("close")
             if row_close is None:
                 continue
@@ -183,22 +186,23 @@ async def trailing_stop_condition(
                 # quantity(권위값 — sym_info 또는 data 행 스냅샷)를 우선 쓰고, 없을
                 # 때만 HWM 트래커 기억값(position_qty)으로 폴백한다. (트레일링 스탑은
                 # 롱 포지션 고점 대비 하락 청산이므로 close_side 는 sell.)
+                # 수량은 절단하지 않는다 — 정수화는 주문 송신부
+                # (_normalize_order)의 명시적 규약이다(_position_qty.preserve_qty).
                 live_qty = None
                 if isinstance(sym_info, dict):
                     q = sym_info.get("quantity", sym_info.get("qty"))
                     if q is not None:
-                        try:
-                            live_qty = int(float(q))
-                        except (TypeError, ValueError):
-                            live_qty = None
+                        live_qty = preserve_qty(q)
                 if live_qty is None:
                     live_qty = latest_qty.get(sym)
                 if live_qty is not None:
                     trail_qty = live_qty
                 else:
-                    try:
-                        trail_qty = int(getattr(hwm, "position_qty", 0) or 0)
-                    except (TypeError, ValueError):
+                    # HWM 트래커의 position_qty 는 Decimal 이다(소수 잔량 보존 —
+                    # workflow_risk_tracker._to_qty_decimal). 여기서 int 로 자르면
+                    # 0.532주 포지션이 quantity=0 으로 실려 주문이 사라진다.
+                    trail_qty = preserve_qty(getattr(hwm, "position_qty", 0) or 0)
+                    if trail_qty is None:
                         trail_qty = 0
                 passed_symbols.append({
                     "symbol": sym,

--- a/src/community/programgarden_community/plugins/var_cvar_monitor/__init__.py
+++ b/src/community/programgarden_community/plugins/var_cvar_monitor/__init__.py
@@ -9,11 +9,28 @@ Value at Risk(VaR)와 Conditional VaR(CVaR, Expected Shortfall) 계산.
 - positions (선택): 보유 포지션 (list[dict]) — 달러 VaR 계산용
   예: [{"symbol": "AAPL", "current_price": 150.0, "qty": 100, ...}, ...]
 - fields: {lookback, confidence_level, var_method, time_horizon, alert_threshold_pct, action}
+
+미검증 경로 주의 — ``positions`` 인자
+------------------------------------
+이 플러그인은 ``required_data=["data"]`` 라 실행기에서 **data 기반 분기**로 돈다.
+그 분기(``ConditionNodeExecutor._execute_condition_plugin``, programgarden/executor.py)
+가 만드는 plugin_kwargs 는 ``{data, fields, field_mapping, symbols}`` 이고
+(시그니처에 ``context`` 가 있으면 context 추가, 그리고 인자로 들어온 경우에만
+``held_symbols``/``position_data``), **``positions`` 키는 없다** — 유일한 호출부
+(같은 파일 ``ConditionNodeExecutor.execute``)도 ``held_symbols``/``position_data``
+를 넘기지 않는다. 따라서 워크플로우 실행 경로에서 ``positions`` 는 항상 ``None``
+이고, ``var_dollar``/``position_value``/``reduce_position`` 의 ``sell_quantity``
+는 그 경로에서 **산출되지 않는다**(관측: 위 두 심볼의 코드 읽기, 2026-09-12).
+아래 positions 분기는 라이브러리를 직접 호출하는 코드와 테스트에서만 돈다 —
+즉 실행기 경로에 대해서는 미검증이다. (실행기가 positions 를 넘기게 하는 수정은
+이 플러그인의 범위 밖이다.)
 """
 
 from typing import List, Dict, Any, Optional, Set
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
+
+from .._position_qty import below_broker_lot, coerce_qty, half_position_qty
 
 
 # risk_features 선언
@@ -81,8 +98,12 @@ VAR_CVAR_MONITOR_SCHEMA = PluginSchema(
         "var_pct": {"type": "float", "description": "Value at Risk over the configured time horizon (%)"},
         "cvar_pct": {"type": "float", "description": "Conditional VaR (Expected Shortfall) over the time horizon (%)"},
         "breached": {"type": "bool", "description": "Whether VaR exceeds the alert threshold"},
-        "var_dollar": {"type": "float", "description": "Dollar VaR of the position (available when positions are provided)"},
-        "position_value": {"type": "float", "description": "Total position market value (available when positions are provided)"},
+        "var_dollar": {"type": "float", "description": "Dollar VaR of the position (available when positions are provided; fractional share counts are kept, not truncated)"},
+        "position_value": {"type": "float", "description": "Total position market value (available when positions are provided; fractional share counts are kept, not truncated)"},
+        "position_value_unavailable_reason": {"type": "str", "description": "Present instead of var_dollar/position_value when the held quantity or current price could not be read"},
+        "sell_quantity": {"type": "float", "description": "Quantity to sell - a number ONLY on the 'reduce_position' action: exactly half of the held quantity, never rounded up and never above the held quantity (fractional halves are kept; the order node truncates to the broker lot and reports the remainder). NOT always a number: on the 'exit_all' action this key carries the literal string \"all\" instead, meaning the whole position (that string is emitted on passed_symbols for the downstream order node to bind, never in symbol_results). Consumers must accept both shapes"},
+        "sell_quantity_unavailable_reason": {"type": "str", "description": "Present only when an action needing a quantity triggered but the held quantity could not be read, so no sell quantity was emitted"},
+        "reduce_skipped_reason": {"type": "str", "description": "Present when the 'reduce_position' half quantity is below 1 share: the order node truncates to the integer part (0) and builds no order, so the reduction silently does nothing this round"},
     },
     locales={
         "ko": {
@@ -247,14 +268,26 @@ async def var_cvar_monitor_condition(
             "breached": breached,
         }
 
-        # positions가 있으면 달러 VaR 계산
+        # positions가 있으면 달러 VaR 계산.
+        # 수량은 int() 로 자르지 않는다 — 0.532주(LS 해외주식 소수점 주식) 포지션이
+        # int(0.532)=0 이 되어 150달러 x 0.532 = 79.8달러짜리 포지션이 0.0 으로
+        # 보고됐다(관측: 이 파일의 수정 전 코드로 재현, 2026-09-12).
         if symbol in position_map:
             pos = position_map[symbol]
-            current_price = float(pos.get("current_price", 0))
-            qty = int(pos.get("qty", pos.get("quantity", 0)))
-            position_value = current_price * qty
-            result_info["var_dollar"] = round(position_value * var_nd, 2)
-            result_info["position_value"] = round(position_value, 2)
+            current_price = coerce_qty(pos.get("current_price", 0))
+            qty = coerce_qty(pos.get("qty", pos.get("quantity", 0)))
+            if current_price is None or qty is None:
+                # 못 읽은 값을 0 으로 뭉개면 '포지션 가치 0' 이라는 거짓 사실이 된다.
+                # 왜 못 실었는지를 남긴다 ('안 보낸 필드는 안 보냈다고 표시' 규약).
+                result_info["position_value_unavailable_reason"] = (
+                    "포지션 금액을 계산할 수 없음 "
+                    f"(current_price={pos.get('current_price')!r}, "
+                    f"qty={pos.get('qty', pos.get('quantity'))!r})"
+                )
+            else:
+                position_value = current_price * qty
+                result_info["var_dollar"] = round(position_value * var_nd, 2)
+                result_info["position_value"] = round(position_value, 2)
 
         all_vars.append(var_pct)
 
@@ -264,13 +297,45 @@ async def var_cvar_monitor_condition(
                 sym_dict["sell_quantity"] = "all"
             elif action == "reduce_position":
                 if symbol in position_map:
-                    qty = int(position_map[symbol].get("qty", position_map[symbol].get("quantity", 0)))
-                    sym_dict["sell_quantity"] = max(1, qty // 2)
+                    raw_qty = position_map[symbol].get(
+                        "qty", position_map[symbol].get("quantity", 0)
+                    )
+                    # 구 코드 ``max(1, qty // 2)`` 는 0.532주 보유에서 1주 매도를
+                    # 실어 보냈다(보유 초과). 공용 헬퍼로 통일 — 절단·바닥올림 없음,
+                    # 상한은 보유량 (_position_qty.half_position_qty).
+                    half = half_position_qty(raw_qty)
+                    if half is None:
+                        result_info["sell_quantity_unavailable_reason"] = (
+                            f"보유 수량을 읽을 수 없어 축소 수량을 싣지 않음 (qty={raw_qty!r})"
+                        )
+                    else:
+                        sym_dict["sell_quantity"] = half
+                        result_info["sell_quantity"] = half
+                        # 0 < 절반 < 1 이면 주문 송신부가 정수부 0 으로 접어 주문
+                        # 자체를 만들지 않는다(_position_qty.below_broker_lot).
+                        # 수량은 그대로 둔다 — 정수화·올림은 송신부의 규약이다.
+                        # 다만 '축소했다고 보고했는데 아무 일도 없었다' 를 없애기
+                        # 위해 사유를 드러낸다.
+                        if below_broker_lot(half):
+                            result_info["reduce_skipped_reason"] = (
+                                f"축소 수량 {half!r} 주는 1주 미만이라 주문 송신부가 정수부(0)로 "
+                                f"접어 주문을 만들지 않는다 — 보유 {raw_qty!r} 주에서 실제 축소가 "
+                                "일어나지 않는다"
+                            )
+                else:
+                    # positions 에 해당 종목이 없으면 수량을 지어내지 않는다.
+                    result_info["sell_quantity_unavailable_reason"] = (
+                        "positions 입력에 해당 종목이 없어 축소 수량을 싣지 않음"
+                    )
             passed.append(sym_dict)
 
             # risk_event 기록
             if context and hasattr(context, "risk_tracker") and context.risk_tracker:
                 try:
+                    # 🔴 record_event 는 실제 트래커에 없는 메서드다 (관측 2026-09-12):
+                    #    WorkflowRiskTracker 의 실제 이름은 record_risk_event 다. 아래 except 가
+                    #    AttributeError 를 삼키므로 이 위험 이벤트는 **한 건도 기록되지 않는다**.
+                    #    메서드명 정렬은 이 플러그인 밖(엔진) 수정이라 여기서 고치지 않는다 — 미검증.
                     context.risk_tracker.record_event(
                         event_type="var_breach",
                         symbol=symbol,

--- a/src/community/pyproject.toml
+++ b/src/community/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-community"
-version = "1.15.1"
+version = "1.15.2"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Community - 전략 플러그인 모음"
 readme = "README.md"

--- a/src/community/tests/test_beta_hedge_plugin.py
+++ b/src/community/tests/test_beta_hedge_plugin.py
@@ -1,5 +1,24 @@
 """
 BetaHedge (베타 헷지) 플러그인 테스트
+
+🔴 이 파일의 ``MockRiskTracker`` 는 **실제 클래스에 없는 메서드를 제공한다** (관측 2026-09-12)
+------------------------------------------------------------------------------------------
+실제 트래커 ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 의
+실제 인터페이스와 대조한 결과:
+
+| 목이 제공하는 이름 | 실제 클래스 | 비고 |
+|---|---|---|
+| ``get_state``   | **없음** | 실제 이름은 ``load_state`` (동기) |
+| ``set_state``   | **없음** | 실제 이름은 ``save_state`` (동기) |
+| ``delete_state``| 있음     | 단 **동기** 메서드 — 플러그인은 ``await`` 한다 |
+| ``record_event``| **없음** | 실제 이름은 ``record_risk_event`` |
+
+즉 아래 상태 관련 테스트들은 '플러그인이 라이브에서 실제로 상태를 저장·복원한다'
+를 증명하지 않는다 — **목이 약속한 계약대로 플러그인이 호출한다**는 것만 증명한다.
+라이브에서는 (가) 실제 트래커를 넘기면 ``AttributeError`` 로 죽고, (나) 애초에
+실행기가 positions 기반 플러그인에 ``context`` 를 넘기지 않아 상태 경로가 아예
+돌지 않는다(플러그인 모듈 docstring 의 '상태 경로' 절 참조).
+목을 실제 시그니처로 맞추는 수정은 이번 회차 범위 밖이다 — 후속 필요.
 """
 
 import pytest
@@ -12,6 +31,13 @@ from programgarden_community.plugins.beta_hedge import (
 
 
 class MockRiskTracker:
+    """strategy_state **목 계약** 모킹 — 실제 WorkflowRiskTracker 인터페이스가 아니다.
+
+    ``get_state``/``set_state`` 는 실제 클래스에 없는 이름이고(실제: ``load_state``/
+    ``save_state``, 둘 다 동기), ``delete_state`` 는 이름은 같지만 실제로는 동기
+    메서드다. 파일 상단 주석 참조.
+    """
+
     def __init__(self):
         self.state = {}
         self.events = []
@@ -239,3 +265,195 @@ class TestBetaHedgePlugin:
         assert analysis["target_beta"] == 0.8
         assert "portfolio_beta" in analysis
         assert "hedge_needed" in analysis
+
+
+class TestBetaHedgeFractionalPosition:
+    """소수 포지션 회귀 — 구 ``int(pos["qty"])`` 절단 (X3 전수확인에서 발견).
+
+    ⚠️ 이 분기(positions 인자)는 워크플로우 실행기 경로에서는 도달하지 않는다 —
+    실행기의 data 기반 분기가 plugin_kwargs 에 ``positions`` 를 넣지 않기 때문이다.
+    여기서 검증하는 것은 라이브러리 직접 호출 경로와 계산식 자체다.
+    """
+
+    @staticmethod
+    def _bars(n=130):
+        data = []
+        spy, tsla = 450.0, 200.0
+        for i in range(n):
+            move = 0.005 if i % 3 < 2 else -0.003
+            spy *= (1 + move)
+            tsla *= (1 + move * 2.0 + 0.001)
+            date = f"2026{(i // 30) + 1:02d}{(i % 30) + 1:02d}"
+            data.append({"symbol": "SPY", "exchange": "NYSE", "date": date, "close": round(spy, 2)})
+            data.append({"symbol": "TSLA", "exchange": "NASDAQ", "date": date, "close": round(tsla, 2)})
+        return data
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("qty,price", [(0.532, 150.0), (1, 150.0), (10, 150.0)])
+    async def test_weight_keeps_fractional_quantity(self, qty, price):
+        """0.532주 x 150달러 = 79.8 — 수정 전에는 int(0.532)=0 이라 weight 가 0.0 이었다."""
+        result = await beta_hedge_condition(
+            data=self._bars(),
+            fields={"lookback": 120, "market_symbol": "SPY"},
+            positions=[{"symbol": "TSLA", "current_price": price, "qty": qty}],
+        )
+        tsla = next(r for r in result["symbol_results"] if r["symbol"] == "TSLA")
+        assert tsla["weight"] == pytest.approx(price * qty, abs=0.01)
+        assert "weight_unavailable_reason" not in tsla
+
+    @pytest.mark.asyncio
+    async def test_fractional_position_still_weights_portfolio_beta(self):
+        """소수 포지션만 있어도 포트폴리오 베타가 0 으로 접히지 않는다.
+
+        수정 전에는 총 포지션 가치가 0 이라 ``total_value > 0`` 가 거짓이 되어
+        portfolio_beta 가 0 으로 떨어졌다.
+        """
+        result = await beta_hedge_condition(
+            data=self._bars(),
+            fields={"lookback": 120, "market_symbol": "SPY"},
+            positions=[{"symbol": "TSLA", "current_price": 150.0, "qty": 0.532}],
+        )
+        assert result["analysis"]["portfolio_beta"] != 0
+
+    @pytest.mark.asyncio
+    async def test_unreadable_quantity_leaves_reason_and_does_not_crash(self):
+        """문자열 쓰레기 수량 — 구 int() 는 ValueError 로 죽었다. 이제 사유를 남긴다."""
+        result = await beta_hedge_condition(
+            data=self._bars(),
+            fields={"lookback": 120, "market_symbol": "SPY"},
+            positions=[{"symbol": "TSLA", "current_price": 150.0, "qty": "n/a"}],
+        )
+        tsla = next(r for r in result["symbol_results"] if r["symbol"] == "TSLA")
+        assert "weight" not in tsla
+        assert "포지션 금액을 계산할 수 없음" in tsla["weight_unavailable_reason"]
+
+
+class TestBetaContributionSymmetry:
+    """Z2 — weight 와 beta_contribution 은 **같은 두 값**(수량·가격)에서 나온다.
+
+    구 코드는 weight 만 '못 읽으면 사유' 로 바꾸고, 바로 옆 beta_contribution 은
+    ``pos_value > 0`` 이 거짓이라는 이유로 0 을 지어냈다 — 같은 회차 안에서
+    "금액은 못 읽었는데 기여도는 0" 이라는 모순이 나왔다.
+    """
+
+    _bars = staticmethod(TestBetaHedgeFractionalPosition._bars)
+
+    async def _run(self, positions):
+        return await beta_hedge_condition(
+            data=self._bars(),
+            fields={"lookback": 120, "market_symbol": "SPY"},
+            positions=positions,
+        )
+
+    @pytest.mark.asyncio
+    async def test_unreadable_position_omits_contribution_with_reason(self):
+        result = await self._run([{"symbol": "TSLA", "current_price": 150.0, "qty": "n/a"}])
+        tsla = next(r for r in result["symbol_results"] if r["symbol"] == "TSLA")
+        assert "beta_contribution" not in tsla, "읽지 못한 값에서 기여도를 지어냈다"
+        assert "포지션 금액을 계산할 수 없음" in tsla["beta_contribution_unavailable_reason"]
+        # weight 와 정확히 같은 사유를 쓴다 — 두 필드의 가용성이 갈라지지 않는다
+        assert tsla["beta_contribution_unavailable_reason"] == tsla["weight_unavailable_reason"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("bad", [{"qty": "n/a"}, {"current_price": "-"}, {"qty": None}])
+    async def test_weight_and_contribution_are_available_together(self, bad):
+        pos = {"symbol": "TSLA", "current_price": 150.0, "qty": 3}
+        pos.update(bad)
+        result = await self._run([pos])
+        tsla = next(r for r in result["symbol_results"] if r["symbol"] == "TSLA")
+        assert ("weight" in tsla) == ("beta_contribution" in tsla)
+        assert (
+            "weight_unavailable_reason" in tsla
+        ) == ("beta_contribution_unavailable_reason" in tsla)
+
+    @pytest.mark.asyncio
+    async def test_readable_position_still_reports_contribution(self):
+        result = await self._run([{"symbol": "TSLA", "current_price": 150.0, "qty": 0.532}])
+        tsla = next(r for r in result["symbol_results"] if r["symbol"] == "TSLA")
+        assert tsla["weight"] == pytest.approx(79.8, abs=0.01)
+        assert tsla["beta_contribution"] == pytest.approx(tsla["beta"] * 79.8, abs=0.05)
+        assert "beta_contribution_unavailable_reason" not in tsla
+
+    @pytest.mark.asyncio
+    async def test_readable_zero_value_keeps_contribution_zero(self):
+        """수량 0 은 **읽은 값**이다 — beta x 0 = 0 은 계산 결과이지 지어낸 값이 아니다."""
+        result = await self._run([{"symbol": "TSLA", "current_price": 150.0, "qty": 0}])
+        tsla = next(r for r in result["symbol_results"] if r["symbol"] == "TSLA")
+        assert tsla["weight"] == 0
+        assert tsla["beta_contribution"] == 0
+        assert "beta_contribution_unavailable_reason" not in tsla
+
+    def test_schema_declares_the_reason(self):
+        assert "beta_contribution_unavailable_reason" in BETA_HEDGE_SCHEMA.output_fields
+
+
+class TestPortfolioBetaIsNotFabricated:
+    """Z2 — 읽힌 포지션이 하나도 없어 total_value 가 0 이면 portfolio 값도 지어내지 않는다.
+
+    구 코드는 ``weighted_beta / total_value if total_value > 0 else 0`` 으로 0 을
+    실었고, 그 0 이 ``beta_deviation = 0 - target_beta`` 를 지나
+    ``hedge_needed=True`` 라는 **거짓 신호**까지 만들었다(target_beta 기본 1.0,
+    tolerance 0.2 에서 |−1.0| > 0.2).
+    """
+
+    _bars = staticmethod(TestBetaHedgeFractionalPosition._bars)
+
+    async def _run(self, positions, **fields):
+        f = {"lookback": 120, "market_symbol": "SPY"}
+        f.update(fields)
+        return await beta_hedge_condition(data=self._bars(), fields=f, positions=positions)
+
+    @pytest.mark.asyncio
+    async def test_all_positions_unreadable_leaves_reason(self):
+        result = await self._run([{"symbol": "TSLA", "current_price": 150.0, "qty": "n/a"}])
+        analysis = result["analysis"]
+        assert "portfolio_beta" not in analysis, "계산되지 않은 베타를 0 으로 실었다"
+        assert "가중치 합" in analysis["portfolio_beta_unavailable_reason"]
+        assert "TSLA" in analysis["portfolio_beta_unavailable_reason"]
+        assert analysis["hedge_needed_undetermined"] is True
+        assert analysis["hedge_needed"] is False
+        assert result["result"] is False
+
+    @pytest.mark.asyncio
+    async def test_no_fabricated_hedge_signal(self):
+        """구 코드에서는 여기서 hedge_needed=True 가 나왔다 (portfolio_beta 0 발)."""
+        result = await self._run(
+            [{"symbol": "TSLA", "current_price": 150.0, "qty": "n/a"}],
+            target_beta=1.0, beta_tolerance=0.2,
+        )
+        assert result["analysis"]["hedge_needed"] is False
+        assert result["passed_symbols"] == []
+
+    @pytest.mark.asyncio
+    async def test_unavailable_portfolio_beta_is_not_put_in_time_series(self):
+        result = await self._run([{"symbol": "TSLA", "current_price": 150.0, "qty": "n/a"}])
+        for v in result["values"]:
+            for row in v["time_series"]:
+                assert "portfolio_beta" not in row
+
+    @pytest.mark.asyncio
+    async def test_unavailable_portfolio_beta_is_not_saved_to_state(self):
+        ctx = MockContext()
+        await beta_hedge_condition(
+            data=self._bars(),
+            fields={"lookback": 120, "market_symbol": "SPY"},
+            positions=[{"symbol": "TSLA", "current_price": 150.0, "qty": "n/a"}],
+            context=ctx,
+        )
+        assert "portfolio_beta" not in ctx.risk_tracker.state
+
+    @pytest.mark.asyncio
+    async def test_readable_position_still_reports_portfolio_beta(self):
+        result = await self._run([{"symbol": "TSLA", "current_price": 150.0, "qty": 0.532}])
+        assert result["analysis"]["portfolio_beta"] != 0
+        assert "portfolio_beta_unavailable_reason" not in result["analysis"]
+        assert "hedge_needed_undetermined" not in result["analysis"]
+
+    @pytest.mark.asyncio
+    async def test_no_positions_still_uses_equal_weight(self):
+        """positions 자체가 없으면 종전대로 동일 비중 가정 — 사유 분기가 아니다."""
+        result = await beta_hedge_condition(
+            data=self._bars(), fields={"lookback": 120, "market_symbol": "SPY"},
+        )
+        assert "portfolio_beta" in result["analysis"]
+        assert "portfolio_beta_unavailable_reason" not in result["analysis"]

--- a/src/community/tests/test_drawdown_protection_plugin.py
+++ b/src/community/tests/test_drawdown_protection_plugin.py
@@ -150,3 +150,194 @@ class TestDrawdownProtectionPlugin:
         )
         for sr in result["symbol_results"]:
             assert sr["exchange"] == "NASDAQ"  # market_code "82" → NASDAQ
+
+
+class TestReduceHalfQuantity:
+    """'reduce_half'(절반 축소)가 보유량을 넘지 않고 소수 잔량도 보존해야 한다.
+
+    구 코드는 ``max(1, int(qty) // 2)`` 였다:
+    - 0.532주 보유 → ``int(0.532)//2 = 0`` → ``max(1,0) = 1`` → **보유 0.532 인데 1주 매도**
+    - 1주 보유 → 같은 경로로 1 → '절반 축소'가 사실상 전량 매도
+    LS 는 해외주식 소수점 주식을 지원한다(출처: 오너 진술 2026-09-12).
+    정수화는 주문 송신부(_normalize_order)의 규약이므로 플러그인은 자르지 않는다.
+    """
+
+    @staticmethod
+    async def _run(qty):
+        return await drawdown_protection_condition(
+            positions=[{
+                "symbol": "AAPL", "pnl_rate": -15.0, "current_price": 131.25,
+                "qty": qty, "market_code": "82",
+            }],
+            fields={"max_drawdown_pct": -10.0, "action": "reduce_half"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_fractional_position_does_not_oversell(self):
+        result = await self._run(0.532)
+        sym = result["passed_symbols"][0]
+        assert sym["sell_quantity"] == pytest.approx(0.266)  # 구 코드는 1 (보유 초과)
+        assert sym["sell_quantity"] <= 0.532
+
+    @pytest.mark.asyncio
+    async def test_decimal_fractional_position(self):
+        from decimal import Decimal
+
+        result = await self._run(Decimal("0.532"))
+        assert result["passed_symbols"][0]["sell_quantity"] == pytest.approx(0.266)
+
+    @pytest.mark.asyncio
+    async def test_single_share_sells_half_not_all(self):
+        result = await self._run(1)
+        sym = result["passed_symbols"][0]
+        assert sym["sell_quantity"] == pytest.approx(0.5)  # 구 코드는 1 (전량)
+        assert sym["sell_quantity"] < 1
+
+    @pytest.mark.asyncio
+    async def test_integer_position_halves_as_int(self):
+        result = await self._run(10)
+        sym = result["passed_symbols"][0]
+        assert sym["sell_quantity"] == 5
+        assert isinstance(sym["sell_quantity"], int)  # 직렬화 모양 유지
+
+    @pytest.mark.asyncio
+    async def test_odd_integer_position_keeps_remainder(self):
+        """홀수 보유(9)는 4.5 — 바닥/올림 모두 하지 않는다(하류가 정수부만 주문)."""
+        result = await self._run(9)
+        assert result["passed_symbols"][0]["sell_quantity"] == pytest.approx(4.5)
+
+    @pytest.mark.asyncio
+    async def test_unreadable_quantity_emits_reason_not_a_guess(self):
+        """수량을 읽을 수 없으면 수량을 지어내지 않고 사유를 남긴다."""
+        result = await self._run("abc")
+        sym = result["passed_symbols"][0]
+        assert "sell_quantity" not in sym
+        sr = result["symbol_results"][0]
+        assert "sell_quantity_unavailable_reason" in sr
+        assert "abc" in sr["sell_quantity_unavailable_reason"]
+
+    @pytest.mark.asyncio
+    async def test_zero_quantity_emits_reason(self):
+        result = await self._run(0)
+        assert "sell_quantity" not in result["passed_symbols"][0]
+        assert "sell_quantity_unavailable_reason" in result["symbol_results"][0]
+
+    @pytest.mark.asyncio
+    async def test_quantity_key_alias_is_read(self):
+        """'qty' 가 없고 'quantity' 만 있는 포지션도 절반 계산이 된다."""
+        result = await drawdown_protection_condition(
+            positions=[{
+                "symbol": "AAPL", "pnl_rate": -15.0, "current_price": 131.25,
+                "quantity": 7, "market_code": "82",
+            }],
+            fields={"max_drawdown_pct": -10.0, "action": "reduce_half"},
+        )
+        assert result["passed_symbols"][0]["sell_quantity"] == pytest.approx(3.5)
+
+    @pytest.mark.asyncio
+    async def test_other_actions_do_not_carry_sell_quantity(self):
+        """exit_all 은 종전대로 sell_quantity 를 싣지 않는다(회귀 방지)."""
+        result = await drawdown_protection_condition(
+            positions=[{
+                "symbol": "AAPL", "pnl_rate": -15.0, "current_price": 131.25,
+                "qty": 10, "market_code": "82",
+            }],
+            fields={"max_drawdown_pct": -10.0, "action": "exit_all"},
+        )
+        assert "sell_quantity" not in result["passed_symbols"][0]
+
+
+class TestReduceHalfBelowOneShareIsNotSilent:
+    """Z4 — 절반 축소 수량이 1주 미만이면 **주문이 만들어지지 않는다**는 사실을 드러낸다.
+
+    주문 송신부 ``NewOrderNodeExecutor._normalize_order`` 는 ``int(raw_quantity)``
+    로 정수부만 주문하고, 정수부가 0 이면 ``None`` 을 돌려 주문을 만들지 않는다.
+    라이브 실측(executor 직접 호출, 2026-09-12):
+    quantity 0.5 → None, 0.999 → None, 1.0 → quantity 1,
+    1.5 → quantity 1 + fractional_remainder 0.5.
+
+    따라서 1주 보유에서 reduce_half(=0.5주)는 **아무 일도 일어나지 않는다**.
+    이번 수정은 동작을 바꾸지 않는다(수량은 그대로 0.5) — 그 무동작이
+    ``reduce_skipped_reason`` 으로 드러나게만 한다. 정책(현행 유지 / 전량 청산
+    승격 / 알림)은 오너 판단 사항이다.
+    """
+
+    @staticmethod
+    async def _run(qty):
+        return await drawdown_protection_condition(
+            positions=[{
+                "symbol": "AAPL", "pnl_rate": -15.0, "current_price": 131.25,
+                "qty": qty, "market_code": "82",
+            }],
+            fields={"max_drawdown_pct": -10.0, "action": "reduce_half"},
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("qty,half", [(1, 0.5), (0.532, 0.266), (1.9, 0.95)])
+    async def test_sub_one_share_half_leaves_reason(self, qty, half):
+        result = await self._run(qty)
+        sr = result["symbol_results"][0]
+        assert sr["sell_quantity"] == pytest.approx(half), "수량을 올리거나 자르지 않는다"
+        assert result["passed_symbols"][0]["sell_quantity"] == pytest.approx(half)
+        assert "1주 미만" in sr["reduce_skipped_reason"]
+        assert repr(qty) in sr["reduce_skipped_reason"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("qty", [2, 10, 3.5])
+    async def test_one_share_or_more_has_no_reason(self, qty):
+        result = await self._run(qty)
+        sr = result["symbol_results"][0]
+        assert sr["sell_quantity"] >= 1
+        assert "reduce_skipped_reason" not in sr
+
+    @pytest.mark.asyncio
+    async def test_unreadable_quantity_is_a_different_event(self):
+        """'못 읽음' 은 축소 무동작과 다른 사건 — 사유 키가 갈린다."""
+        result = await self._run("n/a")
+        sr = result["symbol_results"][0]
+        assert "sell_quantity_unavailable_reason" in sr
+        assert "reduce_skipped_reason" not in sr
+        assert "sell_quantity" not in sr
+
+    @pytest.mark.asyncio
+    async def test_exit_all_action_is_untouched(self):
+        """reduce_half 전용 사유다 — 다른 action 에는 붙지 않는다."""
+        result = await drawdown_protection_condition(
+            positions=[{
+                "symbol": "AAPL", "pnl_rate": -15.0, "current_price": 131.25,
+                "qty": 1, "market_code": "82",
+            }],
+            fields={"max_drawdown_pct": -10.0, "action": "exit_all"},
+        )
+        sr = result["symbol_results"][0]
+        assert "reduce_skipped_reason" not in sr
+
+    def test_schema_declares_the_reason(self):
+        assert "reduce_skipped_reason" in DRAWDOWN_PROTECTION_SCHEMA.output_fields
+
+
+class TestOrderSenderTruncationIsReal:
+    """Z4 전제의 라이브 고정 — 0 < 수량 < 1 이면 주문이 만들어지지 않는다.
+
+    이 사실은 추정이 아니라 엔진 송신부를 직접 호출해 확인한 것이다. 엔진이
+    설치되지 않은 환경에서는 skip 된다.
+    """
+
+    def test_normalize_order_builds_nothing_below_one_share(self):
+        executor_mod = pytest.importorskip(
+            "programgarden.executor",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        ex = executor_mod.NewOrderNodeExecutor()
+
+        def norm(q):
+            return ex._normalize_order(
+                {"symbol": "AAPL", "exchange": "NASDAQ", "quantity": q, "price": 10.0}, {}
+            )
+
+        assert norm(0.5) is None, "0.5주 주문이 만들어졌다 — Z4 전제가 바뀌었다"
+        assert norm(0.999) is None
+        assert norm(1.0)["quantity"] == 1
+        floored = norm(1.5)
+        assert floored["quantity"] == 1
+        assert floored["fractional_remainder"] == pytest.approx(0.5)

--- a/src/community/tests/test_dynamic_stop_loss_plugin.py
+++ b/src/community/tests/test_dynamic_stop_loss_plugin.py
@@ -190,5 +190,80 @@ class TestDynamicStopLossPlugin:
         assert ps["close_side"] == "sell"
 
 
+
+class TestUnreadablePositionValues:
+    """V2 [MAJOR] — pos_data 원값이 ``atr = current_price * 0.02`` / ``current_price <= stop_price``
+    에 그대로 들어가 'n/a' → TypeError, None → TypeError 로 죽던 경로(실측 2026-09-12).
+    이제 연산 전에 읽고, 못 읽으면 계산하지 않고 action='skip' + 사유를 남긴다.
+    (전수 계약은 test_position_field_coercion_regression.py 가 잠근다 — 여기는 이 플러그인의
+    구체 사례 기록.)
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raw", ["n/a", None], ids=repr)
+    async def test_unreadable_current_price_is_skipped_with_reason(self, raw):
+        result = await dynamic_stop_loss_condition(
+            data=[],
+            positions=[{"symbol": "AAPL", "current_price": raw, "avg_price": 140, "qty": 10, "market_code": "82"}],
+            fields={"atr_period": 14, "atr_multiplier": 2.0},
+        )
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "skip"
+        assert f"current_price={raw!r}" in sr["reason"]
+        assert "atr" not in sr and "stop_price" not in sr  # 계산하지 않았다
+        assert result["passed_symbols"] == []
+        assert result["failed_symbols"][0]["symbol"] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_avg_price_is_skipped_not_faked(self):
+        result = await dynamic_stop_loss_condition(
+            data=[],
+            positions=[{"symbol": "AAPL", "current_price": 150, "avg_price": "n/a", "qty": 10, "market_code": "82"}],
+            fields={},
+        )
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "skip"
+        assert "avg_price='n/a'" in sr["reason"]
+
+    @pytest.mark.asyncio
+    async def test_missing_avg_price_falls_back_to_current_price_and_says_so(self):
+        """avg_price 가 아예 없으면 종전대로 현재가를 기준가로 쓰되, 없는 값을 평단으로 싣지 않는다."""
+        result = await dynamic_stop_loss_condition(
+            data=[],
+            positions=[{"symbol": "AAPL", "current_price": 150, "qty": 10, "market_code": "82"}],
+            fields={},
+        )
+        sr = result["symbol_results"][0]
+        assert sr["reference_price"] == 150
+        assert "avg_price" not in sr
+        assert "avg_price=None" in sr["avg_price_unavailable_reason"]
+
+    @pytest.mark.asyncio
+    async def test_unreadable_quantity_is_skipped_with_reason(self):
+        result = await dynamic_stop_loss_condition(
+            data=[],
+            positions=[{"symbol": "AAPL", "current_price": 120, "avg_price": 150, "qty": "n/a", "market_code": "82"}],
+            fields={},
+        )
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "skip"
+        assert "quantity='n/a'" in sr["reason"]
+        assert result["passed_symbols"] == []  # 수량 없는 청산 주문을 싣지 않는다
+
+    @pytest.mark.asyncio
+    async def test_numeric_string_price_is_evaluated_like_number(self):
+        num = await dynamic_stop_loss_condition(
+            data=[], fields={},
+            positions=[{"symbol": "AAPL", "current_price": 120.0, "avg_price": 150.0, "qty": 10, "market_code": "82"}],
+        )
+        txt = await dynamic_stop_loss_condition(
+            data=[], fields={},
+            positions=[{"symbol": "AAPL", "current_price": "120.0", "avg_price": "150.0", "qty": "10", "market_code": "82"}],
+        )
+        assert txt["symbol_results"] == num["symbol_results"]
+        assert txt["passed_symbols"] == num["passed_symbols"]
+        assert txt["result"] is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/src/community/tests/test_max_position_limit_plugin.py
+++ b/src/community/tests/test_max_position_limit_plugin.py
@@ -129,5 +129,70 @@ class TestMaxPositionLimitPlugin:
         assert "action" in MAX_POSITION_LIMIT_SCHEMA.fields_schema
 
 
+
+class TestUnreadablePositionValues:
+    """V3 [MAJOR] — ``market_value = current_price * qty`` 뒤 ``float(market_value)`` 였던 경로.
+
+    current_price='150.0'(정상 숫자 문자열)/qty=100 이면 곱셈이 문자열 반복('150.0'×100)이
+    되고 float() 에서 ValueError 로 죽었다(실측 2026-09-12) — **정상값으로도** 죽었다.
+    'n/a'·None 은 곱셈에서 TypeError. (전수 계약은 test_position_field_coercion_regression.py.)
+    """
+
+    @pytest.mark.asyncio
+    async def test_numeric_string_price_no_longer_repeats_string(self):
+        result = await max_position_limit_condition(
+            positions=[{"symbol": "AAPL", "current_price": "150.0", "qty": 100, "market_code": "82"}],
+            fields={"max_positions": 10},
+        )
+        sr = result["symbol_results"][0]
+        assert sr["market_value"] == 15000.0
+        assert sr["current_price"] == 150.0
+        assert result["analysis"]["total_value"] == 15000.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("raw", ["n/a", None], ids=repr)
+    async def test_unreadable_price_without_market_value_is_skipped_with_reason(self, raw):
+        result = await max_position_limit_condition(
+            positions=[
+                {"symbol": "AAPL", "current_price": raw, "qty": 100, "market_code": "82"},
+                {"symbol": "MSFT", "current_price": 400, "qty": 5, "market_code": "82"},
+            ],
+            fields={"max_positions": 10, "max_single_weight_pct": 50},
+        )
+        aapl = next(sr for sr in result["symbol_results"] if sr["symbol"] == "AAPL")
+        assert aapl["action_taken"] == "skip"
+        assert f"current_price={raw!r}" in aapl["reason"]
+        assert "market_value" not in aapl and "weight_pct" not in aapl  # 0 으로 지어내지 않는다
+        # 못 읽은 포지션은 총액·비중에서 빠진다 — MSFT 가 100% 가 된다(그게 읽은 값의 사실이다).
+        msft = next(sr for sr in result["symbol_results"] if sr["symbol"] == "MSFT")
+        assert msft["weight_pct"] == 100.0
+        assert result["analysis"]["total_value"] == 2000.0
+        assert result["analysis"]["unreadable_count"] == 1
+        assert result["analysis"]["position_count"] == 2  # 포지션인 건 사실이다
+
+    @pytest.mark.asyncio
+    async def test_unreadable_qty_is_skipped_with_reason(self):
+        result = await max_position_limit_condition(
+            positions=[{"symbol": "AAPL", "current_price": 150.0, "qty": "n/a", "market_code": "82"}],
+            fields={},
+        )
+        sr = result["symbol_results"][0]
+        assert sr["action_taken"] == "skip"
+        assert "qty='n/a'" in sr["reason"]
+        assert result["passed_symbols"] == []
+
+    @pytest.mark.asyncio
+    async def test_unreadable_price_with_readable_market_value_still_evaluates(self):
+        """market_value 로 금액은 읽혔다 — 현재가만 표시에서 빠지고 사유가 남는다."""
+        result = await max_position_limit_condition(
+            positions=[{"symbol": "AAPL", "current_price": "n/a", "qty": 100, "market_value": 15000, "market_code": "82"}],
+            fields={},
+        )
+        sr = result["symbol_results"][0]
+        assert sr["market_value"] == 15000.0
+        assert "current_price" not in sr
+        assert "current_price='n/a'" in sr["current_price_unavailable_reason"]
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/src/community/tests/test_partial_tp_plugin.py
+++ b/src/community/tests/test_partial_tp_plugin.py
@@ -1,5 +1,24 @@
 """
 PartialTakeProfit 플러그인 테스트
+
+🔴 이 파일의 ``MockRiskTracker`` 는 **실제 클래스에 없는 메서드를 제공한다** (관측 2026-09-12)
+------------------------------------------------------------------------------------------
+실제 트래커 ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 의
+실제 인터페이스와 대조한 결과:
+
+| 목이 제공하는 이름 | 실제 클래스 | 비고 |
+|---|---|---|
+| ``get_state``   | **없음** | 실제 이름은 ``load_state`` (동기) |
+| ``set_state``   | **없음** | 실제 이름은 ``save_state`` (동기) |
+| ``delete_state``| 있음     | 단 **동기** 메서드 — 플러그인은 ``await`` 한다 |
+| ``record_event``| **없음** | 실제 이름은 ``record_risk_event`` |
+
+즉 아래 상태 관련 테스트들은 '플러그인이 라이브에서 실제로 상태를 저장·복원한다'
+를 증명하지 않는다 — **목이 약속한 계약대로 플러그인이 호출한다**는 것만 증명한다.
+라이브에서는 (가) 실제 트래커를 넘기면 ``AttributeError`` 로 죽고, (나) 애초에
+실행기가 positions 기반 플러그인에 ``context`` 를 넘기지 않아 상태 경로가 아예
+돌지 않는다(플러그인 모듈 docstring 의 '상태 경로' 절 참조).
+목을 실제 시그니처로 맞추는 수정은 이번 회차 범위 밖이다 — 후속 필요.
 """
 
 import pytest
@@ -10,7 +29,12 @@ from programgarden_community.plugins.partial_take_profit import (
 
 
 class MockRiskTracker:
-    """strategy_state 모킹"""
+    """strategy_state **목 계약** 모킹 — 실제 WorkflowRiskTracker 인터페이스가 아니다.
+
+    ``get_state``/``set_state`` 는 실제 클래스에 없는 이름이고(실제: ``load_state``/
+    ``save_state``, 둘 다 동기), ``delete_state`` 는 이름은 같지만 실제로는 동기
+    메서드다. 파일 상단 주석 참조.
+    """
     def __init__(self):
         self._state = {}
 
@@ -33,7 +57,7 @@ class TestPartialTakeProfitPlugin:
 
     @pytest.mark.asyncio
     async def test_level_triggered(self):
-        """1단계 익절 트리거"""
+        """1단계 익절 트리거 (context 경로는 목 계약 — 라이브에서는 context 가 오지 않는다)"""
         tracker = MockRiskTracker()
         context = MockContext(tracker)
 
@@ -67,7 +91,7 @@ class TestPartialTakeProfitPlugin:
 
     @pytest.mark.asyncio
     async def test_completed_level_skip(self):
-        """완료된 단계 건너뛰기"""
+        """[목 계약 — 라이브 아님] 완료된 단계 건너뛰기 — 목이 복원해 준 completed_levels 를 플러그인이 읽는지만 본다"""
         tracker = MockRiskTracker()
         tracker._state["partial_tp.AAPL.completed_levels"] = [0]
         tracker._state["partial_tp.AAPL.original_qty"] = 100
@@ -86,7 +110,7 @@ class TestPartialTakeProfitPlugin:
 
     @pytest.mark.asyncio
     async def test_second_level_triggered(self):
-        """2단계 익절 트리거 (1단계 완료 상태)"""
+        """[목 계약 — 라이브 아님] 2단계 익절 트리거 (1단계 완료 상태) — 상태 복원은 목이 해 준 것이다"""
         tracker = MockRiskTracker()
         tracker._state["partial_tp.AAPL.completed_levels"] = [0]
         tracker._state["partial_tp.AAPL.original_qty"] = 100
@@ -107,7 +131,7 @@ class TestPartialTakeProfitPlugin:
 
     @pytest.mark.asyncio
     async def test_position_closed_clears_state(self):
-        """포지션 청산 시 상태 삭제"""
+        """[목 계약 — 라이브 아님] 포지션 청산 시 상태 삭제 — 실제 delete_state 는 동기라 await 하면 라이브에서 죽는다"""
         tracker = MockRiskTracker()
         tracker._state["partial_tp.AAPL.completed_levels"] = [0]
         tracker._state["partial_tp.AAPL.original_qty"] = 100
@@ -122,7 +146,11 @@ class TestPartialTakeProfitPlugin:
 
     @pytest.mark.asyncio
     async def test_without_context(self):
-        """context 없이 실행 (상태 관리 없음)"""
+        """context 없이 실행 — **이것이 현재 라이브 실행기의 실제 모습이다**
+
+        실행기의 positions 분기가 context 를 넘기지 않으므로 라이브는 항상 이
+        경로다. 매 호출이 level_index=0 을 다시 트리거한다(상태 없음).
+        """
         positions = [
             {"symbol": "AAPL", "pnl_rate": 8.0, "qty": 100, "market_code": "82"},
         ]
@@ -191,5 +219,283 @@ class TestSellQuantityWiring:
         assert ps["quantity"] == 2  # 4 * 50%
 
 
+class TestFractionalPartialQuantity:
+    """소수 포지션의 부분 익절이 절단돼 사라지면 안 된다.
+
+    구 코드는 ``int(original_qty * sell_pct / 100)`` 이라 0.532주 × 50% = 0.266 이
+    0 으로 잘렸고, ``if sell_quantity > 0`` 게이트에 걸려 단계가 통째로
+    건너뛰어졌다(상태도 갱신되지 않아 매 실행 반복). LS 는 해외주식 소수점 주식을
+    지원한다(출처: 오너 진술 2026-09-12). 정수화는 주문 송신부
+    (_normalize_order)의 명시적 규약이다 — 정수부만 주문하고 잔량은
+    fractional_remainder 로, 정수부가 0 이면 FRACTIONAL_ONLY 로 사유를 남긴다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fractional_position_is_not_skipped(self):
+        positions = [
+            {"symbol": "AAPL", "pnl_rate": 6.0, "qty": 0.532, "market_code": "82"},
+        ]
+        result = await partial_take_profit_condition(
+            positions=positions,
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": 50}]},
+        )
+        assert result["result"] is True  # 구 코드는 False (조용한 스킵)
+        ps = result["passed_symbols"][0]
+        assert ps["quantity"] == pytest.approx(0.266)
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "sell"
+        assert sr["sell_quantity"] == pytest.approx(0.266)
+
+    @pytest.mark.asyncio
+    async def test_decimal_quantity_position(self):
+        from decimal import Decimal
+
+        positions = [
+            {"symbol": "AAPL", "pnl_rate": 6.0, "qty": Decimal("0.532"), "market_code": "82"},
+        ]
+        result = await partial_take_profit_condition(
+            positions=positions,
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": 50}]},
+        )
+        assert result["passed_symbols"][0]["quantity"] == pytest.approx(0.266)
+
+    @pytest.mark.asyncio
+    async def test_fractional_remainder_of_integer_position(self):
+        """9주 × 30% = 2.7 — 2 로 자르지 않는다(잔량 판단은 주문 송신부 몫)."""
+        positions = [
+            {"symbol": "AAPL", "pnl_rate": 6.0, "qty": 9, "market_code": "82"},
+        ]
+        result = await partial_take_profit_condition(
+            positions=positions,
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": 30}]},
+        )
+        assert result["passed_symbols"][0]["quantity"] == pytest.approx(2.7)
+
+    @pytest.mark.asyncio
+    async def test_integer_result_stays_int(self):
+        """정수로 떨어지면 종전대로 int (직렬화 모양 유지)."""
+        positions = [
+            {"symbol": "AAPL", "pnl_rate": 6.0, "qty": 100, "market_code": "82"},
+        ]
+        result = await partial_take_profit_condition(
+            positions=positions,
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": 50}]},
+        )
+        qty = result["passed_symbols"][0]["quantity"]
+        assert qty == 50 and isinstance(qty, int)
+
+    @pytest.mark.asyncio
+    async def test_never_exceeds_held_quantity(self):
+        """기준 수량이 보유량보다 커도 보유량 상한을 넘지 않는다(기존 가드 유지)."""
+        tracker = MockRiskTracker()
+        tracker._state["partial_tp.AAPL.original_qty"] = 100
+        context = MockContext(tracker)
+        positions = [
+            {"symbol": "AAPL", "pnl_rate": 6.0, "qty": 3, "market_code": "82"},
+        ]
+        result = await partial_take_profit_condition(
+            positions=positions,
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": 90}]},  # 100*90% = 90 > 보유 3
+            context=context,
+        )
+        assert result["passed_symbols"][0]["quantity"] == 3
+
+    @pytest.mark.asyncio
+    async def test_decimal_original_qty_state_is_used(self):
+        """[목 계약 — 라이브 아님] Decimal 로 저장된 기준 수량도 읽는다(구 isinstance(int,float) 는 놓쳤다).
+
+        라이브에서는 get_state 가 아예 호출되지 않으므로(모듈 docstring 참조) 이
+        분기는 목 위에서만 검증된다.
+        """
+        from decimal import Decimal
+
+        tracker = MockRiskTracker()
+        tracker._state["partial_tp.AAPL.original_qty"] = Decimal("10")
+        tracker._state["partial_tp.AAPL.completed_levels"] = [0]
+        context = MockContext(tracker)
+        positions = [
+            {"symbol": "AAPL", "pnl_rate": 11.0, "qty": 5, "market_code": "82"},
+        ]
+        result = await partial_take_profit_condition(
+            positions=positions,
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": 50},
+                               {"pnl_pct": 10, "sell_pct": 30}]},
+            context=context,
+        )
+        # 기준 10 × 30% = 3 (현재 보유 5 기준이면 1.5 가 나온다)
+        assert result["passed_symbols"][0]["quantity"] == 3
+
+    @pytest.mark.asyncio
+    async def test_zero_sell_pct_leaves_reason(self):
+        """진짜 0 인 경우는 스킵하되 숫자가 담긴 사유를 남긴다."""
+        positions = [
+            {"symbol": "AAPL", "pnl_rate": 6.0, "qty": 10, "market_code": "82"},
+        ]
+        result = await partial_take_profit_condition(
+            positions=positions,
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": 0}]},
+        )
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "skip"
+        assert sr["sell_quantity"] == 0
+        assert "0" in sr["reason"] and "10" in sr["reason"]
+
+    @pytest.mark.asyncio
+    async def test_unreadable_sell_pct_leaves_reason(self):
+        """비율을 읽을 수 없으면 수량을 지어내지 않고 사유를 남긴다."""
+        positions = [
+            {"symbol": "AAPL", "pnl_rate": 6.0, "qty": 10, "market_code": "82"},
+        ]
+        result = await partial_take_profit_condition(
+            positions=positions,
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": "절반"}]},
+        )
+        assert result["result"] is False
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "skip"
+        assert "읽을 수 없어" in sr["reason"]
+        assert "sell_quantity" not in sr
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestLiveStatePathIsDead:
+    """상태 경로가 라이브에서 죽어 있다는 **실제 동작**을 고정한다 (X4, 관측 2026-09-12).
+
+    실행기의 positions 기반 분기(``ConditionNodeExecutor.execute``)는 plugin_kwargs
+    를 ``{"positions", "fields"}`` 로 고정해 ``context`` 를 넘기지 않는다. 따라서
+    라이브 호출은 항상 context=None 이고, 아래처럼 같은 단계가 매 사이클 재발동한다.
+
+    이 테스트가 초록인 것은 '정상' 이라는 뜻이 아니라 '아직 깨진 채다' 라는 뜻이다.
+    실행기가 context 를 넘기도록 고쳐지면 이 테스트가 빨개져야 하고, 그때 플러그인
+    docstring 의 '미검증' 문구도 함께 걷어내면 된다. 근본 수정은 이번 회차 범위 밖.
+    """
+
+    @pytest.mark.asyncio
+    async def test_same_level_retriggers_every_cycle_without_context(self):
+        positions = [{"symbol": "AAPL", "pnl_rate": 6.0, "qty": 100, "market_code": "82"}]
+        levels = [{"pnl_pct": 5, "sell_pct": 50}]
+
+        seen = []
+        for _ in range(3):
+            result = await partial_take_profit_condition(
+                positions=positions, fields={"levels": levels},
+            )
+            sr = result["symbol_results"][0]
+            seen.append((sr["level_index"], sr["sell_quantity"]))
+
+        assert seen == [(0, 50), (0, 50), (0, 50)], (
+            "상태가 저장·복원되지 않아 매 사이클 같은 단계가 재발동한다. "
+            f"관측: {seen}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_would_crash_on_the_state_path(self):
+        """실제 트래커를 넘기면 상태 경로가 AttributeError 로 즉사한다."""
+        mod = pytest.importorskip(
+            "programgarden.database.workflow_risk_tracker",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        import tempfile, os
+
+        tracker = mod.WorkflowRiskTracker(
+            db_path=os.path.join(tempfile.mkdtemp(), "rt.db"),
+            job_id="pin", product="overseas_stock", provider="ls",
+            trading_mode="real", features={"state"},
+        )
+
+        class RealCtx:
+            risk_tracker = tracker
+
+        with pytest.raises(AttributeError, match="get_state"):
+            await partial_take_profit_condition(
+                positions=[{"symbol": "AAPL", "pnl_rate": 6.0, "qty": 100, "market_code": "82"}],
+                fields={"levels": [{"pnl_pct": 5, "sell_pct": 50}]},
+                context=RealCtx(),
+            )
+
+
+class TestUnreadableQuantityIsReachable:
+    """Z1 — '수량을 못 읽었다' 사유가 **실제로 도달 가능**해야 한다 (관측 2026-09-12).
+
+    구 코드는 pos_data 원값을 그대로 ``if qty <= 0:`` 에 넣었다. 파이썬에서
+    ``'n/a' <= 0`` · ``'100' <= 0`` · ``None <= 0`` 는 전부 TypeError 다(직접 실행
+    확인) — 그래서 수량이 숫자가 아니면 이 플러그인은 그 줄에서 **통째로 죽었고**,
+    아래 사유 분기는 수량에 대해 한 번도 도달할 수 없었다.
+    """
+
+    @staticmethod
+    async def _run(qty):
+        return await partial_take_profit_condition(
+            positions=[{"symbol": "AAPL", "pnl_rate": 6.5, "qty": qty, "market_code": "82"}],
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": 50}]},
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("qty", ["n/a", None, "", float("nan")])
+    async def test_unreadable_quantity_leaves_reason_instead_of_crashing(self, qty):
+        result = await self._run(qty)  # 구 코드: TypeError
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "skip"
+        assert "보유 수량을 읽을 수 없어" in sr["reason"]
+        assert repr(qty) in sr["reason"], "원값이 사유에 그대로 남아야 진단이 된다"
+        assert "sell_quantity" not in sr
+        assert result["passed_symbols"] == []
+        assert result["failed_symbols"][0]["symbol"] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_numeric_string_quantity_is_read_not_crashed(self):
+        """'100' 은 읽을 수 있는 수량이다 — 구 코드는 여기서도 TypeError 로 죽었다."""
+        result = await self._run("100")
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "sell"
+        assert sr["qty"] == 100
+        assert sr["sell_quantity"] == 50
+
+    @pytest.mark.asyncio
+    async def test_readable_zero_is_still_cleared_not_skipped(self):
+        """'0' 과 '못 읽음' 은 다른 사건이다 — 0 은 종전대로 청산 완료(cleared)."""
+        result = await self._run(0)
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "cleared"
+        assert sr["reason"] == "Position closed"
+
+
+class TestPartialSellBelowOneShareIsNotSilent:
+    """Z4 — 1주 미만 부분 익절 수량은 주문이 만들어지지 않는다는 사실을 드러낸다.
+
+    주문 송신부 ``NewOrderNodeExecutor._normalize_order`` 는 ``int(raw_quantity)``
+    로 정수부만 주문하고 정수부가 0 이면 ``None`` 을 돌린다 — 라이브 실측:
+    quantity 0.5 → None, 0.999 → None, 1.0 → quantity 1, 1.5 → quantity 1 +
+    fractional_remainder 0.5 (executor 직접 호출, 2026-09-12).
+    동작은 바꾸지 않는다(수량은 그대로) — 조용한 무동작만 드러낸다.
+    """
+
+    @staticmethod
+    async def _run(qty, sell_pct=50):
+        return await partial_take_profit_condition(
+            positions=[{"symbol": "AAPL", "pnl_rate": 6.5, "qty": qty, "market_code": "82"}],
+            fields={"levels": [{"pnl_pct": 5, "sell_pct": sell_pct}]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_sub_one_share_sell_leaves_reason(self):
+        result = await self._run(0.532)  # 0.532 x 50% = 0.266 주
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "sell"
+        assert sr["sell_quantity"] == pytest.approx(0.266)  # 수량은 그대로 둔다
+        assert "reduce_skipped_reason" in sr
+        assert "1주 미만" in sr["reduce_skipped_reason"]
+
+    @pytest.mark.asyncio
+    async def test_one_share_or_more_has_no_reason(self):
+        result = await self._run(10)  # 10 x 50% = 5 주
+        sr = result["symbol_results"][0]
+        assert sr["sell_quantity"] == 5
+        assert "reduce_skipped_reason" not in sr
+
+    @pytest.mark.asyncio
+    async def test_schema_declares_the_reason(self):
+        assert "reduce_skipped_reason" in PARTIAL_TAKE_PROFIT_SCHEMA.output_fields

--- a/src/community/tests/test_position_field_coercion_regression.py
+++ b/src/community/tests/test_position_field_coercion_regression.py
@@ -1,0 +1,287 @@
+"""
+positions 기반 플러그인 **전수** 회귀 테스트 — pos_data 원값이 산술/비교에 그대로 들어가 죽는 부류.
+
+배경 (2026-09-12 실측)
+--------------------
+``pos_data.get("current_price")`` / ``.get("qty")`` / ``.get("pnl_rate")`` 원값을
+coerce 없이 ``*``·``<=``·``round()``·``float()`` 에 넣는 코드가 여러 플러그인에 흩어져
+있었다. 'n/a'·None 이면 TypeError, 그리고 ``max_position_limit`` 은 **정상 숫자
+문자열** ``'150.0'`` 로도 죽었다(``'150.0' * 100`` 이 문자열 반복이 되고 뒤따르는
+``float()`` 에서 ValueError). 5차 스캔이 qty 키만 훑고 current_price 를 빼먹어 두
+플러그인이 남았던 것이 이 파일의 동기다.
+
+이 파일이 잠그는 계약 (키 종류 무관)
+-------------------------------
+positions 를 받는 모든 플러그인에 대해, 포지션의 **모든 숫자 필드**에 각각
+``'n/a'`` / ``None`` / 숫자 문자열을 넣어 호출했을 때:
+
+1. 예외가 나지 않는다.
+2. 종목이 조용히 사라지지 않는다(passed 또는 failed 에 있고 symbol_results 에 항목이 있다).
+3. 못 읽은 값을 **0 으로 지어내지 않는다**(해당 필드의 echo 가 0/0.0 이 아니다).
+4. 못 읽은 값 때문에 판정/출력이 정상 실행과 달라졌다면, 그 항목에 **어느 필드가 어떤
+   원값이었는지**를 담은 사유(``reason`` / ``*_reason``)가 남는다. 필드를 쓰지 않는
+   플러그인이면 판정이 같아야 하고 사유는 요구하지 않는다.
+5. 숫자 문자열은 그 숫자와 **완전히 같은 결과**를 낸다(판정·출력·passed 항목 모두).
+
+플러그인 목록은 하드코딩하지 않는다 — ``plugins/`` 디렉토리에서 발견한다. 시그니처에
+``positions`` 가 있거나 스키마 ``required_data`` 에 ``"positions"`` 가 있으면 대상이다.
+신규 플러그인은 자동으로 포함되고, 기본 실행이 positions 루프에 도달하지 못하면(데이터
+부족 등) 테스트가 **명시적으로 실패**한다 — 조용히 초록이 되지 않도록.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import pytest
+
+import programgarden_community.plugins as plugins_pkg
+
+# 선물 월물 코드 형식(roll_management 의 만기 파싱을 통과)이면서 다른 플러그인에는 무해한 심볼.
+SYMBOL = "ESZ30"
+MARKET_SYMBOL = "SPY"  # beta_hedge 기본 market_symbol / correlation_guard 의 두 번째 종목
+
+# 실행기(AccountNode/RealAccountNode)가 싣는 모양을 따른다: qty 와 quantity 를 같이 싣는다.
+BASE_POSITION: Dict[str, Any] = {
+    "symbol": SYMBOL, "exchange": "NASDAQ", "market_code": "82", "close_side": "sell",
+    "current_price": 150.0, "avg_price": 140.0, "pnl_rate": 7.14,
+    "qty": 100, "quantity": 100,
+}
+# market_value 는 기본 포지션에 **넣지 않는다** — max_position_limit 의
+# ``current_price × qty`` 경로(정상 숫자 문자열로도 죽던 경로)가 기본 실행에서 돌게 한다.
+EXTRA_FIELDS: Dict[str, Any] = {"market_value": 15000.0}
+
+# 논리 필드 → 실제로 주입할 키들. qty 는 두 별칭에 같이 넣는다(플러그인마다 읽는 별칭이 다르다).
+FIELD_KEYS: Dict[str, Tuple[str, ...]] = {
+    "current_price": ("current_price",),
+    "avg_price": ("avg_price",),
+    "pnl_rate": ("pnl_rate",),
+    "qty": ("qty", "quantity"),
+    "market_value": ("market_value",),
+}
+UNREADABLE_RAWS = ("n/a", None)
+
+
+# ---------------------------------------------------------------------------
+# 발견 (디렉토리 기반)
+# ---------------------------------------------------------------------------
+
+def _discover_position_plugins() -> List[Tuple[str, Callable[..., Any], Any]]:
+    found = []
+    for mod in pkgutil.iter_modules(plugins_pkg.__path__):
+        if not mod.ispkg or mod.name.startswith("_"):
+            continue
+        module = importlib.import_module(f"{plugins_pkg.__name__}.{mod.name}")
+        exported = getattr(module, "__all__", None) or dir(module)
+        fn = None
+        schema = None
+        for name in exported:
+            obj = getattr(module, name, None)
+            if name.endswith("_condition") and callable(obj):
+                fn = obj
+            elif name.endswith("_SCHEMA"):
+                schema = obj
+        if fn is None:
+            continue
+        params = inspect.signature(fn).parameters
+        by_signature = "positions" in params
+        by_schema = "positions" in list(getattr(schema, "required_data", []) or [])
+        if by_signature or by_schema:
+            found.append((mod.name, fn, schema))
+    return sorted(found, key=lambda t: t[0])
+
+
+DISCOVERED = _discover_position_plugins()
+PLUGIN_PARAMS = [pytest.param(fn, id=name) for name, fn, _ in DISCOVERED]
+
+
+# ---------------------------------------------------------------------------
+# 입력 빌더
+# ---------------------------------------------------------------------------
+
+def _bars(n: int = 130) -> List[Dict[str, Any]]:
+    """모든 data 의존 플러그인이 positions 루프까지 도달하게 하는 공용 시계열.
+
+    SYMBOL 과 MARKET_SYMBOL 두 종목, close/high/low/open/volume/date 포함.
+    (beta_hedge lookback 기본 120 · var_cvar/correlation_guard 기본 60 · dynamic_stop_loss ATR 14)
+    """
+    rows: List[Dict[str, Any]] = []
+    spy, px = 450.0, 150.0
+    for i in range(n):
+        move = 0.005 if i % 3 < 2 else -0.003
+        spy *= (1 + move)
+        px *= (1 + move * 2.0 + 0.001)
+        date = f"2026{(i // 30) + 1:02d}{(i % 30) + 1:02d}"
+        for sym, p in ((MARKET_SYMBOL, spy), (SYMBOL, px)):
+            c = round(p, 2)
+            rows.append({
+                "symbol": sym, "exchange": "NASDAQ", "date": date,
+                "open": c, "high": round(c * 1.01, 2), "low": round(c * 0.99, 2),
+                "close": c, "volume": 1000,
+            })
+    return rows
+
+
+def _position_with(field: Optional[str] = None, raw: Any = None) -> Dict[str, Any]:
+    pos = dict(BASE_POSITION)
+    if field is not None:
+        for key in FIELD_KEYS[field]:
+            pos[key] = raw
+    return pos
+
+
+async def _run(fn: Callable[..., Any], positions: List[Dict[str, Any]]) -> Dict[str, Any]:
+    return await fn(data=_bars(), positions=positions, fields={})
+
+
+# ---------------------------------------------------------------------------
+# 결과 읽기
+# ---------------------------------------------------------------------------
+
+def _entry(result: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    return next(
+        (sr for sr in result.get("symbol_results", []) if isinstance(sr, dict) and sr.get("symbol") == SYMBOL),
+        None,
+    )
+
+
+def _membership(result: Dict[str, Any]) -> str:
+    if any(isinstance(p, dict) and p.get("symbol") == SYMBOL for p in result.get("passed_symbols", [])):
+        return "passed"
+    if any(isinstance(p, dict) and p.get("symbol") == SYMBOL for p in result.get("failed_symbols", [])):
+        return "failed"
+    return "absent"
+
+
+def _passed_entry(result: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    return next(
+        (p for p in result.get("passed_symbols", []) if isinstance(p, dict) and p.get("symbol") == SYMBOL),
+        None,
+    )
+
+
+def _is_reason_key(key: str) -> bool:
+    return key == "reason" or key.endswith("_reason")
+
+
+def _reasons(entry: Dict[str, Any]) -> List[str]:
+    return [v for k, v in entry.items() if _is_reason_key(k) and isinstance(v, str)]
+
+
+def _strip(entry: Dict[str, Any], injected_keys: Tuple[str, ...]) -> Dict[str, Any]:
+    """사유 키와 주입 필드의 echo 를 뺀 '판정·출력' 부분."""
+    return {k: v for k, v in entry.items() if not _is_reason_key(k) and k not in injected_keys}
+
+
+def _fabricated_zero(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and value == 0
+
+
+def _baseline(fn: Callable[..., Any], result: Dict[str, Any]) -> Dict[str, Any]:
+    entry = _entry(result)
+    if entry is None or _membership(result) == "absent":
+        pytest.fail(
+            f"{fn.__name__}: 기본 실행이 positions 루프에 도달하지 못했다 "
+            f"(symbol_results={result.get('symbol_results')!r}, analysis={result.get('analysis')!r}). "
+            "이 테스트가 이 플러그인을 실제로 검증하려면 _bars()/BASE_POSITION 을 확장해야 한다 — "
+            "조용히 초록으로 두지 않는다."
+        )
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# 테스트
+# ---------------------------------------------------------------------------
+
+def test_discovery_covers_positions_plugins():
+    """디렉토리 발견이 실제로 동작하는지 — 바닥선. (목록 하드코딩이 아니라 하한만 잠근다.)"""
+    names = [name for name, _, _ in DISCOVERED]
+    by_schema = [name for name, _, schema in DISCOVERED
+                 if "positions" in list(getattr(schema, "required_data", []) or [])]
+    assert len(by_schema) >= 8, f"required_data=positions 플러그인이 8개 미만으로 발견됨: {by_schema}"
+    assert len(names) >= len(by_schema)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn", PLUGIN_PARAMS)
+async def test_baseline_reaches_positions_loop(fn):
+    """기본 입력으로 종목이 평가되고(passed/failed 어딘가에 있고) 항목이 남는다."""
+    result = await _run(fn, [_position_with()])
+    _baseline(fn, result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn", PLUGIN_PARAMS)
+@pytest.mark.parametrize("field", sorted(FIELD_KEYS))
+@pytest.mark.parametrize("raw", UNREADABLE_RAWS, ids=lambda r: repr(r))
+async def test_unreadable_position_field_never_crashes_and_leaves_reason(fn, field, raw):
+    injected_keys = FIELD_KEYS[field]
+
+    base_result = await _run(fn, [_position_with()])
+    base_entry = _baseline(fn, base_result)
+
+    # 1. 예외가 나지 않는다 (여기서 TypeError/ValueError 가 나면 그게 곧 회귀다).
+    result = await _run(fn, [_position_with(field, raw)])
+
+    # 2. 종목이 조용히 사라지지 않는다.
+    assert isinstance(result.get("passed_symbols"), list)
+    assert isinstance(result.get("failed_symbols"), list)
+    assert isinstance(result.get("symbol_results"), list)
+    where = _membership(result)
+    assert where != "absent", f"{fn.__name__}: {field}={raw!r} 에서 종목이 passed/failed 어디에도 없다"
+    entry = _entry(result)
+    assert entry is not None, f"{fn.__name__}: {field}={raw!r} 에서 symbol_results 항목이 없다"
+
+    # 3. 못 읽은 값을 0 으로 지어내지 않는다.
+    for key in injected_keys:
+        assert not _fabricated_zero(entry.get(key)), (
+            f"{fn.__name__}: {key}={raw!r} 를 0 으로 뭉갰다 (symbol_results={entry!r})"
+        )
+    passed_entry = _passed_entry(result)
+    if passed_entry is not None:
+        for key in injected_keys:
+            assert not _fabricated_zero(passed_entry.get(key)), (
+                f"{fn.__name__}: passed_symbols 의 {key} 가 0 으로 지어졌다 ({passed_entry!r})"
+            )
+
+    # 4. 판정/출력이 달라졌으면 사유가 남아야 하고, 사유는 필드명과 원값을 담아야 한다.
+    changed = (
+        _strip(entry, injected_keys) != _strip(base_entry, injected_keys)
+        or where != _membership(base_result)
+    )
+    if changed:
+        reasons = _reasons(entry)
+        assert reasons, (
+            f"{fn.__name__}: {field}={raw!r} 로 판정/출력이 달라졌는데 사유가 없다 "
+            f"(base={base_entry!r}, got={entry!r})"
+        )
+        names_ok = any(any(k in r for k in injected_keys) for r in reasons)
+        raw_ok = any(repr(raw) in r for r in reasons)
+        assert names_ok and raw_ok, (
+            f"{fn.__name__}: 사유에 필드명({injected_keys})과 원값({raw!r})이 없다: {reasons!r}"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fn", PLUGIN_PARAMS)
+@pytest.mark.parametrize("field", sorted(FIELD_KEYS))
+async def test_numeric_string_position_field_behaves_like_number(fn, field):
+    """'150.0' 은 150.0 과 완전히 같아야 한다 — 문자열 반복(‘150.0150.0…’)으로 죽던 경로의 잠금."""
+    numeric = EXTRA_FIELDS[field] if field in EXTRA_FIELDS else BASE_POSITION[FIELD_KEYS[field][0]]
+
+    base_result = await _run(fn, [_position_with(field, numeric)])
+    base_entry = _baseline(fn, base_result)
+
+    result = await _run(fn, [_position_with(field, str(numeric))])
+
+    entry = _entry(result)
+    assert entry is not None, f"{fn.__name__}: {field}={str(numeric)!r} 에서 항목이 없다"
+    assert entry == base_entry, (
+        f"{fn.__name__}: 숫자 문자열 {field}={str(numeric)!r} 이 숫자와 다른 결과를 냈다 "
+        f"(number={base_entry!r}, string={entry!r})"
+    )
+    assert _membership(result) == _membership(base_result)
+    assert _passed_entry(result) == _passed_entry(base_result)

--- a/src/community/tests/test_position_qty_helpers.py
+++ b/src/community/tests/test_position_qty_helpers.py
@@ -1,0 +1,191 @@
+"""
+공용 수량 헬퍼(``plugins/_position_qty.py``) 계약 테스트 + 상태 경로 실상 고정(pin).
+
+이 파일은 두 가지를 한다:
+1. 절단(``int()``)·바닥올림(``max(1, ...)``) 없는 수량 계산 계약을 고정한다.
+   같은 식이 여러 플러그인에 복사돼 있던 것을 한 곳으로 모았으므로, 계약도
+   한 곳에서 잠근다.
+2. risk_tracker 상태/이벤트 경로가 **실제로는 동작하지 않는다**는 사실을
+   테스트로 못 박는다(아래 ``TestRiskTrackerInterfaceTruth``). 지금 초록인 것은
+   '고쳐졌다'는 뜻이 아니라 '아직 깨진 채다'라는 뜻이다 — 엔진 쪽에서 메서드명을
+   맞추면 이 테스트가 빨개지고, 그때 플러그인 docstring 의 '미검증' 문구와 목을
+   함께 고치면 된다.
+"""
+
+from decimal import Decimal
+
+import pytest
+
+from programgarden_community.plugins._position_qty import (
+    below_broker_lot,
+    coerce_qty,
+    half_position_qty,
+    partial_sell_qty,
+    preserve_qty,
+)
+
+
+class TestCoerceQty:
+    @pytest.mark.parametrize("raw,expected", [
+        (0.532, 0.532), (1, 1.0), (10, 10.0), ("2.5", 2.5),
+        (Decimal("0.532"), 0.532), (0, 0.0), (-3, -3.0),
+    ])
+    def test_reads_finite_values(self, raw, expected):
+        assert coerce_qty(raw) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("raw", [None, "n/a", "", object(), float("nan"),
+                                     float("inf"), Decimal("NaN")])
+    def test_unreadable_is_none_not_zero(self, raw):
+        """'못 읽음' 과 '0' 은 다른 사건이다 — 0 으로 뭉개지 않는다."""
+        assert coerce_qty(raw) is None
+
+
+class TestPreserveQty:
+    @pytest.mark.parametrize("raw,expected,typ", [
+        (0.532, 0.532, float), (1, 1, int), (10.0, 10, int),
+        (Decimal("0.847972"), 0.847972, float), (Decimal("3"), 3, int),
+    ])
+    def test_integers_stay_int_fractions_stay_float(self, raw, expected, typ):
+        out = preserve_qty(raw)
+        assert out == pytest.approx(expected)
+        assert isinstance(out, typ)
+
+
+class TestHalfPositionQty:
+    @pytest.mark.parametrize("qty,expected", [
+        (0.532, 0.266),   # 구: max(1, int(0.532)//2) = 1 → 보유 초과 매도
+        (1, 0.5),         # 구: max(1, 1//2) = 1 → '절반 축소'가 전량 매도
+        (10, 5),
+        (3, 1.5),         # 구: 3//2 = 1 (0.5주 증발)
+        (Decimal("0.532"), 0.266),
+    ])
+    def test_exact_half_no_truncation_no_floor(self, qty, expected):
+        assert half_position_qty(qty) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("qty", [0.532, 1, 10, 3, 0.001])
+    def test_never_exceeds_held(self, qty):
+        assert half_position_qty(qty) <= qty
+
+    @pytest.mark.parametrize("qty", [0, -1, None, "n/a", float("nan")])
+    def test_unusable_quantity_is_none(self, qty):
+        """수량을 못 읽거나 0 이하면 수량을 지어내지 않는다(호출부가 사유를 남긴다)."""
+        assert half_position_qty(qty) is None
+
+    def test_integer_half_is_int(self):
+        assert isinstance(half_position_qty(10), int)
+
+
+class TestPartialSellQty:
+    @pytest.mark.parametrize("base,pct,held,expected", [
+        (0.532, 50, 0.532, 0.266),   # 구: int(0.266) = 0 → 단계 통째로 스킵
+        (100, 30, 100, 30),
+        (100, 30, 5, 5),             # 보유량 상한
+        (Decimal("10"), 30, 5, 3),
+    ])
+    def test_percentage_of_base_capped_at_held(self, base, pct, held, expected):
+        assert partial_sell_qty(base, pct, held) == pytest.approx(expected)
+
+    def test_zero_percent_is_zero_not_none(self):
+        """진짜 0 은 0 으로 돌려준다 — '못 읽음'(None)과 구분."""
+        assert partial_sell_qty(100, 0, 100) == 0
+
+    @pytest.mark.parametrize("args", [
+        ("n/a", 50, 100), (100, "n/a", 100), (100, 50, None),
+    ])
+    def test_unreadable_is_none(self, args):
+        assert partial_sell_qty(*args) is None
+
+
+@pytest.fixture(scope="module")
+def tracker_cls():
+    # community 패키지는 엔진(programgarden)에 의존하지 않는다 —
+    # 엔진 없이 설치된 환경에서는 이 pin 을 건너뛴다.
+    mod = pytest.importorskip(
+        "programgarden.database.workflow_risk_tracker",
+        reason="engine package not installed; interface pin skipped",
+    )
+    return mod.WorkflowRiskTracker
+
+
+class TestRiskTrackerInterfaceTruth:
+    """플러그인이 부르는 이름과 실제 트래커의 이름이 **어긋나 있다**는 사실을 고정한다.
+
+    관측 2026-09-12 (실제 클래스 introspection).
+    엔진 쪽에서 이름을 맞추는 수정은 이번 회차 범위 밖 — 후속 필요.
+    """
+
+    @pytest.mark.parametrize("name", ["get_state", "set_state", "record_event"])
+    def test_names_the_plugins_call_do_not_exist(self, tracker_cls, name):
+        """플러그인들이 호출하는 이름이 실제 클래스에 없다 → 상태/이벤트 경로는 죽어 있다."""
+        assert not hasattr(tracker_cls, name), (
+            f"{name} 이 생겼다면 엔진이 고쳐진 것이다 — 플러그인 docstring 의 "
+            "'미검증/동작하지 않음' 문구와 MockRiskTracker 를 함께 갱신할 것."
+        )
+
+    @pytest.mark.parametrize("name", ["load_state", "save_state", "delete_state",
+                                      "record_risk_event"])
+    def test_real_names_are_these(self, tracker_cls, name):
+        assert hasattr(tracker_cls, name)
+
+    def test_real_state_methods_are_synchronous(self, tracker_cls):
+        """플러그인은 ``await delete_state(...)`` 하지만 실제 메서드는 동기다."""
+        import inspect
+        for name in ("save_state", "load_state", "delete_state"):
+            assert not inspect.iscoroutinefunction(getattr(tracker_cls, name)), name
+
+
+class TestBelowBrokerLot:
+    """0 < 수량 < 1 판정 — 주문 송신부가 정수부 0 으로 접어 주문을 만들지 않는 구간.
+
+    근거는 추정이 아니라 엔진 송신부 직접 호출 실측이다(2026-09-12):
+    ``NewOrderNodeExecutor._normalize_order`` 에 quantity 0.5 / 0.999 를 주면
+    ``None`` 을 돌려 주문을 만들지 않고, 1.0 은 quantity 1, 1.5 는 quantity 1 +
+    fractional_remainder 0.5 를 돌려준다. 아래 ``TestOrderSenderContract`` 가
+    그 사실을 직접 고정한다.
+    """
+
+    @pytest.mark.parametrize("raw", [0.5, 0.266, 0.999, 0.001, Decimal("0.532"), "0.75"])
+    def test_true_below_one_share(self, raw):
+        assert below_broker_lot(raw) is True
+
+    @pytest.mark.parametrize("raw", [1, 1.0, 1.5, 10, Decimal("1"), "2"])
+    def test_false_at_or_above_one_share(self, raw):
+        assert below_broker_lot(raw) is False
+
+    @pytest.mark.parametrize("raw", [0, 0.0, -0.5, -3])
+    def test_false_for_zero_and_negative(self, raw):
+        """0 과 음수는 이 판정의 대상이 아니다(호출부가 앞서 걸러낸다)."""
+        assert below_broker_lot(raw) is False
+
+    @pytest.mark.parametrize("raw", [None, "n/a", "", float("nan")])
+    def test_false_for_unreadable(self, raw):
+        """'못 읽음' 은 별개의 사건 — 호출부가 다른 사유로 따로 보고한다."""
+        assert below_broker_lot(raw) is False
+
+    def test_it_only_judges_and_never_changes_the_quantity(self):
+        """판정 함수다 — 수량을 올리거나 자르지 않는다(반환형은 bool)."""
+        assert isinstance(below_broker_lot(0.5), bool)
+        assert half_position_qty(1) == 0.5  # 판정과 무관하게 절반은 그대로 0.5
+
+
+class TestOrderSenderContract:
+    """Z4 전제의 라이브 고정 — 송신부가 1주 미만을 주문으로 만들지 않는다."""
+
+    def test_normalize_order_drops_sub_one_share(self):
+        executor_mod = pytest.importorskip(
+            "programgarden.executor",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        ex = executor_mod.NewOrderNodeExecutor()
+
+        def norm(q):
+            return ex._normalize_order(
+                {"symbol": "AAPL", "exchange": "NASDAQ", "quantity": q, "price": 10.0}, {}
+            )
+
+        for q in (0.5, 0.266, 0.999):
+            assert norm(q) is None, f"{q} 주 주문이 만들어졌다 — below_broker_lot 전제가 바뀌었다"
+            assert below_broker_lot(q) is True
+        for q in (1.0, 1.5, 10):
+            assert norm(q) is not None
+            assert below_broker_lot(q) is False

--- a/src/community/tests/test_profit_target_plugin.py
+++ b/src/community/tests/test_profit_target_plugin.py
@@ -110,5 +110,35 @@ class TestSellQuantityWiring:
         assert result["passed_symbols"][0]["quantity"] == 9
 
 
+class TestFractionalQuantityPassthrough:
+    """소수 수량 포지션은 절단 없이 그대로 실려야 한다(전량 청산 플러그인).
+
+    ProfitTarget 은 계산 없이 포지션의 quantity 를 그대로 싣기 때문에 원래도
+    절단이 없었다 — 이 테스트는 나중에 int() 정수화가 끼어드는 회귀를 막는 잠금이다.
+    (LS 해외주식 소수점 주식 — 출처: 오너 진술 2026-09-12. 정수화는 주문 송신부
+    _normalize_order 의 명시적 규약이다.)
+    """
+
+    @pytest.mark.asyncio
+    async def test_fractional_quantity_is_not_truncated(self):
+        result = await profit_target_condition(
+            positions=[{"symbol": "AAPL", "pnl_rate": 6.0, "quantity": 0.532,
+                        "market_code": "82"}],
+            fields={"target_percent": 5.0},
+        )
+        assert result["passed_symbols"][0]["quantity"] == pytest.approx(0.532)
+
+    @pytest.mark.asyncio
+    async def test_decimal_quantity_is_passed_through(self):
+        from decimal import Decimal
+
+        result = await profit_target_condition(
+            positions=[{"symbol": "AAPL", "pnl_rate": 6.0,
+                        "quantity": Decimal("9.5"), "market_code": "82"}],
+            fields={"target_percent": 5.0},
+        )
+        assert result["passed_symbols"][0]["quantity"] == Decimal("9.5")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/src/community/tests/test_time_exit_plugin.py
+++ b/src/community/tests/test_time_exit_plugin.py
@@ -1,5 +1,24 @@
 """
 TimeBasedExit 플러그인 테스트
+
+🔴 이 파일의 ``MockRiskTracker`` 는 **실제 클래스에 없는 메서드를 제공한다** (관측 2026-09-12)
+------------------------------------------------------------------------------------------
+실제 트래커 ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 의
+실제 인터페이스와 대조한 결과:
+
+| 목이 제공하는 이름 | 실제 클래스 | 비고 |
+|---|---|---|
+| ``get_state``   | **없음** | 실제 이름은 ``load_state`` (동기) |
+| ``set_state``   | **없음** | 실제 이름은 ``save_state`` (동기) |
+| ``delete_state``| 있음     | 단 **동기** 메서드 — 플러그인은 ``await`` 한다 |
+| ``record_event``| **없음** | 실제 이름은 ``record_risk_event`` |
+
+즉 아래 상태 관련 테스트들은 '플러그인이 라이브에서 실제로 상태를 저장·복원한다'
+를 증명하지 않는다 — **목이 약속한 계약대로 플러그인이 호출한다**는 것만 증명한다.
+라이브에서는 (가) 실제 트래커를 넘기면 ``AttributeError`` 로 죽고, (나) 애초에
+실행기가 positions 기반 플러그인에 ``context`` 를 넘기지 않아 상태 경로가 아예
+돌지 않는다(플러그인 모듈 docstring 의 '상태 경로' 절 참조).
+목을 실제 시그니처로 맞추는 수정은 이번 회차 범위 밖이다 — 후속 필요.
 """
 
 import pytest
@@ -12,6 +31,13 @@ from programgarden_community.plugins.time_based_exit import (
 
 
 class MockRiskTracker:
+    """strategy_state **목 계약** 모킹 — 실제 WorkflowRiskTracker 인터페이스가 아니다.
+
+    ``get_state``/``set_state`` 는 실제 클래스에 없는 이름이고(실제: ``load_state``/
+    ``save_state``, 둘 다 동기), ``delete_state`` 는 이름은 같지만 실제로는 동기
+    메서드다. 파일 상단 주석 참조.
+    """
+
     def __init__(self):
         self._state = {}
 
@@ -34,7 +60,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_new_position_records_entry(self):
-        """신규 포지션 진입일 기록"""
+        """[목 계약 — 라이브 아님] 신규 포지션 진입일 기록"""
         tracker = MockRiskTracker()
         context = MockContext(tracker)
 
@@ -53,7 +79,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_exit_triggered(self):
-        """보유일 초과 시 청산 트리거"""
+        """[목 계약 — 라이브 아님] 보유일 초과 시 청산 트리거"""
         tracker = MockRiskTracker()
         entry = (date.today() - timedelta(days=6)).isoformat()
         tracker._state["time_exit.AAPL.entry_date"] = entry
@@ -72,7 +98,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_warn_triggered(self):
-        """경고 일수 도달"""
+        """[목 계약 — 라이브 아님] 경고 일수 도달"""
         tracker = MockRiskTracker()
         entry = (date.today() - timedelta(days=4)).isoformat()
         tracker._state["time_exit.AAPL.entry_date"] = entry
@@ -91,7 +117,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_position_closed_clears_state(self):
-        """포지션 청산 시 상태 삭제"""
+        """[목 계약 — 라이브 아님] 포지션 청산 시 상태 삭제"""
         tracker = MockRiskTracker()
         tracker._state["time_exit.AAPL.entry_date"] = "2025-01-01"
         context = MockContext(tracker)
@@ -119,7 +145,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_multiple_symbols(self):
-        """여러 종목"""
+        """[목 계약 — 라이브 아님] 여러 종목"""
         tracker = MockRiskTracker()
         tracker._state["time_exit.AAPL.entry_date"] = (date.today() - timedelta(days=10)).isoformat()
         tracker._state["time_exit.NVDA.entry_date"] = (date.today() - timedelta(days=2)).isoformat()
@@ -144,3 +170,68 @@ class TestTimeBasedExitPlugin:
         assert (cat.value if hasattr(cat, 'value') else cat) == "position"
         assert "max_hold_days" in TIME_BASED_EXIT_SCHEMA.fields_schema
         assert "warn_days" in TIME_BASED_EXIT_SCHEMA.fields_schema
+
+
+class TestUnreadableQuantityIsReachable:
+    """Z1 — 원값 비교(``if qty <= 0``)가 '수량을 못 읽었다' 를 삼키지 않아야 한다.
+
+    구 코드는 pos_data 원값을 그대로 비교해, 수량이 숫자가 아니면 그 줄에서
+    TypeError 로 플러그인 전체가 죽었다(``'n/a' <= 0`` · ``'100' <= 0`` ·
+    ``None <= 0`` 모두 TypeError — 직접 실행 확인 2026-09-12). 결과에 사유가
+    남을 기회 자체가 없었다.
+    """
+
+    @staticmethod
+    async def _run(qty):
+        return await time_based_exit_condition(
+            positions=[{"symbol": "AAPL", "qty": qty, "market_code": "82"}],
+            fields={"max_hold_days": 5},
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("qty", ["n/a", None, "", float("nan")])
+    async def test_unreadable_quantity_leaves_reason_instead_of_crashing(self, qty):
+        result = await self._run(qty)  # 구 코드: TypeError
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "skip"
+        assert "보유 수량을 읽을 수 없어" in sr["reason"]
+        assert repr(qty) in sr["reason"]
+        assert result["passed_symbols"] == []
+        assert result["failed_symbols"][0]["symbol"] == "AAPL"
+        # 보유일수를 지어내지 않는다
+        assert "hold_days" not in sr
+
+    @pytest.mark.asyncio
+    async def test_numeric_string_quantity_is_read_not_crashed(self):
+        """'100' 은 읽을 수 있는 수량이다 — 구 코드는 여기서도 TypeError 였다."""
+        result = await self._run("100")
+        sr = result["symbol_results"][0]
+        assert sr["action"] in {"hold", "warn", "exit"}
+        assert sr["hold_days"] == 0
+
+    @pytest.mark.asyncio
+    async def test_readable_zero_is_still_cleared(self):
+        """'0' 과 '못 읽음' 은 다른 사건 — 0 은 종전대로 청산 완료(cleared)."""
+        result = await self._run(0)
+        sr = result["symbol_results"][0]
+        assert sr["action"] == "cleared"
+        assert sr["reason"] == "Position closed"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_quantity_does_not_delete_entry_date_state(self):
+        """[목 계약] 청산인지 알 수 없으므로 진입일 상태를 지우지 않는다."""
+        tracker = MockRiskTracker()
+        key = "time_exit.AAPL.entry_date"
+        tracker._state[key] = (date.today() - timedelta(days=10)).isoformat()
+        result = await time_based_exit_condition(
+            positions=[{"symbol": "AAPL", "qty": "n/a", "market_code": "82"}],
+            fields={"max_hold_days": 5},
+            context=MockContext(tracker),
+        )
+        assert result["symbol_results"][0]["action"] == "skip"
+        assert key in tracker._state
+
+    def test_schema_declares_skip_and_reason(self):
+        of = TIME_BASED_EXIT_SCHEMA.output_fields
+        assert "reason" in of
+        assert "skip" in of["action"]["description"]

--- a/src/community/tests/test_trailing_stop_plugin.py
+++ b/src/community/tests/test_trailing_stop_plugin.py
@@ -342,5 +342,203 @@ class TestSellQuantityWiring:
         assert ps["close_side"] == "sell"
 
 
+class TestFractionalSellQuantity:
+    """소수점(fractional) 청산 수량이 플러그인에서 절단되지 않아야 한다.
+
+    LS 는 해외주식 소수점 주식을 지원한다(출처: 오너 진술 2026-09-12).
+    WorkflowRiskTracker.position_qty 는 소수 잔량을 Decimal 로 보존하는데,
+    플러그인이 int() 로 자르면 0.532주 포지션의 청산 수량이 0 으로 실려
+    주문이 조용히 사라진다. 정수화는 주문 송신부(_normalize_order)의 명시적
+    규약이다 — 정수부만 주문하고 잔량은 fractional_remainder 로 남기며,
+    정수부가 0 이면 FRACTIONAL_ONLY 로 사유를 밝힌다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hwm_fallback_preserves_fractional_qty(self):
+        # 라이브 수량이 없어 HWM 기억값(Decimal)으로 폴백하는 경로
+        tracker = MockRiskTracker({
+            "AAPL": MockHWM(hwm_price=120.0, current_price=113.0,
+                            position_avg_price=100.0, drawdown_pct=5.83,
+                            position_qty=Decimal("0.532")),
+        })
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610", "close": 113.0}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ"}],
+            context=MockContext(tracker),
+        )
+        ps = result["passed_symbols"][0]
+        assert ps["quantity"] == pytest.approx(0.532)  # int 절단이면 0
+        assert ps["close_side"] == "sell"
+
+    @pytest.mark.asyncio
+    async def test_hwm_fallback_mixed_fractional_qty(self):
+        # 정수부가 있는 소수 수량(9.5)도 잔량을 잃지 않는다
+        tracker = MockRiskTracker({
+            "AAPL": MockHWM(hwm_price=120.0, current_price=113.0,
+                            position_avg_price=100.0, drawdown_pct=5.83,
+                            position_qty=Decimal("9.5")),
+        })
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610", "close": 113.0}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ"}],
+            context=MockContext(tracker),
+        )
+        assert result["passed_symbols"][0]["quantity"] == pytest.approx(9.5)  # int 절단이면 9
+
+    @pytest.mark.asyncio
+    async def test_live_data_fractional_qty_preserved(self):
+        # data 행(라이브 포지션 스냅샷)의 소수 수량도 절단되지 않는다
+        tracker = MockRiskTracker({
+            "AAPL": MockHWM(hwm_price=120.0, current_price=113.0,
+                            position_avg_price=100.0, drawdown_pct=5.83,
+                            position_qty=15),
+        })
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610",
+                   "close": 113.0, "quantity": 0.847972}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ"}],
+            context=MockContext(tracker),
+        )
+        assert result["passed_symbols"][0]["quantity"] == pytest.approx(0.847972)
+
+    @pytest.mark.asyncio
+    async def test_symbols_fractional_qty_preserved(self):
+        # symbols 포트의 소수 수량(최우선 권위값)도 절단되지 않는다
+        tracker = MockRiskTracker({
+            "AAPL": MockHWM(hwm_price=120.0, current_price=113.0,
+                            position_avg_price=100.0, drawdown_pct=5.83,
+                            position_qty=15),
+        })
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610",
+                   "close": 113.0, "quantity": 8}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ", "quantity": Decimal("2.25")}],
+            context=MockContext(tracker),
+        )
+        assert result["passed_symbols"][0]["quantity"] == pytest.approx(2.25)
+
+    @pytest.mark.asyncio
+    async def test_integer_qty_stays_int(self):
+        # 정수 수량은 종전과 동일하게 int 로 실린다(직렬화 모양 유지)
+        tracker = MockRiskTracker({
+            "AAPL": MockHWM(hwm_price=120.0, current_price=113.0,
+                            position_avg_price=100.0, drawdown_pct=5.83,
+                            position_qty=Decimal("15")),
+        })
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610", "close": 113.0}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ"}],
+            context=MockContext(tracker),
+        )
+        qty = result["passed_symbols"][0]["quantity"]
+        assert qty == 15
+        assert isinstance(qty, int)
+
+    @pytest.mark.asyncio
+    async def test_unreadable_live_qty_falls_back_to_hwm(self):
+        # 읽을 수 없는 수량('abc')은 '0' 이 아니라 '없음'으로 취급 → HWM 폴백
+        tracker = MockRiskTracker({
+            "AAPL": MockHWM(hwm_price=120.0, current_price=113.0,
+                            position_avg_price=100.0, drawdown_pct=5.83,
+                            position_qty=Decimal("0.532")),
+        })
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610",
+                   "close": 113.0, "quantity": "abc"}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ"}],
+            context=MockContext(tracker),
+        )
+        assert result["passed_symbols"][0]["quantity"] == pytest.approx(0.532)
+
+    @pytest.mark.asyncio
+    async def test_explicit_zero_live_qty_is_not_overridden(self):
+        # 실제로 0 인 라이브 수량은 폴백하지 않고 0 그대로 (종전 동작 유지)
+        tracker = MockRiskTracker({
+            "AAPL": MockHWM(hwm_price=120.0, current_price=113.0,
+                            position_avg_price=100.0, drawdown_pct=5.83,
+                            position_qty=Decimal("0.532")),
+        })
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610",
+                   "close": 113.0, "quantity": 0}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ"}],
+            context=MockContext(tracker),
+        )
+        assert result["passed_symbols"][0]["quantity"] == 0
+
+
+class TestNonFiniteQuantity:
+    """NaN/Inf 수량은 '0' 이 아니라 '못 읽음'으로 취급해 HWM 폴백으로 내려가야 한다.
+
+    _position_qty.preserve_qty 의 비유한수 분기 회귀 테스트다. NaN 을 그대로 실으면 주문 수량이
+    NaN 으로 흘러가고(비교 연산이 전부 False 라 조용히 버려짐), 0 으로 접으면
+    '실제 보유 0' 과 구분되지 않아 폴백이 막힌다.
+    """
+
+    @staticmethod
+    def _tracker(position_qty=Decimal("0.532")):
+        return MockRiskTracker({
+            "AAPL": MockHWM(hwm_price=120.0, current_price=113.0,
+                            position_avg_price=100.0, drawdown_pct=5.83,
+                            position_qty=position_qty),
+        })
+
+    @pytest.mark.asyncio
+    async def test_nan_live_data_qty_falls_back_to_hwm(self):
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610",
+                   "close": 113.0, "quantity": float("nan")}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ"}],
+            context=MockContext(self._tracker()),
+        )
+        qty = result["passed_symbols"][0]["quantity"]
+        assert qty == pytest.approx(0.532)  # NaN 을 싣지 않고 HWM 기억값으로 폴백
+        assert qty == qty  # NaN 이면 False
+
+    @pytest.mark.asyncio
+    async def test_nan_symbols_qty_falls_back_to_hwm(self):
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610",
+                   "close": 113.0}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ",
+                      "quantity": Decimal("NaN")}],
+            context=MockContext(self._tracker()),
+        )
+        assert result["passed_symbols"][0]["quantity"] == pytest.approx(0.532)
+
+    @pytest.mark.asyncio
+    async def test_infinite_live_qty_falls_back_to_hwm(self):
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610",
+                   "close": 113.0, "quantity": float("inf")}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ"}],
+            context=MockContext(self._tracker()),
+        )
+        assert result["passed_symbols"][0]["quantity"] == pytest.approx(0.532)
+
+    @pytest.mark.asyncio
+    async def test_nan_hwm_qty_becomes_zero_without_crash(self):
+        """마지막 폴백(HWM 기억값)마저 NaN 이면 0 으로 실어 하류가 사유를 남기게 한다."""
+        result = await trailing_stop_condition(
+            data=[{"symbol": "AAPL", "exchange": "NASDAQ", "date": "20260610",
+                   "close": 113.0}],
+            fields={"trail_percent": 5.0},
+            symbols=[{"symbol": "AAPL", "exchange": "NASDAQ"}],
+            context=MockContext(self._tracker(position_qty=float("nan"))),
+        )
+        qty = result["passed_symbols"][0]["quantity"]
+        assert qty == 0
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/src/community/tests/test_var_cvar_monitor_plugin.py
+++ b/src/community/tests/test_var_cvar_monitor_plugin.py
@@ -12,7 +12,13 @@ from programgarden_community.plugins.var_cvar_monitor import (
 
 
 class MockRiskTracker:
-    """mock risk tracker for event recording"""
+    """위험 이벤트 기록 **목 계약** — 실제 WorkflowRiskTracker 인터페이스가 아니다.
+
+    실제 클래스에는 ``record_event`` 가 없다(실제 이름은 ``record_risk_event``).
+    플러그인 쪽 호출은 ``except Exception: pass`` 로 감싸져 있어 라이브에서는
+    이벤트가 한 건도 기록되지 않는다 — 아래 이벤트 테스트는 '목이 약속한
+    계약대로 플러그인이 호출한다' 만 증명한다. 관측 2026-09-12.
+    """
     def __init__(self):
         self.events = []
 
@@ -202,7 +208,7 @@ class TestVarCvarMonitorPlugin:
 
     @pytest.mark.asyncio
     async def test_risk_event_recording(self, mock_data_volatile):
-        """risk_tracker 이벤트 기록"""
+        """[목 계약 — 라이브 아님] risk_tracker 이벤트 기록"""
         ctx = MockContext()
         result = await var_cvar_monitor_condition(
             data=mock_data_volatile,
@@ -229,3 +235,175 @@ class TestVarCvarMonitorPlugin:
         assert analysis["confidence_level"] == 99.0
         assert "portfolio_var_pct" in analysis
         assert "portfolio_cvar_pct" in analysis
+
+
+class TestVarCvarFractionalPosition:
+    """소수 포지션 회귀 — int() 절단 + max(1, qty // 2) 바닥올림 (X3).
+
+    ⚠️ 이 분기(positions 인자)는 워크플로우 실행기 경로에서는 도달하지 않는다 —
+    실행기의 data 기반 분기가 plugin_kwargs 에 ``positions`` 를 넣지 않기 때문이다
+    (플러그인 모듈 docstring 참조). 여기서 검증하는 것은 라이브러리를 직접
+    호출하는 경로와 계산식 자체다.
+    """
+
+    @staticmethod
+    def _volatile_bars(symbol="AAPL", n=70):
+        """VaR 가 임계를 확실히 넘도록 +-3% 로 진동하는 결정론적 시계열."""
+        bars = []
+        price = 150.0
+        for i in range(n):
+            price = price * (1.03 if i % 2 == 0 else 0.97)
+            bars.append({
+                "symbol": symbol, "exchange": "NASDAQ",
+                "date": f"2026-{(i // 28) + 1:02d}-{(i % 28) + 1:02d}",
+                "close": round(price, 4),
+            })
+        return bars
+
+    async def _run(self, qty, action="reduce_position", price=150.0):
+        return await var_cvar_monitor_condition(
+            data=self._volatile_bars(),
+            fields={"lookback": 20, "alert_threshold_pct": 1.0, "action": action},
+            positions=[{"symbol": "AAPL", "current_price": price, "qty": qty}],
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("qty", [0.532, 1, 10])
+    async def test_sell_quantity_never_exceeds_held(self, qty):
+        """0.532 / 1 / 10 보유 어느 쪽도 보유량을 넘는 수량을 싣지 않는다.
+
+        수정 전에는 0.532 보유에서 ``max(1, int(0.532) // 2) = 1`` 이 실렸다
+        (보유 초과 매도).
+        """
+        result = await self._run(qty)
+        assert result["result"] is True, "변동성 픽스처가 임계를 넘지 못했다"
+        passed = result["passed_symbols"][0]
+        assert passed["sell_quantity"] <= qty, (
+            f"보유 {qty} 인데 매도 수량 {passed['sell_quantity']}"
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("qty,expected", [(0.532, 0.266), (1, 0.5), (10, 5)])
+    async def test_sell_quantity_is_exact_half(self, qty, expected):
+        """정확히 절반 — 소수는 보존되고 정수는 int 로 남는다."""
+        result = await self._run(qty)
+        passed = result["passed_symbols"][0]
+        assert passed["sell_quantity"] == pytest.approx(expected)
+        if float(expected).is_integer():
+            assert isinstance(passed["sell_quantity"], int)
+
+    @pytest.mark.asyncio
+    async def test_fractional_position_value_is_not_zero(self):
+        """150달러 x 0.532 = 79.8 — 수정 전에는 int(0.532)=0 이라 0.0 으로 보고됐다."""
+        result = await self._run(0.532)
+        sr = result["symbol_results"][0]
+        assert sr["position_value"] == pytest.approx(79.8, abs=0.01)
+        assert sr["var_dollar"] > 0
+        assert "position_value_unavailable_reason" not in sr
+
+    @pytest.mark.asyncio
+    async def test_unreadable_quantity_leaves_reason_not_a_made_up_number(self):
+        """수량을 읽을 수 없으면 수량을 지어내지 않고 사유를 남긴다."""
+        result = await self._run("n/a")
+        passed = result["passed_symbols"][0]
+        sr = result["symbol_results"][0]
+        assert "sell_quantity" not in passed
+        assert "보유 수량을 읽을 수 없어" in sr["sell_quantity_unavailable_reason"]
+        assert "position_value" not in sr
+        assert "position_value_unavailable_reason" in sr
+
+    @pytest.mark.asyncio
+    async def test_missing_position_leaves_reason(self):
+        """positions 에 종목이 없으면 sell_quantity 대신 사유를 남긴다."""
+        result = await var_cvar_monitor_condition(
+            data=self._volatile_bars(),
+            fields={"lookback": 20, "alert_threshold_pct": 1.0, "action": "reduce_position"},
+            positions=[{"symbol": "MSFT", "current_price": 300.0, "qty": 5}],
+        )
+        passed = result["passed_symbols"][0]
+        sr = result["symbol_results"][0]
+        assert "sell_quantity" not in passed
+        assert "positions 입력에 해당 종목이 없어" in sr["sell_quantity_unavailable_reason"]
+
+    @pytest.mark.asyncio
+    async def test_exit_all_still_sells_everything(self):
+        """exit_all 은 수량 계산과 무관하게 'all' 이다 (회귀 가드)."""
+        result = await self._run(0.532, action="exit_all")
+        assert result["passed_symbols"][0]["sell_quantity"] == "all"
+
+
+class TestSellQuantityDeclarationMatchesValue:
+    """Z3 — output_fields 선언과 실제 값이 어긋나지 않아야 한다.
+
+    ``sell_quantity`` 는 'reduce_position' 에서는 숫자지만 'exit_all' 에서는 전량을
+    뜻하는 **문자열 "all"** 이다. 선언 type 은 레지스트리 공통 검증
+    (``test_plugin_output_fields.VALID_TYPES`` = float/int/str/bool/list/dict)이
+    유니온 표기를 허용하지 않으므로, description 이 두 모양을 모두 밝힌다.
+    """
+
+    def test_description_documents_the_all_string(self):
+        meta = VAR_CVAR_MONITOR_SCHEMA.output_fields["sell_quantity"]
+        desc = meta["description"]
+        assert '"all"' in desc, "문자열 'all' 을 싣는다는 사실이 선언에 없다"
+        assert "exit_all" in desc
+        assert "NOT always a number" in desc
+
+    def test_declared_type_stays_in_the_registry_vocabulary(self):
+        """공통 검증이 받는 어휘를 벗어나지 않는다(전 플러그인 일괄 테스트와 충돌 금지)."""
+        assert VAR_CVAR_MONITOR_SCHEMA.output_fields["sell_quantity"]["type"] in {
+            "float", "int", "str", "bool", "list", "dict"
+        }
+
+    @pytest.mark.asyncio
+    async def test_exit_all_really_emits_the_string(self):
+        result = await var_cvar_monitor_condition(
+            data=TestVarCvarFractionalPosition._volatile_bars(),
+            fields={"lookback": 20, "alert_threshold_pct": 1.0, "action": "exit_all"},
+            positions=[{"symbol": "AAPL", "current_price": 150.0, "qty": 10}],
+        )
+        assert result["passed_symbols"][0]["sell_quantity"] == "all"
+
+
+class TestReducePositionBelowOneShareIsNotSilent:
+    """Z4 — 1주 미만 축소 수량은 주문이 만들어지지 않는다는 사실을 드러낸다.
+
+    주문 송신부 ``NewOrderNodeExecutor._normalize_order`` 라이브 실측(2026-09-12,
+    executor 직접 호출): quantity 0.5 → None, 0.999 → None, 1.0 → quantity 1,
+    1.5 → quantity 1 + fractional_remainder 0.5. 즉 0 < 수량 < 1 이면 주문 자체가
+    만들어지지 않는다. 동작은 바꾸지 않고(수량 그대로) 사유만 드러낸다.
+    """
+
+    async def _run(self, qty):
+        return await var_cvar_monitor_condition(
+            data=TestVarCvarFractionalPosition._volatile_bars(),
+            fields={"lookback": 20, "alert_threshold_pct": 1.0, "action": "reduce_position"},
+            positions=[{"symbol": "AAPL", "current_price": 150.0, "qty": qty}],
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("qty,half", [(1, 0.5), (0.532, 0.266), (1.9, 0.95)])
+    async def test_sub_one_share_half_leaves_reason(self, qty, half):
+        result = await self._run(qty)
+        sr = result["symbol_results"][0]
+        assert sr["sell_quantity"] == pytest.approx(half)  # 수량은 그대로 둔다
+        assert result["passed_symbols"][0]["sell_quantity"] == pytest.approx(half)
+        assert "1주 미만" in sr["reduce_skipped_reason"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("qty", [2, 10, 3.5])
+    async def test_one_share_or_more_has_no_reason(self, qty):
+        result = await self._run(qty)
+        sr = result["symbol_results"][0]
+        assert sr["sell_quantity"] >= 1
+        assert "reduce_skipped_reason" not in sr
+
+    @pytest.mark.asyncio
+    async def test_unreadable_quantity_is_a_different_event(self):
+        """'못 읽음' 은 축소 무동작이 아니라 수량 미발행이다 — 사유 키가 다르다."""
+        result = await self._run("n/a")
+        sr = result["symbol_results"][0]
+        assert "sell_quantity_unavailable_reason" in sr
+        assert "reduce_skipped_reason" not in sr
+
+    def test_schema_declares_the_reason(self):
+        assert "reduce_skipped_reason" in VAR_CVAR_MONITOR_SCHEMA.output_fields

--- a/src/finance/CHANGELOG.md
+++ b/src/finance/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [1.9.6] - 2026-09-12
+
+### Changed
+- TC3 (overseas futures real-time fill) field documentation only — no runtime change. Recorded owner-observed
+  facts (2026-09-12, unverified in-repo) alongside the upstream labels: `fcm_fee` carries the FCM fee (upstream
+  title "매입잔고수량" is preserved with the conflict surfaced); `lineseq`/`filler2` reported always blank;
+  `orgn_ordr_no` populated only for modify/cancel; `sprd_*` populated only for spread instruments;
+  `lme_prdt_ccd` owner ("0" for non-LME) vs upstream ("blank") conflict left unresolved and both recorded.
+  `ccls_no`/`ordr_no` now state that the fill number is issued per execution (one order → N fill numbers)
+  and is the dedup key. Wording for required fields uses "populated / empty string" instead of "absent";
+  `examples` widened to the union of both readings.
+- New test guards TC3 required-field descriptions against "absent/not provided" vocabulary.
+
+### Notes
+- Pair with core 1.28.0 and engine 1.37.0.
+
 ## [1.9.5] - 2026-09-10
 
 ### Fixed

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/real/TC3/blocks.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/real/TC3/blocks.py
@@ -23,14 +23,35 @@ Field source policy (per CLAUDE.md ``feedback_no_inferred_formulas`` and the
       ``feedback_no_inferred_formulas``.
     - The ``fcm_fee`` field carries an ambiguous in-source label
       (``title="매입잔고수량"`` while the docstring notes "또는 FCM 수수료
-      필드") — preserved verbatim with the ambiguity surfaced in description.
+      필드") — the upstream ambiguity is still preserved verbatim, but a
+      2026-09-12 owner observation (~90% confidence) says the value actually
+      carried is the FCM (해외 브로커) fee, not a holding quantity: do not
+      parse it as a quantity. 미관측 — 라이브 TC3 프레임으로 대조하지 않았다
+      (출처: 오너 진술 2026-09-12).
     - The ``exec_prdt_tp_code`` field's source ``title`` matches
       ``ord_prdt_tp_code``'s title (``"주문상품구분코드"``) but its
       docstring describes "실행 상품 구분 코드" — preserved with the
       English clarifier in title.
     - Account number placeholders use ``"12345678901"`` per safety policy.
     - Spread / LME / 만기 fields are populated only for relevant contracts;
-      blank otherwise.
+      empty otherwise. 여기서 "비어 있다" 는 키가 없다는 뜻이 아니다 — 이
+      응답 모델의 필드는 전부 ``Field(...)`` required 이므로 스키마상 항상
+      존재하고 값만 빈 문자열('')이다. 소비 측 판별은 hasattr / ``is None``
+      이 아니라 ``== ''`` 로 해야 한다 — body 가 성공적으로 검증된 뒤라면
+      hasattr/None 분기는 발화하지 않는다. 다만 ``TC3RealResponse.body``
+      자체는 ``Optional[TC3RealResponseBody]`` 라서, 프레임에 body 가 없거나
+      required 키가 빠져 검증이 실패하면 ``real_base`` 가 ``body=None`` 을
+      콜백에 넘긴다 (``ls/real_base.py`` 의 ``body=... if resp_body else
+      None`` 분기와 검증 예외 분기 — 2026-09-12 기준 각각 342행 / 350행).
+      즉 None 검사는 ``response.body`` 객체 자체에 대해서는 필요하고,
+      검증을 통과한 body **안의 개별 필드**에 대해서만 불필요하다.
+    - 단, ``lme_prdt_ccd`` 의 "blank otherwise" 는 오너 진술("일반
+      해외선물이면 '0'", 2026-09-12, ~90% 확신)과 충돌한다 — 양쪽을 그 필드
+      description 에 병기했고 라이브 프레임으로만 결론낼 수 있다(미해결).
+    - ``sprd_base_isu_yn`` 은 스프레드 여부를 가리는 판별 플래그다. 오너의
+      "sprd_* 는 스프레드 상품에만" 포괄 진술이 이 판별 플래그에까지
+      적용되는지는 오너가 말한 바 없어 미확인이며, 상류는 아웃라이트에도
+      'N' 이 실린다고 선언한다 — 해당 필드 description 참조.
 """
 
 from typing import Optional
@@ -107,7 +128,14 @@ class TC3RealResponseBody(BaseModel):
     lineseq: str = Field(
         ...,
         title="라인일련번호 (Line sequence number)",
-        description="Line-level sequence number assigned by LS for the push frame.",
+        description=(
+            "Line-level sequence number assigned by LS for the push frame. "
+            "Owner reports it is always blank (2026-09-12, ~90% confidence); "
+            "unverified in-repo — 저장소 내 라이브 TC3 프레임으로 대조한 바 "
+            "없다. 오너 진술이 맞다면 채워진 적이 없으므로 정렬/중복제거 키로 "
+            "쓰지 말 것. 아래 examples 는 상류 선언값이며 관측값이 아니다. "
+            "(출처: 오너 진술 2026-09-12)"
+        ),
         examples=["1", "0001"],
     )
     key: str = Field(
@@ -143,14 +171,28 @@ class TC3RealResponseBody(BaseModel):
     ordr_no: str = Field(
         ...,
         title="주문번호 (Order number)",
-        description="Order number for the event, as a string.",
+        description=(
+            "Order number for the event, as a string. 주문 접수 시 발행되며 "
+            "체결 단위로 유일하지 않다 — 1주문이 분할체결되면 동일 값이 여러 "
+            "체결 푸시에 반복 등장한다. 체결 단위 식별 / 중복제거 키로 쓰지 "
+            "말 것(``ccls_no`` 참조). (출처: 오너 진술 2026-09-12)"
+        ),
         examples=["100001"],
     )
     orgn_ordr_no: str = Field(
         ...,
         title="원주문번호 (Original order number)",
-        description="Original order number this event references (0 / blank when not applicable).",
-        examples=["0", "100001"],
+        description=(
+            "Original order number this event references ('0' / 빈 "
+            "문자열('') when not applicable). Conditionally populated: "
+            "'' / '0' on new (신규) orders, carries the original order number "
+            "only on modify (정정) / cancel (취소) orders — 판정은 ``ordr_ccd`` "
+            "와 교차 확인할 것. 값이 안 채워지는 경우에도 필드는 스키마상 항상 "
+            "존재(required)하므로 판별은 hasattr / ``is None`` 이 아니라 "
+            "``== ''`` / ``== '0'`` 으로 하라. "
+            "(출처: 오너 진술 2026-09-12, ~90% 확신 · 라이브 프레임 미관측)"
+        ),
+        examples=["", "0", "100001"],
     )
     mthr_ordr_no: str = Field(
         ...,
@@ -201,7 +243,13 @@ class TC3RealResponseBody(BaseModel):
     ccls_no: str = Field(
         ...,
         title="체결번호 (Fill number)",
-        description="Exchange-assigned fill identifier, as a string.",
+        description=(
+            "Exchange-assigned fill identifier, as a string. 체결이 성립할 때 "
+            "발행된다 — 1주문이 분할체결되면 동일한 ``ordr_no`` 에 대해 N 개의 "
+            "``ccls_no`` 가 발행된다. 따라서 체결 단위 식별 / 중복제거 키는 "
+            "``ordr_no`` 가 아니라 ``ccls_no`` 여야 한다. "
+            "(출처: 오너 진술 2026-09-12)"
+        ),
         examples=["1"],
     )
     ccls_tm: str = Field(
@@ -254,9 +302,13 @@ class TC3RealResponseBody(BaseModel):
         description=(
             "Source declares ``title='매입잔고수량'`` (purchase holding "
             "quantity) but the in-source docstring notes the field may "
-            "alternatively represent an FCM fee. Both interpretations are "
-            "preserved verbatim from source — consume as returned by LS "
-            "and do not infer one over the other."
+            "alternatively represent an FCM fee. Both upstream readings are "
+            "kept on record, and the upstream label remains ambiguous. "
+            "2026-09-12 owner observation (~90% confidence): this field "
+            "carries the FCM (foreign broker) fee, not a holding quantity — "
+            "do not parse as quantity. 상류 라벨과 오너 관측이 갈리므로 값 "
+            "자체는 LS 가 준 그대로 소비하되, 잔고 수량 목적의 파싱은 금지. "
+            "(출처: 오너 진술 2026-09-12 · 라이브 프레임 미관측)"
         ),
         examples=["0", "0.25"],
     )
@@ -314,8 +366,22 @@ class TC3RealResponseBody(BaseModel):
     sprd_base_isu_yn: str = Field(
         ...,
         title="스프레드종목여부 (Spread-instrument flag)",
-        description="Spread-instrument flag. 'Y' = spread instrument, 'N' = outright.",
-        examples=["Y", "N"],
+        description=(
+            "Spread-instrument flag. Upstream declares 'Y' = spread "
+            "instrument, 'N' = outright (즉 상류 기준으로는 아웃라이트 "
+            "체결에도 'N' 이 실린다). Owner observation (2026-09-12, ~90% "
+            "confidence) says the ``sprd_*`` family is filled in only for "
+            "spread-product trades; 다만 그 포괄 진술이 '스프레드 여부를 "
+            "가리는 이 판별 플래그' 에까지 적용되는지는 오너가 말한 바 없어 "
+            "미확인이다 — 판별 플래그마저 비면 스프레드 여부를 알 방법이 "
+            "사라지므로 상류 해석이 오히려 유력하다. CONFLICT UNRESOLVED: "
+            "라이브 프레임으로 확정되기 전까지 'N' 과 빈 문자열('')을 모두 "
+            "비(非)스프레드로 취급하라. 값이 안 채워지는 경우에도 필드는 "
+            "스키마상 항상 존재(required)하며 빈 문자열('')로 온다 — 판별은 "
+            "hasattr / ``is None`` 이 아니라 ``== ''`` 로 할 것. "
+            "(출처: 오너 진술 2026-09-12 · 라이브 프레임 미관측)"
+        ),
+        examples=["Y", "N", ""],
     )
     ccls_dt: str = Field(
         ...,
@@ -326,17 +392,28 @@ class TC3RealResponseBody(BaseModel):
     filler2: str = Field(
         ...,
         title="FILLER2 (Reserved area 2)",
-        description="Reserved area; consume as returned by LS.",
+        description=(
+            "Reserved area; consume as returned by LS. Owner reports it is "
+            "always blank (2026-09-12, ~90% confidence); unverified in-repo — "
+            "저장소 내 라이브 TC3 프레임으로 대조한 바 없다. 더미 필드이므로 "
+            "의미 있는 값이 실려 오는 경우를 가정하지 말 것. "
+            "(출처: 오너 진술 2026-09-12)"
+        ),
         examples=[""],
     )
     sprd_is_cd: str = Field(
         ...,
         title="스프레드종목코드 (Spread instrument code)",
         description=(
-            "Spread instrument code for spread fills; blank otherwise. "
+            "Spread instrument code for spread fills; empty otherwise. "
             "LS-internal spread-symbol encoding is not declared in "
             "available source — consume as returned by LS, do not assume "
-            "a particular leg-pair format."
+            "a particular leg-pair format. Owner observation (2026-09-12, "
+            "~90% confidence): populated only when a spread product is "
+            "traded — 일반 해외선물 체결에서는 빈 문자열('')로 온다. 필드는 "
+            "스키마상 항상 존재(required)하며 값만 비어 있으므로, 판별은 "
+            "hasattr / ``is None`` 이 아니라 ``== ''`` 로 할 것. "
+            "(출처: 오너 진술 2026-09-12 · 라이브 프레임 미관측)"
         ),
         examples=[""],
     )
@@ -344,17 +421,35 @@ class TC3RealResponseBody(BaseModel):
         ...,
         title="LME상품유형 (LME product-type code)",
         description=(
-            "LME product-type classifier (populated for LME contracts; "
-            "blank otherwise). Code mapping not declared in available source."
+            "LME product-type classifier. Upstream source: populated for "
+            "LME contracts, blank otherwise. Owner observation (2026-09-12, "
+            "~90% confidence): ordinary (non-LME) overseas futures carry "
+            "'0', LME items carry '1' / '2'. CONFLICT UNRESOLVED — 상류는 "
+            "비LME 를 공백이라 하고 오너는 '0' 이라 한다; 어느 쪽도 버리지 "
+            "않고 병기하며 라이브 프레임을 받아야 결론난다(live frame "
+            "needed). 잠정 지침으로 소비 측이 '' 와 '0' 을 모두 'LME 상품 "
+            "아님' 으로 동일 취급할 수는 있으나, 이는 오너 해석 쪽으로 충돌을 "
+            "닫는 선택이다 — 상류 해석('populated for LME contracts, blank "
+            "otherwise')이 맞다면 '0' 은 값이 실린 상태 = LME 계약일 수 있어 "
+            "이 잠정 규칙은 LME 계약을 비LME 로 접는 오분류 위험을 안는다. "
+            "Code mapping otherwise not declared in available source. "
+            "아래 examples 는 상류 선언('')과 오너 진술('0' / '1' / '2')을 "
+            "합집합으로 나열한 것이며 관측값이 아니다. "
+            "(출처: 오너 진술 2026-09-12 · 라이브 프레임 미관측)"
         ),
-        examples=[""],
+        examples=["", "0", "1", "2"],
     )
     lme_sprd_prc: str = Field(
         ...,
         title="LME스프레드가격 (LME spread price)",
         description=(
             "LME spread price as a string (populated for LME contracts; "
-            "blank otherwise). Scale not declared."
+            "empty otherwise). Scale not declared. Owner observation "
+            "(2026-09-12, ~90% confidence): filled in only when a spread "
+            "product is traded — 일반 해외선물 체결에서는 빈 문자열('')로 "
+            "온다. 필드는 스키마상 항상 존재(required)하며 값만 비어 "
+            "있으므로, 판별은 hasattr / ``is None`` 이 아니라 ``== ''`` 로 할 "
+            "것. (출처: 오너 진술 2026-09-12 · 라이브 프레임 미관측)"
         ),
         examples=[""],
     )

--- a/src/finance/pyproject.toml
+++ b/src/finance/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-finance"
-version = "1.9.5"
+version = "1.9.6"
 license = "AGPL-3.0-or-later"
 description = "프로그램 동산 운영진이 관리하는 증권사 데이터 오픈소스"
 readme = "README.md"

--- a/src/finance/tests/test_tc3_required_field_description_truth.py
+++ b/src/finance/tests/test_tc3_required_field_description_truth.py
@@ -1,0 +1,131 @@
+"""Regression guard against absence vocabulary on TC3's required field descriptions.
+
+Why this test exists (2026-09-12 LS 브로커 필드 의미 확인 후속):
+    Every field on ``TC3RealResponseBody`` is declared ``Field(...)`` —
+    i.e. **required**. A required key is always present in a validated body;
+    what varies is only its *value* (often the empty string ``''`` or
+    ``'0'``). Descriptions that say a field is "not provided" / "제공되지
+    않음" / "Conditionally provided" push consumers toward ``hasattr()`` or
+    ``is None`` checks that can never fire on a validated body, so the real
+    empty-value case (``== ''`` / ``== '0'``) silently goes unhandled.
+
+    ``TC3RealResponse.body`` itself is ``Optional[...]`` (``real_base``
+    passes ``body=None`` when the frame carries no body or validation
+    fails), so ``None`` checks remain correct for the **body object** — but
+    never for individual fields inside a body that validated.
+
+The two existing metadata guards do not cover this:
+    - ``test_field_metadata_coverage.py`` reads ``examples`` / ``title``,
+      never ``description``.
+    - ``test_literal_field_docstring_truth.py`` only scans
+      ``Literal[...]``-typed fields (TC3's fields are all ``str``).
+
+Run only this module:
+
+    cd src/finance && pytest tests/test_tc3_required_field_description_truth.py -v
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Tuple
+
+import pytest
+
+from programgarden_finance.ls.overseas_futureoption.real.TC3.blocks import (
+    TC3RealResponseBody,
+)
+
+
+# Phrases that describe a *missing key*. On an all-required model they are
+# false: the key is always there, only the value is empty.
+_ABSENCE_PATTERNS: Tuple[Tuple[str, re.Pattern[str]], ...] = (
+    ("미제공", re.compile("미제공")),
+    ("제공되지 않", re.compile(r"제공되지\s*않")),
+    ("not provided", re.compile(r"not\s+provided", re.IGNORECASE)),
+    ("absent", re.compile(r"\babsent\b", re.IGNORECASE)),
+    # The exact framing removed on 2026-09-12: "Conditionally provided:" reads
+    # as "the key may be omitted"; the truthful wording is
+    # "Conditionally populated" + "== '' / == '0'" guidance.
+    ("conditionally provided", re.compile(r"conditionally\s+provided", re.IGNORECASE)),
+)
+
+
+def _offending_phrases(text: str) -> List[str]:
+    return [label for label, pattern in _ABSENCE_PATTERNS if pattern.search(text)]
+
+
+def _required_fields() -> List[Tuple[str, str]]:
+    """[(field_name, description)] for every required field of the response body."""
+    out: List[Tuple[str, str]] = []
+    for name, info in TC3RealResponseBody.model_fields.items():
+        if not info.is_required():
+            continue
+        out.append((name, info.description or ""))
+    return out
+
+
+def test_all_response_body_fields_are_required():
+    """Premise of this guard: the TC3 push body has no optional field.
+
+    If this ever fails, the "always present, only the value is empty"
+    reasoning below no longer holds for the newly-optional field and the
+    absence-vocabulary rule must be revisited for it (do not just delete
+    this assertion).
+    """
+    optional = [
+        name
+        for name, info in TC3RealResponseBody.model_fields.items()
+        if not info.is_required()
+    ]
+    assert optional == [], (
+        f"TC3RealResponseBody gained optional field(s): {optional}. "
+        "The required-field description rule assumes every key is always present."
+    )
+    # Upstream TC3 schema size, pinned so a silent field add/drop is reviewed.
+    assert len(TC3RealResponseBody.model_fields) == 37, (
+        "TC3RealResponseBody field count changed from 37 to "
+        f"{len(TC3RealResponseBody.model_fields)} — review the schema change."
+    )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "description"),
+    _required_fields(),
+    ids=[name for name, _ in _required_fields()],
+)
+def test_required_field_description_has_no_absence_vocabulary(field_name, description):
+    """A required field's description must not claim the key can be missing."""
+    offending = _offending_phrases(description)
+    assert not offending, (
+        f"TC3RealResponseBody.{field_name} description uses absence vocabulary "
+        f"{offending}, but the field is required (the key is always present on a "
+        "validated body). Describe the empty *value* instead — e.g. "
+        "\"Conditionally populated … 판별은 hasattr / is None 이 아니라 "
+        "== '' / == '0' 으로 하라\".\n"
+        f"      description: {description!r}"
+    )
+
+
+def test_detector_fires_on_known_bad_wording_as_positive_control():
+    """Sanity: the scanner is not vacuous — it catches each banned phrasing."""
+    samples = {
+        "미제공": "신규 주문에서는 미제공.",
+        "제공되지 않": "신규 주문에서는 제공되지 않는다.",
+        "not provided": "Not provided on new orders.",
+        "absent": "The key is absent for outright fills.",
+        "conditionally provided": "Conditionally provided: blank on new orders.",
+    }
+    for expected_label, text in samples.items():
+        assert expected_label in _offending_phrases(text), (
+            f"detector missed {expected_label!r} in {text!r}"
+        )
+    # Negative control: the truthful replacement wording must pass.
+    good = (
+        "Conditionally populated: '' / '0' on new (신규) orders. 필드는 스키마상 "
+        "항상 존재(required)하므로 판별은 hasattr / ``is None`` 이 아니라 "
+        "``== ''`` / ``== '0'`` 으로 하라."
+    )
+    assert _offending_phrases(good) == [], (
+        f"detector false-positive on truthful wording: {_offending_phrases(good)}"
+    )

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,3 +1,60 @@
+## [1.37.0] - 2026-09-12
+
+LS 브로커 필드 의미를 오너가 확인해준 사실(체결번호·AP처리시각·소수점 주식·TC3 조건부 필드·국내 매체코드)로
+코드를 전수 대조해 확정된 결함을 고친 릴리스. 체결 **분류(classification)** 가 깨지던 경로가 여럿 있었다.
+
+### Fixed
+- **국내주식 신규주문이 원장(`workflow_orders`)에 기록되지 않던 결함** — `record_workflow_order` 호출이
+  해외주식·해외선물에만 있고 국내(CSPAT00601)에 없어, 국내 워크플로우 체결이 한 건도 `workflow` 로 분류될 수
+  없었다(승률·손익비 전량 누락, pg-worker 전건 드롭). 성공 분기에 동일 규약(로컬 주문일자)으로 기록.
+- **정정(modify) 주문** — 브로커가 발급한 새 주문번호를 원장에 기록하지 않아 정정 후 체결이 오분류되던 결함.
+  세 경로(COSAT00311/CIDBT00900/CSPAT00701) 모두 원 주문 행에서 side·symbol·수량·가격을 **승계**해 기록하고
+  와이어에도 같은 값을 싣는다(SDK 예제가 실제 값을 싣고 CSPAT00701 은 0 을 시장가용 값으로 명시하므로 '0=변경 없음'
+  으로 보지 않는다). 해외선물 `BnsTpCode` 가 존재할 수 없는 config 키(`side` — ModifyOrder 노드에 없음)에서
+  항상 '2'(매수)로 나가던 것을 원 주문 방향으로 교정. 원 주문을 못 찾으면 방향을 추측하지 않고 실패
+  (`original_order_not_found`), 원장 트래커 자체가 없으면 `ledger_unavailable` 로 구분하되 호출자가 side 를
+  명시하면 그 값을 쓴다. 정수가 아닌 승계 수량(`non_integer_quantity`)·0 이하 수량·승계 가격 0 이하
+  (`non_positive_inherited_price`, 시장가 주문 승계)는 게이트에서 거부 — 정정 TR 은 정수 수량만 받고 0 에
+  '변경 없음' 뜻이 없다. `find_workflow_order` 는 오늘 → D±1 창(종목 일치) 순으로 조회(전 기간 폴백 폐기).
+- **SC1 `execno` / TC3 `ccls_no` 를 `execution_id` 로 싣는다**(AS1 `sExecNO` 와 동일). 두 상품은 원장
+  중복방지가 통째로 비활성이었다. 주문번호/주문일자가 쓸 수 없으면 싣지 않는다.
+- **체결 유실 부류 차단** — identity 정규화 예외(`ExecutionIdentityError`, 신설)가 `record_workflow_fill` 의
+  광역 except 에 삼켜져 체결이 통째로 사라지던 경로를 닫았다: 그 예외에 한해 identity 없이 한 번 더 기록
+  (중복방지만 포기, 체결은 보존, warning). `ExecutionIdentityConflictError` 는 재시도하지 않는다. 버퍼 처리
+  태스크(`create_task`) 의 침묵 실패에 예외 로깅 콜백 추가.
+- **AS1 체결시각** — `proctm`(AP처리시각, AS0~AS4 공용 프레임 헤더 필드)을 체결시각으로 쓰던 것을
+  `sExecTime` → `sRcptExecTime` 순으로 교체. 둘 다 비면 **빈 문자열**(합성 `now()` 폴백 제거 — 서버가 도착시각
+  폴백을 정직하게 표시하도록). SC1/TC3 의 합성 폴백도 제거. ⚠️ `sExecTime` 의 자릿수·타임존은 **라이브 미관측**.
+- **TC3 매체코드 `'40'` 하드코딩 폐기** — 프레임에 매체 필드가 없으므로 빈 값으로 싣는다(분류 결과 불변;
+  `detect_anomalies` 분모 오염 제거).
+- **매체코드 표** — 국내 SC1 값 **60(HTS)·50(MTS)** 을 사람 채널에 추가(출처: 오너 진술 2026-09-12, 라이브
+  미관측 — SDK 는 국내 매체코드 enum 미선언). 단일 합집합 표 유지(같은 코드가 시장별로 다른 채널을 뜻하는
+  사례 없음; 혼합 워크플로우에서 상품 분기가 오분류를 만들어 분기하지 않음).
+- **주문일자 창 매칭** — 주문 기록(접수 시점 로컬 날짜)과 AS1 체결(수신 시점 로컬 날짜)이 KST 자정을 넘기면
+  갈려 우리 체결이 `unknown_api` 로 떨어지던 결함, 그리고 LS 야간장 영업일 파일링(TC3 `ordr_dt` = 전 영업일,
+  2026-09-10 실측)으로 반대 방향이 갈리던 결함. 정확일치(SQL 등가조회) 실패 시에만 D±1 창으로 넓히되
+  **①후보 정확히 1건 ②종목 일치 ③방향 일치 ④사람 매체코드면 거부 ⑤주문 created_at↔체결 수신 12시간 이내
+  ⑥체결수량 ≤ 주문수량** 을 모두 요구한다(넓힌 창은 추론이므로). 시각 가드는 휴리스틱이다 — 미국주식은 KST
+  주간(09:00~)에도 거래되므로 세션 경계로 가를 수 없다. `lookup_order_identity` 도 같은 매처를 써 창으로
+  매칭된 체결에 node_id 가 붙는다.
+- `detect_anomalies` 의 unknown_api 비율 분모를 `commda_code='40'` 리터럴 대신 `media_channel()` 기준으로.
+- `RealAccountNode` 해외주식 미체결 수량 `int()` 절삭(소수점 주식 → 0) 및 `filled_qty` 필드명 오타
+  (SDK 실제 필드 `executed_qty`, 항상 0 이었음) 수정. `exchange` 는 SDK 매핑이 떨어뜨리는 값이라 사유 표기.
+- 위험관리 HWM `position_qty` 를 `int()` 로 잘라 소수점 포지션의 트레일링 고점을 재시작마다 리셋하던 결함 —
+  Decimal 보관(SQLite 저장 시 float 바인딩). NaN 가드, 0 수량 연속 매수 시 0 나눗셈 가드.
+- `sync_fills_from_history` — 존재하지 않는 `FillEvent` import 로 호출 즉시 죽고 0 을 돌려주던 죽은 복구 경로를
+  **미구현으로 명시**(명시적 로그 + 0 반환, 독스트링에 별도 작업 필요 기록). 동작 복원은 후속.
+- `record_workflow_fill(commda_code)` 기본값 `"40"` → `""`.
+
+### Changed
+- deps: `programgarden-finance ^1.9.6`, `programgarden-community ^1.15.2` (core 1.28.0 유지 — 이번 릴리스에
+  core 변경 없음).
+
+### Known / 후속
+- `sExecTime` 형식·타임존 미관측(월 2026-09-14 주간장 1주 체결로 확정 예정). 국내 매체코드 60/50 미관측.
+- SC2/SC3 미구독(국내 정정·취소 확인이 원장에 반영되지 않음), `_ls_korea_stock_order_event` 파서 필드명 오류,
+  `_parse_tc3_data` 의 `fill_price` 키 오타, 트레이앱 `on_order_fill` 미구현 — 별건.
+
 ## [1.36.0] - 2026-09-12
 
 ### Added

--- a/src/programgarden/programgarden/context.py
+++ b/src/programgarden/programgarden/context.py
@@ -11,7 +11,7 @@ Workflow execution context protocol
 
 from typing import Optional, Dict, Any, List, Protocol, runtime_checkable, Callable, Awaitable, TYPE_CHECKING, Tuple
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from collections import deque
 import asyncio
@@ -43,6 +43,25 @@ from programgarden_core.bases.listener import (
 from programgarden_core.models.resilience import RetryEvent
 
 logger = logging.getLogger("programgarden.context")
+
+# 체결시각을 브로커 프레임이 싣지 않았을 때 **원장에만** 쓰는 표식.
+#
+# 서버로 나가는 OrderFillEvent.fill_time 은 이때 빈 문자열이어야 한다 — 소비자
+# (pg-worker app/order_fill_updates.py)가 `order_date + fill_time` 을 시장 세션
+# 타임존으로 읽어 executed_at 을 **계산된 체결시각**으로 확정하기 때문이다. 값이
+# 없는데 무언가를 채우면 그게 체결시각으로 승격된다(엔진 <= v1.36.0 이
+# `datetime.now().strftime('%H%M%S000')` 를 합성하던 자리가 정확히 그 사고였다).
+#
+# 그런데 원장(workflow_position_lots.fill_datetime = f"{order_date}_{fill_time}")
+# 에 빈 값을 그대로 넣으면 다른 결함이 생긴다: 날짜 필터가
+# `fill_datetime >= f"{start_date}_000000000"` 문자열 비교라
+# ("20260912_" < "20260912_000000000") 그 로트가 **대회 구간 PnL 에서 통째로
+# 사라진다**(workflow_position_tracker.get_workflow_positions / calculate_pnl).
+# 그래서 원장에는 숫자가 아닌 표식을 쓴다 — 시계 값으로 오독될 수 없고(비숫자),
+# 날짜 필터에 포함되며("u" > "0"), FIFO 정렬에서는 그날 알려진 시각들 뒤에 온다.
+# 이 값은 컨텍스트 밖으로 나가지 않는다: _on_tracker_fill_classified 가 이벤트를
+# 만들 때 다시 빈 문자열로 되돌린다.
+UNKNOWN_FILL_TIME = "unknown"
 
 
 def _honest_execution_count(metrics, product, order_lifecycle_handler):
@@ -2512,6 +2531,22 @@ class ExecutionContext:
             logger.warning(f"Failed to init risk tracker: {e}")
             self._workflow_risk_tracker = None
 
+    def has_workflow_order_ledger(self) -> bool:
+        """이 실행에 **워크플로우 주문 원장이 존재하는가**(행이 있는지가 아니다).
+
+        트래커는 워크플로우에 PnL 리스너가 하나라도 있을 때만 만들어진다
+        (init_workflow_position_tracker 의
+        ``any(hasattr(l, 'on_workflow_pnl_update') ...)`` 게이트). 리스너 0개로
+        엔진을 라이브러리처럼 직접 구동하거나 초기화가 예외로 끝나면 트래커는
+        None 이고, 그러면 record_workflow_order 는 **no-op** 이라 원장에 행이
+        생길 수 없고 find_workflow_order 는 영원히 None 이다.
+
+        정정(ModifyOrder) 경로가 '원장에 행이 없다' 와 '원장 자체가 없다' 를
+        갈라 말하려고 쓴다 — 앞은 "그 주문을 우리가 기록한 적 없다", 뒤는
+        "이 구성에서는 어떤 주문도 조회할 수 없다" 로 운영자 조치가 다르다.
+        """
+        return self._workflow_position_tracker is not None
+
     def record_workflow_order(
         self,
         order_no: str,
@@ -2522,6 +2557,8 @@ class ExecutionContext:
         quantity: int,
         price: float,
         node_id: str,
+        *,
+        register_risk: bool = True,
     ) -> None:
         """Record workflow order for FIFO tracking.
         
@@ -2537,8 +2574,24 @@ class ExecutionContext:
             quantity: 수량
             price: 가격
             node_id: 주문을 실행한 노드 ID
+            register_risk: 리스크 트래커(HWM) 부수효과를 낼지 여부.
+                기본 True 는 **신규 주문** 의미다 — buy 면 HWM 을 등록하고
+                (register_symbol: 수량 누적 + 평단 갱신), 전량 매도면 해제한다.
+                정정(ModifyOrder)처럼 *이미 접수된 같은 주문의 새 주문번호* 를
+                남기는 경로는 False 로 불러야 한다. 정정은 새 포지션이 아니므로
+                HWM 에 수량을 한 번 더 더하거나(같은 물량 이중계상),
+                아직 체결되지도 않은 매도 정정으로 HWM 을 풀어버리면 안 된다.
+                원장 행 자체는 체결 분류((order_no, order_date) 대조)에 필요하므로
+                기록은 그대로 하고 리스크 부수효과만 끈다.
         """
         if self._workflow_position_tracker is None:
+            # 원장 자체가 없는 구성(PnL 리스너 0개 / 초기화 실패)이다. 조용히
+            # 지나가면 나중에 find_workflow_order 가 영원히 None 인 이유를 알 수
+            # 없으므로 최소한 흔적은 남긴다(주문마다 나므로 debug).
+            logger.debug(
+                "Workflow order ledger unavailable; not recording order %s (%s %s %s)",
+                order_no, symbol, side, quantity,
+            )
             return
         
         try:
@@ -2556,7 +2609,8 @@ class ExecutionContext:
             logger.debug(f"Recorded workflow order: {order_no} ({symbol} {side} {quantity})")
 
             # ━━━ Risk Tracker 체결 연동 ━━━
-            if self._workflow_risk_tracker:
+            # register_risk=False 는 "이 행은 새 포지션이 아니다"(정정 경로).
+            if register_risk and self._workflow_risk_tracker:
                 if side == "buy":
                     self._workflow_risk_tracker.register_symbol(
                         symbol=symbol,
@@ -2573,6 +2627,172 @@ class ExecutionContext:
                         self._workflow_risk_tracker.unregister_symbol(symbol)
         except Exception as e:
             logger.warning(f"Failed to record workflow order: {e}")
+
+    def find_workflow_order(
+        self,
+        order_no: str,
+        order_date: Optional[str] = None,
+        *,
+        symbol: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """원장에 기록된 워크플로우 주문 1건을 **읽기 전용**으로 조회한다.
+
+        정정(ModifyOrder) 경로가 원 주문의 방향(side)·종목·수량·가격을 승계하기
+        위해 쓴다. ModifyOrder 계열 노드 스키마에는 side 필드가 아예 없어
+        (core/programgarden_core/nodes/order.py:245-263 = connection /
+        original_order_id / symbol / exchange), config 에서 읽으면 사실상 항상
+        "buy" 가 된다. 그 값으로 record_workflow_order 를 부르면 보유하지도 않은
+        종목에 롱 HWM 이 등록되고(register_symbol), 이후 그 종목 신규 매수가
+        drawdown 게이트에 막힌다. 방향은 **추측하지 않고 원장에서 승계**한다.
+
+        조회 범위는 이 원장의 product/provider/trading_mode 로 한정한다.
+        주문번호는 정확히 일치하는 행을 먼저 보고, 없으면 0-패딩 차이를 흡수한
+        정규화 형태로 맞춘다(ACK 의 "0000123" 과 체결 프레임의 "123").
+
+        order_date 를 주면 **같은 날짜의 행을 먼저** 본다 — 브로커 주문번호는
+        날짜 안에서만 유일하므로, 날짜가 다른 행을 아무렇게나 집으면 어제 다른
+        주문의 방향을 승계한다.
+
+        그래도 자정을 관통하는 정정(장 마감 직전 접수 → 자정 이후 정정)은 살려야
+        한다. 종전에는 그걸 **전 기간 스캔 + 후보 정확히 1건**으로 풀었는데, 그건
+        워크플로우 DB 가 며칠~몇 주 누적되는 한 거의 항상 실패한다 — 브로커
+        주문번호는 **영업일마다 리셋**되므로(근거: database/workflow_position_tracker.py
+        모듈 독스트링 — 창 가드 수용조건 ④의 근거로 쓰이는 사실) 같은 번호가
+        과거 날짜에 또 있는 순간 후보가 2건이 돼 None → side 미해결 → 브로커 호출
+        0회 거부가 된다.
+
+        그래서 전 기간 폴백을 버리고, 트래커가 이미 세운 **D±1 창 규약**을 그대로
+        쓴다(_order_date_window 와 같은 조건: D-1·D+1 두 칸만, D±2 이상은 보지
+        않는다). 창 후보가 여러 건이면 **종목 일치**로 가른다(tracker 의 창 수용
+        조건 ② 와 같은 조건 — 종목이 다른 후보는 남의 주문번호 재발급이다).
+        종목까지 같은 후보가 둘 이상이면 모호하므로 None — '방향을 추측하지
+        않는다' 는 안전성은 그대로다. 정확일치(같은 날짜) 경로의 의미는 건들지
+        않는다 — 거긴 (주문번호, 주문일자) 동시 일치가 더 강한 증거다(tracker 모듈
+        독스트링과 같은 분배).
+
+        Args:
+            symbol: 주어지면 **창 경로의 후보 판정에만** 쓰인다(정확일치 경로는
+                종전 그대로). 비워두면 창 후보가 정확히 1건일 때만 수용한다.
+
+        Returns:
+            {"order_no", "order_date", "symbol", "exchange", "side",
+             "quantity", "price", "node_id", "job_id"} 또는 None(미발견/조회 실패).
+        """
+        tracker = self._workflow_position_tracker
+        if tracker is None:
+            return None
+
+        def _norm(value: Any) -> Optional[str]:
+            # workflow_position_tracker._normalize_identifier 의 숫자 규칙과 같은
+            # 접음(0-패딩 제거). 사설 메서드를 건드리지 않으려고 여기서 최소 구현.
+            text = str(value).strip() if value is not None else ""
+            if not text:
+                return None
+            return (text.lstrip("0") or None) if text.isdigit() else text
+
+        def _window(date: Any) -> List[str]:
+            """정확일치가 실패했을 때만 훑는 후보 날짜 — **D-1 과 D+1, 두 칸**.
+
+            workflow_position_tracker._order_date_window 와 **같은 규약**이다(근거는
+            그 모듈 독스트링: 실시간 체결 프레임의 로컬 날짜 채움 → D-1, LS 야간
+            세션의 전 영업일 파일링 → D+1). 사설 메서드를 건드리지 않으려고 여기
+            최소 구현한다(위 _norm 과 같은 이유). 날짜가 YYYYMMDD 가 아니면 창을
+            넓히지 않는다 — 근거 없는 매칭을 만들지 않기 위해서다.
+            """
+            try:
+                base = datetime.strptime(str(date or "").strip(), "%Y%m%d")
+            except (TypeError, ValueError):
+                return []
+            return [
+                (base - timedelta(days=1)).strftime("%Y%m%d"),
+                (base + timedelta(days=1)).strftime("%Y%m%d"),
+            ]
+
+        def _symbol_matches(row_symbol: Any) -> bool:
+            # tracker._normalize_symbol 과 같은 규칙(strip + upper).
+            return (str(row_symbol or "").strip().upper()
+                    == str(symbol or "").strip().upper())
+
+        wanted = _norm(order_no)
+        if wanted is None:
+            return None
+
+        want_symbol = bool(str(symbol or "").strip())
+
+        import sqlite3
+
+        columns = ("order_no, order_date, symbol, exchange, side, "
+                   "quantity, price, node_id, job_id")
+
+        def _matching_rows(scope: Tuple[Any, ...], db_path: str,
+                           date: Optional[str]) -> list:
+            # 0-패딩 차이는 SQL 로 접을 수 없어(정규화가 파이썬 규칙) 후보를 읽어
+            # 와서 거른다. 날짜를 주면 그날 주문으로 범위를 묶어 스캔을 줄인다.
+            sql = (f"SELECT {columns} FROM workflow_orders "
+                   "WHERE product = ? AND provider = ? AND trading_mode = ?")
+            params: Tuple[Any, ...] = scope
+            if date:
+                sql += " AND order_date = ?"
+                params = scope + (date,)
+            sql += " ORDER BY created_at DESC"
+            with sqlite3.connect(db_path) as conn:
+                return [r for r in conn.execute(sql, params).fetchall()
+                        if _norm(r[0]) == wanted]
+
+        try:
+            # 🔴 트래커 속성 독출도 try 안에 둔다. 독스트링이 'None(미발견/조회
+            # 실패)' 를 약속하는데, product/provider/trading_mode/db_path 중 하나라도
+            # 없는 트래커(테스트 더블·구판 트래커)를 물면 AttributeError 가 호출자
+            # (정정 경로)로 그대로 올라가 정정 자체를 죽인다. 조회 실패는 None 이다.
+            scope = (tracker.product, tracker.provider, tracker.trading_mode)
+            db_path = tracker.db_path
+
+            def _rows(date: Optional[str]) -> list:
+                return _matching_rows(scope, db_path, date)
+
+            row = None
+            if order_date:
+                same_date = _rows(order_date)
+                if same_date:
+                    row = same_date[0]
+                else:
+                    # 장 마감 직전 주문 → 자정 이후 정정(자정 관통). 전 기간을 훑지
+                    # 않고 **D±1 두 칸**만 본다 — 주문번호는 영업일마다 리셋되므로
+                    # 누적된 DB 에서 전체 유일성을 요구하면 멀지않아 항상 거부된다.
+                    widened = [r for d in _window(order_date) for r in _rows(d)]
+                    if want_symbol:
+                        # 창 후보는 '날짜가 한 칸 어긋났을 것' 이라는 추론이다.
+                        # 종목이 다른 후보는 남의 주문번호 재발급이므로 버린다
+                        # (tracker 창 수용조건 ② 와 같은 조건).
+                        widened = [r for r in widened if _symbol_matches(r[2])]
+                    if len(widened) != 1:
+                        return None
+                    row = widened[0]
+                    logger.warning(
+                        "find_workflow_order: order %s recorded on %s but looked up "
+                        "for %s; using the single D±1 match (symbol=%s)",
+                        order_no, row[1], order_date, row[2],
+                    )
+            else:
+                anywhere = _rows(None)
+                if not anywhere:
+                    return None
+                row = anywhere[0]
+        except Exception as e:
+            logger.warning(f"find_workflow_order failed: {e}")
+            return None
+
+        return {
+            "order_no": row[0],
+            "order_date": row[1],
+            "symbol": row[2],
+            "exchange": row[3],
+            "side": row[4],
+            "quantity": row[5],
+            "price": row[6],
+            "node_id": row[7],
+            "job_id": row[8],
+        }
 
     def update_workflow_order_fill_price(
         self,
@@ -2616,7 +2836,7 @@ class ExecutionContext:
         quantity: int,
         price: float,
         fill_time: str,
-        commda_code: str = "40",
+        commda_code: str = "",
         *,
         execution_id: Optional[str | int] = None,
         account_avg_price: Optional[float] = None,
@@ -2633,8 +2853,15 @@ class ExecutionContext:
             side: 매매구분 ("buy" | "sell")
             quantity: 체결 수량
             price: 체결 가격
-            fill_time: 체결시각 (HHMMSSsss)
-            commda_code: 매체구분코드 (프레임 값 그대로; "40"=OPEN API, 기타=수동/HTS)
+            fill_time: 체결시각 (HHMMSSsss). 프레임이 체결시각을 싣지 않았으면
+                **빈 문자열**을 넘긴다 — 값을 합성하면 하류(pg-worker)가 그걸
+                거래소 체결시각으로 승격시킨다. 원장 쪽 표기는 이 메서드가
+                UNKNOWN_FILL_TIME 으로 바꿔 넣고, 서버로 나가는 이벤트에서는
+                다시 빈 문자열로 되돌린다(_on_tracker_fill_classified).
+            commda_code: 매체구분코드 — **프레임 값 그대로**. 기본값은 ""(= 프레임이
+                말하지 않음)이다. 종전 기본값 "40"(OPEN API)은 관측되지 않은 값을
+                원장에 증거처럼 남기는 조작값이었다(tracker.detect_anomalies 가
+                `WHERE commda_code='40'` 을 unknown_api 비율 분모로 쓴다).
             execution_id: Optional broker execution number, preserved for durable replay detection.
             account_avg_price: Optional account average purchase price for this
                 symbol at fill time; only a workflow sell's residual tail uses it.
@@ -2646,11 +2873,56 @@ class ExecutionContext:
             logger.debug("Workflow position tracker not initialized, skipping record_fill")
             return "skipped"
         
+        # 빈 체결시각은 원장 정렬/날짜필터에서 위험하다(UNKNOWN_FILL_TIME 주석 참고).
+        # 원장에만 비숫자 표식을 넣고, 서버로 나가는 값은 비워둔다.
+        ledger_fill_time = fill_time if str(fill_time or "").strip() else UNKNOWN_FILL_TIME
+
         try:
-            identity_kwargs = {"execution_id": execution_id} if execution_id is not None else {}
-            if account_avg_price is not None:
-                identity_kwargs["account_avg_price"] = account_avg_price
-            result = await self._workflow_position_tracker.record_fill(
+            # 🔴 중복방지 키(execution_id)는 **체결 보존보다 우선하지 않는다**.
+            # tracker.record_fill 은 본문 첫 줄에서 _execution_key(fill) 를 계산하고
+            # (workflow_position_tracker.py 의 record_fill — PendingFill 생성 직후, 버퍼
+            # 락도 DB 연결도 잡기 전), 그 안의 _normalize_identifier 가
+            #   · 체결번호가 정수가 아닌 수치 문자열("0.0"/"-0"/"12.5")이면
+            #     ValueError("Numeric execution/order identity must be a positive integer")
+            #   · str/int 가 아니면 ValueError("Execution/order identity must be a string or integer")
+            #   · 체결번호는 쓸 만한데 주문번호/주문일자가 비면
+            #     ValueError("Explicit execution identity requires an order number and date")
+            # 를 올린다. 종전에는 그 예외를 아래 광역 except 가 삼켜 "error" 만
+            # 반환했고 — trade_history · workflow_position_lots 에 **아무것도 남지
+            # 않았다**. 체결 한 건이 통째로 사라지는 것보다 중복방지를 포기하는 쪽이
+            # 언제나 낫다. 그래서 identity 축이 깨지면 체결번호 없이 한 번 더 부른다.
+            # (executor._usable_execution_identity 는 '가능하면 미리 거른다' 는 최적화로
+            #  남아 있지만, 그건 (주문번호, 주문일자) 축만 본다 — 체결번호 자체가
+            #  비정수 수치 문자열인 경우는 여기서만 닫힌다.)
+            #
+            # ⚠️ 재시도가 이중 기록을 만들지 않는 근거(코드 확인,
+            #    database/workflow_position_tracker.py):
+            #   · record_fill 은 `fill = PendingFill(...)` 다음 줄이 곧바로
+            #     `identity = self._execution_key(fill)` 다. 그 사이에 쓰기가 없다.
+            #   · 그 뒤의 ValueError 발생 지점(_find_execution → _execution_facts,
+            #     _process_fill_internal 의 payload 구성)도 전부 INSERT/UPDATE 보다
+            #     앞이고, _process_fill_internal 의 쓰기는 `BEGIN IMMEDIATE` 트랜잭션
+            #     안이라 예외 시 롤백된다. 버퍼(_pending_fills) 등록도 그 모든
+            #     분기보다 뒤다. 즉 첫 호출이 ValueError 로 끝났다면 이 체결은
+            #     원장에도 버퍼에도 흔적이 없다.
+            #   · 단 하나의 예외가 ExecutionIdentityConflictError(ValueError 서브클래스)다.
+            #     이건 "같은 체결번호가 **이미 기록돼 있는데** 체결 사실이 다르다" 는
+            #     신호라, 체결번호를 떼고 다시 넣으면 같은 브로커 체결이 두 번
+            #     기록된다. 그래서 재시도 대상에서 제외하고 종전대로 "error" 로 둔다.
+            #
+            # 🔴 잡는 범위는 **ExecutionIdentityError 하나**다(모든 ValueError 가
+            #    아니다). 종전에는 광역 `except ValueError` 였는데, 그러면
+            #    execution_id 가 실려 있기만 하면 identity 와 무관한 tracker 예외까지
+            #    삼켜 체결번호 없이 재기록했다 — 실제로 닿는 경로가 있다:
+            #    _execution_facts 의 유한성 가드(수량/가격이 inf·nan 이면 plain
+            #    ValueError). 그건 체결번호를 뗀다고 나아지지 않는 **체결 사실의
+            #    문제**라 원장에 비유한 값을 남기는 대신 "error" 로 끝나야 한다.
+            from programgarden.database.workflow_position_tracker import (
+                ExecutionIdentityConflictError,
+                ExecutionIdentityError,
+            )
+
+            base_kwargs: Dict[str, Any] = dict(
                 order_no=order_no,
                 order_date=order_date,
                 symbol=symbol,
@@ -2658,10 +2930,35 @@ class ExecutionContext:
                 side=side,
                 quantity=quantity,
                 price=price,
-                fill_time=fill_time,
+                fill_time=ledger_fill_time,
                 commda_code=commda_code,
-                **identity_kwargs,
             )
+            if account_avg_price is not None:
+                # 재시도에도 유지한다 — identity 축이 아니고, 매도 잔량 추정의
+                # 유일한 근거다.
+                base_kwargs["account_avg_price"] = account_avg_price
+
+            try:
+                result = await self._workflow_position_tracker.record_fill(
+                    **base_kwargs,
+                    **({"execution_id": execution_id} if execution_id is not None else {}),
+                )
+            except ExecutionIdentityConflictError:
+                # ExecutionIdentityError 의 서브클래스가 아니라 아래 절에 걸리지
+                # 않지만, "충돌은 재시도하지 않는다" 는 의도를 코드로 못박아 둔다
+                # (누군가 상속 관계를 바꾸면 이 절이 이중 기록을 막는다).
+                raise
+            except ExecutionIdentityError as identity_err:
+                if execution_id is None:
+                    # 체결번호를 싣지도 않았는데 난 ValueError 는 identity 축이
+                    # 아니다 — 떼어낼 것이 없으므로 종전대로 처리한다.
+                    raise
+                logger.warning(
+                    "Execution identity unusable for fill %s/%s (execution_id=%r): %s "
+                    "— retrying without it (replay protection dropped, fill preserved)",
+                    order_date, order_no, execution_id, identity_err,
+                )
+                result = await self._workflow_position_tracker.record_fill(**base_kwargs)
             logger.info(f"Recorded workflow fill: {order_no} ({symbol} {side} {quantity}@{price}) → {result}")
 
             # 체결 후 PnL refresh 트리거
@@ -2732,7 +3029,10 @@ class ExecutionContext:
             side=fill.side,
             quantity=fill.quantity,
             price=fill.price,
-            fill_time=fill.fill_time,
+            # 원장 전용 표식은 서버로 내보내지 않는다 — 빈 fill_time 이어야
+            # pg-worker 의 `and fill_time` 가드가 걸려 executed_at 이 정직한
+            # received_at 폴백(+ executed_at_source 태그)이 된다.
+            fill_time=("" if fill.fill_time == UNKNOWN_FILL_TIME else fill.fill_time),
             product=tracker.product,
             provider=tracker.provider,
             classification=classification,

--- a/src/programgarden/programgarden/database/workflow_position_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_position_tracker.py
@@ -9,15 +9,83 @@ FIFO 방식으로 포지션을 관리합니다.
 - FIFO 기반 포지션 청산 처리
 - 실시간 평가 수익률 계산
 - 이상 거래 감지 및 신뢰도 점수 계산
+
+주문일자(order_date) 매칭 규약 — 왜 ±1일 창인가:
+- 주문 기록의 order_date 와 체결의 order_date 는 **출처가 다르다**. 같은 주문이라도 두
+  값이 하루 어긋날 수 있고, 어긋나는 방향은 **양쪽 다 이 저장소에 근거가 있다**:
+  · **D-1**(주문 기록일 = 체결일자 − 1) — 설계상. 실시간 체결 프레임(AS1/SC1)에는
+    주문일자 필드 자체가 없어 **수신 시각의 로컬 날짜**로 채운다(executor.py 의 AS1/SC1
+    경로). 미국장은 KST 자정을 항상 관통하므로 23:5x 접수 → 00:0x 체결이면 주문 기록일이
+    체결일자보다 하루 앞선다.
+  · **D+1**(주문 기록일 = 체결일자 + 1) — 실측. LS 는 **야간 세션을 전 영업일로
+    파일링**한다: 00:39:25 KST(로컬 20260910)에 접수된 주문이 CIDBQ02400 에서
+    OrdDt/ExecDt **20260909** 로 돌아왔다(2026-09-10 실측 —
+    tests/test_broker_business_date_window.py 헤더). record_order 는 접수 시점 **로컬**
+    날짜를 쓰고 TC3 체결은 프레임의 ordr_dt(= 브로커 영업일)를 쓰므로(executor.py 의 TC3
+    경로), 이때는 주문 기록일이 체결일자보다 하루 **뒤**가 된다.
+  어느 쪽이든 정확일치만 보면 우리 주문인데도 매칭에 실패한다. 그러면 매체코드
+  '40'(API) → 버퍼 → 타임아웃 후 **unknown_api** 로 굳어, 우리 체결이 workflow 집계에서
+  통째로 빠진다.
+- 그래서 **정확일치를 먼저** 보고, 실패했을 때만 **D-1·D+1 두 칸**을 훑는다
+  (_order_date_window). D±2 이상은 어느 쪽으로도 보지 않는다.
+- 넓힌 창은 '날짜가 한 칸 어긋났을 것' 이라는 **추론**이다. 그래서 수용 조건이 다섯이다:
+  ① 후보가 **정확히 1건**일 것 — 우리 원장 안에서 같은 주문번호가 재사용된 경우를 거른다.
+  ② 후보의 **종목이 체결의 종목과 일치**할 것. ①만으로는 부족하다: 제3자(남의) 주문번호는
+     정의상 우리 원장에 없으므로 후보가 늘 1건이라 ①을 항상 통과한다. 종목 대조가 없으면
+     번호가 우연히 겹친 남의 체결(HTS 85 포함)이 workflow 로 흡수된다 — 2026-09-12 적대적
+     검토 실측: 우리 D-1 AAPL buy #86382 기록 뒤 다음 날 TSLA sell 5@300 commda=85 체결이
+     classification='workflow' 로 기록되고 FIFO 가 'Sell without enough position' 까지 냈다.
+  ③ 양쪽에 매매구분이 있으면 **side 도 일치**할 것.
+  ④ 프레임의 **매체코드가 사람 채널이 아닐 것**(_may_widen_for_media). 브로커 주문번호는
+     **영업일마다 리셋**되므로 어제 우리 번호가 오늘 사용자 주문에 재발급될 수 있다 —
+     2026-09-12 적대적 재검증 실측: 우리 D-1 AAPL buy #3 기록 뒤 다음 날 14:00 사용자 HTS
+     매수 7@250(order_no '3', commda_code '85')이 종목·side 까지 같아 ①②③ 을 전부
+     통과해 workflow 로 기록되고 workflow_position_lots 에 남의 로트가 생겼다. 프레임이
+     "이건 사람이 낸 주문" 이라고 명시한 체결을 추론으로 삼키지 않는다.
+  ⑤ **체결 수량이 주문 수량(workflow_orders.quantity)을 넘지 않을** 것
+     (_accept_widened_match → _fill_quantity_within_order). 우리 주문의 체결(부분·전량)은
+     주문 수량을 넘을 수 없으므로 이 가드는 우리 체결을 놓치지 않고(false-miss 없음),
+     세션 시각에 의존하지도 않는다. ④가 못 막는 재발급(매체코드가 사람이 아닌 경로)이
+     종목·side 까지 같아도 수량이 우리 주문보다 크면 여기서 걸린다(2026-09-12 재검증
+     실측 형태: 우리 1주 주문 → 남의 7주 체결). 비교는 float(소수점 주식 0.847972 vs
+     주문 1 → 통과). 원장 수량이 비었거나 0 이면 대조 불가이므로 추론 없이 거부한다.
+  ⑥ 주문 기록 시각(workflow_orders.created_at)과 체결 수신 시각(PendingFill.received_at)의
+     간격이 **_WIDENED_MATCH_MAX_GAP 이내**일 것(_accept_widened_match). 이건 세션 경계
+     **사실이 아니라 휴리스틱(보조 가드)** 이다 — 미국주식은 KST 주간(09:00~, Blue Ocean
+     주간거래)에도 거래되므로(저장소 메모리 관측 확정 2026-09-11: MARA 거래량 26→938)
+     '다음 날 낮에 재발급된 번호' 는 우리 주문 몇 시간 뒤일 수 있어 시각만으로는 못
+     가른다. 수량이 우리 주문 이하라 ⑤ 를 통과한 재발급이 임계 밖에서 오면 여기가
+     마지막 방어다. 임계 근거는 상수 정의 주석 참조. created_at 이 비어 있는 옛 행은
+     추론 없이 거부한다.
+  하나라도 어긋나면 넓히기 전과 같이 미매칭(→ unknown_api) 쪽으로 남긴다.
+  실질 방어는 ④(사람 매체코드 거부)·②③(종목/방향 일치)·⑤(체결수량≤주문수량)이고,
+  ⑥(시각)은 보조다.
+- ②③④⑤⑥ 은 **창 경로에만** 적용한다. 정확일치 경로의 의미는 건드리지 않는다 — 거기선
+  (주문번호, 주문일자) 동시 일치가 더 강한 증거다. 또 국내 SC1 체결의 종목코드는
+  'A005930' 처럼 접두가 붙어 주문 기록('005930')과 문자열이 다르므로, 정확일치 경로에
+  종목 대조를 넣으면 지금 맞던 매칭이 깨진다.
+- 넓히는 건 날짜뿐이다. product/provider/trading_mode/주문번호 스코프는 정확일치 조회와
+  똑같이 유지한다.
+- 분류 경로(_is_workflow_fill)와 식별자 조회 경로(lookup_order_identity)는 **같은 매칭
+  함수**(_match_workflow_order)를 쓰되, **주문번호 대조 mode 는 호출부마다 다르다**:
+  _is_workflow_fill 은 명시 체결번호가 없으면 'exact'(문자열 정확일치), 있으면
+  'normalized'; lookup_order_identity 는 'exact_or_normalized'. 이유는 각 호출부의 종전
+  의미를 그대로 보존하기 위해서다 — 분류는 처음부터 문자열 정확일치였고(느슨하게 바꾸면
+  오분류 표면이 커진다), 조회는 주문 ACK 와 체결의 0 패딩 차이를 흡수해야 node_id 를 붙일
+  수 있었다. mode 를 통일하면 둘 중 한쪽의 의미가 바뀌므로 통일하지 않는다. **날짜 규약과
+  창 수용 조건은 두 경로가 공유한다** — 그게 갈리면 classification='workflow' 인데 node_id
+  가 None 인 상태가 만들어지고, 하류 멱등 키(job_id:node_id:order_id:seq)의 node 축이 빈
+  문자열로 접혀 같은 주문의 경계 전후 체결이 서로 다른 축을 갖는다.
 """
 
 import sqlite3
 import asyncio
 import logging
 import json
+import math
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal, ROUND_HALF_UP
 from typing import Dict, List, Optional, Any, Tuple, Callable, Awaitable
 from pathlib import Path
@@ -39,6 +107,30 @@ _MULT_MIN_REL_GAP = Decimal("0.001")   # 0.1%
 _MULT_MIN = Decimal("0.5")
 _MULT_MAX = Decimal("10000")
 _MULT_INT_SNAP_REL = Decimal("0.02")   # 2%
+
+# ── 넓힌 주문일자 창(D±1)의 시각 근접 임계 — **휴리스틱(보조 가드)** ──
+# 창은 '영업일/자정 경계가 한 칸 어긋난 같은 주문' 하나만 구제하려고 존재한다. 그런데
+# 브로커 주문번호는 **영업일마다 리셋**되므로(저장소 기록), 어제 우리 주문번호가 오늘
+# 사용자 주문에 재발급되고 종목·매매구분까지 같으면 후보 수·종목·side 가드를 전부
+# 통과한다. 그래서 창 수용은 **주문 기록 시각(workflow_orders.created_at)과 체결 수신
+# 시각(PendingFill.received_at)의 간격이 이 임계 이내** 일 때만 인정한다.
+#
+# 🔴 이 시각 가드는 세션 경계 **사실이 아니라 휴리스틱**이다. 미국주식은 KST 주간
+# (09:00~, Blue Ocean 주간거래)에도 거래된다 — 저장소 메모리 관측 확정(2026-09-11
+# 09:02~09:05 KST, g3101 반복 샘플링: MARA 거래량 26→938, NVDA 1,239→4,854). 우리
+# 워크플로우의 ScheduleNode/TradingHoursFilterNode 가 그 구간을 막고 있을 뿐, 사용자는
+# 그 시간에 거래한다. 따라서 '다음 날 낮에 재발급된 주문번호' 는 우리 주문 몇 시간 뒤일
+# 수 있다(자정 직전 우리 주문 → 다음 날 10:00 남의 주문 = 10시간, 임계 안). 시각만으로는
+# 재발급을 못 가른다. 실질 방어는 ① 사람 매체코드 거부(_may_widen_for_media)
+# ② 종목/방향 일치 ③ 체결수량 ≤ 주문수량(_fill_quantity_within_order) 이고, 시각은
+# 보조다.
+#
+# 값(12시간)을 유지하는 이유: 구제 대상(자정 관통·야간 세션 파일링)의 실제 간격은 미국
+# 정규장 한 세션(KST 22:30~05:00, 6.5시간) 안이고, 22:35 접수 → 04:5x 체결(6.4시간)
+# 지정가 체결이 실재한다. 더 줄이면 그 체결을 놓친다(false-miss). 더 늘리면 D±1 창 안에서
+# '반대쪽 날의 같은 시간대' 가 들어온다. 12시간은 그 두 제약 사이의 값이지 재발급을 끊는
+# 경계가 아니다.
+_WIDENED_MATCH_MAX_GAP = timedelta(hours=12)
 
 
 @dataclass
@@ -93,32 +185,70 @@ class PendingFill:
     account_avg_price: Optional[float] = None
 
 
+class ExecutionIdentityError(ValueError):
+    """A fill's execution/order identity could not be normalized into a key.
+
+    ``_normalize_identifier`` / ``_execution_key`` 계열이 **이것만** 올린다 —
+    "체결번호(또는 그 짝인 주문번호/주문일자)가 원장 중복방지 키로 쓸 수 없다" 는
+    뜻이다. 전용 타입을 두는 이유: context.record_workflow_fill 의 폴백이
+    "identity 축이 깨졌으면 체결번호를 떼고 한 번 더 기록한다" 를 수행하는데,
+    그 폴백이 **모든 ValueError** 를 잡으면 identity 와 무관한 예외까지 삼켜
+    체결번호 없이 재기록한다. 실제로 닿는 경로가 있다 —
+    ``_execution_facts`` 의 유한성 가드
+    (ValueError("Explicit execution quantity and price must be finite"))는
+    수량/가격이 inf·nan 일 때 나는데, 그건 체결번호를 뗀다고 나아지지 않는
+    **체결 사실 자체의 문제**다. 그래서 그 부류는 plain ValueError 로 남겨
+    폴백이 잡지 않게 한다.
+    """
+
+
 class ExecutionIdentityConflictError(ValueError):
-    """An explicit execution identity was replayed with different fill facts."""
+    """An explicit execution identity was replayed with different fill facts.
+
+    ⚠️ 일부러 ``ExecutionIdentityError`` 의 서브클래스가 **아니다**. 이건 정규화
+    실패가 아니라 "같은 체결번호가 이미 기록돼 있는데 체결 사실이 다르다" 는
+    신호라, 체결번호를 떼고 재시도하면 같은 브로커 체결이 두 번 기록된다.
+    context 의 폴백 대상에서 빠져 있어야 한다.
+    """
 
 
-# LS 통신매체코드(CommdaCode / MdaCode) — 출처: src/finance/docs/cidbq02400_contract.md:74-77
-# "The published media map is 00=branch, 22=iPhone, 23=Android, 41=API, 43=Robo API,
-#  85=HTS, 96=final settlement, LP=loss cut, SK=CashCall and SO=conditional order.
-#  The example uses 40, which the table does not map. Preserve it as returned;
-#  do not classify it by guessing a nearby code."
-# '40' 은 표에 없지만 우리 OPEN API 주문이 실제로 받는 값이다(dev verified_fills 실측 4건 +
-# 2026-09-12 해외주식 AS1 실측: 우리 매도 주문 244 → 40) — 표의 41/43 과 함께 API 묶음으로 둔다.
-# 🔴 해외주식 AS1 실측(2026-09-12, 실계좌 NIO 1주씩): HTS → 85(표와 일치) · iPhone 투혼앱 → **51**
-# (표의 22 아님) · 투혼 웹 → **03**(표에 없음). 표는 해외선물 TR 문서라 해외주식 푸시와 앱/웹 코드가
-# 다르다. 관측된 값만 사람 채널에 추가한다 — 표에 없고 관측도 안 된 값은 여전히 "other".
-MEDIA_CODES_HUMAN = frozenset({"85", "22", "23", "00", "51", "03"})   # HTS · iPhone(표) · Android(표) · 지점 · 투혼앱(실측) · 투혼웹(실측)
-MEDIA_CODES_API = frozenset({"40", "41", "43"})                       # OPEN API(실측) · API · Robo API
+# LS 통신매체코드(CommdaCode / MdaCode) — **상품 구분 없는 단일 합집합 표**.
+# 값마다 출처가 다르다:
+#  · 해외선물 TR 문서(src/finance/docs/cidbq02400_contract.md:74-77) — 00=지점, 22=iPhone,
+#    23=Android, 41=API, 43=Robo API, 85=HTS, 96=최종결제, LP=로스컷, SK=CashCall,
+#    SO=조건주문. 문서 예시에 나오는 40 은 이 표에 없다.
+#  · '40' = 우리 OPEN API 주문이 실제로 받는 값(dev verified_fills 실측 4건 + 2026-09-12
+#    해외주식 AS1 실측: 우리 매도 주문 244 → 40) — 표의 41/43 과 함께 API 묶음.
+#  · 해외주식 AS1 라이브 실측(2026-09-12, 실계좌 NIO 1주씩): HTS → 85(표와 일치) ·
+#    iPhone 투혼앱 → **51**(표의 22 아님) · 투혼 웹 → **03**(표에 없음).
+#  · 국내(SC1) **50=MTS · 60=HTS** · 00=지점 · 40/41=오픈API — **오너 진술(2026-09-12),
+#    라이브 미관측**. 저장소 SDK 에는 국내 매체코드 enum 이 선언돼 있지 않다.
+#
+# 왜 상품별로 쪼개지 않는가(2026-09-12 적대적 검토 지적 B3): tracker 는 워크플로우당 1개이고
+# **가장 먼저 초기화된 브로커의 product 로 고정**된다(context.py 의 조기 return). 한 워크플로우에
+# 해외+국내 브로커가 같이 있는 구성은 executor 가 이미 인정하는데, 표를 상품으로 가르면 국내가
+# 먼저 뜬 워크플로우에서 **해외 체결이 국내 표로 판정**돼 85(HTS)가 other 로 떨어지고 43 은
+# api→other 가 되어 버퍼를 건너뛰고 즉시 확정된다 — 표가 하나였을 때는 없던 회귀다.
+# 두 표 사이에 **같은 코드가 서로 다른 채널을 뜻하는 사례는 현재까지 없어** 합집합이 안전하다.
+# (해외 85=HTS / 국내 60=HTS 처럼 값이 다를 뿐, 같은 값이 한쪽은 사람 다른 쪽은 API 인 경우가
+# 없다.) 충돌이 관측되면 그때 상품별로 쪼갠다.
+MEDIA_CODES_HUMAN = frozenset({"85", "60", "22", "23", "50", "00", "51", "03"})
+# 85=HTS(해외) · 60=HTS(국내, 오너 진술) · 22/23=앱(표) · 50=MTS(국내, 오너 진술) ·
+# 00=지점 · 51=투혼앱(실측) · 03=투혼웹(실측)
+MEDIA_CODES_API = frozenset({"40", "41", "43"})   # OPEN API(실측) · API · Robo API
 
 
 def media_channel(commda_code: str | None) -> str:
     """Map a broker media code to "human" | "api" | "unknown" | "other".
 
-    unknown = blank/None (the frame said nothing); other = a code the published
-    table does not attribute to a person or an API client (96/LP/SK/SO …) or one
-    the table does not list at all. Neither is ever asserted to be a person.
+    One table for every product — see MEDIA_CODES_* above for why splitting it
+    by product regressed mixed (overseas + KRX) workflows.
+
+    unknown = blank/None (the frame said nothing); other = a code the table does
+    not attribute to a person or an API client (96/LP/SK/SO ...) or one it does
+    not list at all. Neither is ever asserted to be a person.
     """
-    code = (commda_code or "").strip()
+    code = str(commda_code or "").strip()
     if not code:
         return "unknown"
     if code in MEDIA_CODES_HUMAN:
@@ -212,41 +342,99 @@ class WorkflowPositionTracker:
         self,
         order_no: str,
         order_date: str,
+        *,
+        symbol: Optional[str] = None,
+        side: Optional[str] = None,
+        commda_code: Optional[str] = None,
+        received_at: Optional[datetime] = None,
+        quantity: Optional[float] = None,
     ) -> Optional[Tuple[Optional[str], Optional[str]]]:
         """Return ``(job_id, node_id)`` for a recorded workflow order, else None.
 
-        Scoped to this ledger's product/provider/trading mode and the order date.
-        Matches the exact order number first, then the normalized form (so
-        zero-padding differences between the order ACK and the fill still map).
-        A fill that is not one of our workflow orders returns None (node_id then
-        stays None on the emitted event).
+        Uses the same matcher as classification (``_match_workflow_order``), but
+        **the order-number comparison mode differs per call site**: this path
+        asks for "exact_or_normalized" while ``_is_workflow_fill`` asks for
+        "exact" (no explicit execution id) or "normalized" (with one). That
+        difference is deliberate — each call site keeps the meaning it had before
+        the two matchers were merged: classification was always a plain string
+        comparison, and this lookup had to absorb zero-padding differences
+        between the order ACK and the fill in order to resolve a node_id at all.
+        What the two paths DO share is the date rule and the widened-window
+        accept guards — exact order date first, then the D±1 window under
+        single-candidate + symbol/side + media-channel + fill-quantity-within-
+        order-quantity + time-proximity (heuristic) guards.
+        Sharing those is the contract: a fill classified "workflow" through the
+        window must resolve its node_id here too, or the downstream idempotency
+        key ``job_id:node_id:order_id:seq`` collapses its node axis to an empty
+        string for exactly those boundary-straddling fills.
+
+        ``symbol``/``side``/``commda_code``/``received_at``/``quantity`` describe
+        the fill being resolved and are used only by the widened path. When a caller does
+        not pass them, they are read back from this ledger's own trade_history
+        row for that order (the fill row is committed before the classified
+        callback fires) — never guessed. With no such row and no argument, the
+        widened path has nothing to compare and is refused, which is the safe
+        direction.
+
+        Scoped to this ledger's product/provider/trading mode.
         """
         try:
-            norm = self._normalize_identifier(order_no)
-        except ValueError:
-            norm = None
-        try:
-            with sqlite3.connect(self.db_path) as conn:
-                rows = conn.execute(
-                    """
-                    SELECT order_no, job_id, node_id FROM workflow_orders
-                    WHERE product = ? AND provider = ? AND trading_mode = ? AND order_date = ?
-                    """,
-                    (self.product, self.provider, self.trading_mode, order_date),
-                ).fetchall()
+            if (symbol is None or side is None or commda_code is None
+                    or received_at is None or quantity is None):
+                recorded = self._recorded_fill_identity(order_no, order_date)
+                if recorded is not None:
+                    if symbol is None:
+                        symbol = recorded[0]
+                    if side is None:
+                        side = recorded[1]
+                    if commda_code is None:
+                        commda_code = recorded[2]
+                    if received_at is None:
+                        received_at = recorded[3]
+                    if quantity is None:
+                        quantity = recorded[4]
+            match = self._match_workflow_order(
+                order_no, order_date, mode="exact_or_normalized",
+                symbol=symbol, side=side,
+                commda_code=commda_code, received_at=received_at,
+                quantity=quantity,
+            )
         except Exception as e:
             logger.warning(f"lookup_order_identity failed: {e}")
             return None
-        for row_order_no, job_id, node_id in rows:
-            if row_order_no == order_no:
-                return (job_id, node_id)
-            if norm is not None:
-                try:
-                    if self._normalize_identifier(row_order_no) == norm:
-                        return (job_id, node_id)
-                except ValueError:
-                    continue
-        return None
+        if match is None:
+            return None
+        _matched_date, job_id, node_id = match
+        return (job_id, node_id)
+
+    def _recorded_fill_identity(
+        self, order_no: str, order_date: str
+    ) -> Optional[Tuple[Optional[str], Optional[str], Optional[str], Optional[datetime],
+                        Optional[float]]]:
+        """This order's most recently recorded fill facts.
+
+        Returns ``(symbol, side, commda_code, recorded_at, quantity)``. Facts only — the
+        row was written by ``_process_fill_internal`` straight from the broker
+        frame, and ``recorded_at`` is this ledger's own ``created_at`` for that
+        row, i.e. when the fill was written (milliseconds after the arrival that
+        ``PendingFill.received_at`` stamps). Returns None when no fill has been
+        recorded for the order, and ``recorded_at`` is None when the stored
+        timestamp is missing or unparseable (nothing is inferred; the caller then
+        refuses to widen).
+        """
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT symbol, side, commda_code, created_at, quantity FROM trade_history
+                WHERE product = ? AND provider = ? AND trading_mode = ?
+                  AND order_date = ? AND order_no = ?
+                ORDER BY id DESC LIMIT 1
+                """,
+                (self.product, self.provider, self.trading_mode, order_date, order_no),
+            ).fetchone()
+        if row is None:
+            return None
+        return (row[0], row[1], row[2], self._parse_recorded_timestamp(row[3]), row[4])
     
     def _init_db(self) -> None:
         """데이터베이스 테이블 초기화"""
@@ -462,26 +650,62 @@ class WorkflowPositionTracker:
         # 버퍼에서 매칭되는 체결 확인 (이벤트 루프가 있는 경우에만)
         try:
             loop = asyncio.get_running_loop()
-            loop.create_task(self._process_buffered_fill(order_no, order_date))
+            task = loop.create_task(self._process_buffered_fill(order_no, order_date))
         except RuntimeError:
             # 동기 환경에서는 버퍼 처리 생략 (체결이 먼저 올 일 없음)
             pass
+        else:
+            # 🔴 fire-and-forget 태스크의 예외는 **아무 데도 안 남는다**.
+            # _process_buffered_fill 안에서는 _normalize_identifier 가
+            # ExecutionIdentityError 를 올릴 수 있고(버퍼에 깨진 체결번호가
+            # 섞였을 때), 그러면 그 체결은 버퍼에 남아 타임아웃 경로로
+            # unknown_api 가 되면서 **원인 기록이 하나도 없다**. 아무도 await 하지
+            # 않으므로 done 콜백으로 직접 로깅한다(취소는 정상 종료로 본다 —
+            # 워크플로우 종료 시 루프가 태스크를 취소한다).
+            task.add_done_callback(self._log_buffered_fill_task_error)
         
         logger.debug(f"Recorded workflow order: {order_no} ({symbol} {side} {quantity}@{price})")
     
+    @staticmethod
+    def _log_buffered_fill_task_error(task: "asyncio.Task") -> None:
+        """record_order 가 띄운 버퍼 처리 태스크의 침묵 실패를 로그로 드러낸다."""
+        if task.cancelled():
+            return
+        error = task.exception()
+        if error is not None:
+            logger.error(
+                "Buffered-fill processing task failed after record_order: %r",
+                error, exc_info=error,
+            )
+
     async def _process_buffered_fill(self, order_no: str, order_date: str) -> None:
-        """Process all buffered partial fills after recording their order."""
+        """Process all buffered partial fills after recording their order.
+
+        버퍼에 있는 체결의 order_date 와 방금 기록한 주문의 order_date 는 출처가 달라
+        하루 갈릴 수 있다(양방향 모두 — 자정 관통이면 주문이 하루 앞서고, LS 야간 세션
+        영업일 파일링이면 주문이 하루 뒤다). 그래서 정확일치 먼저, 실패하면 **D±1** 후보를
+        추가로 본다. 날짜가 갈린 후보는 _is_workflow_fill 로 창 수용 조건을 전부 다시
+        확인한다. 모듈 상단 규약 참조.
+        """
         notifications: list = []
         async with self._buffer_lock:
             for key, fill in list(self._pending_fills.items()):
-                if fill.order_date != order_date:
+                same_date = fill.order_date == order_date
+                if not same_date and order_date not in self._order_date_window(fill.order_date):
                     continue
                 matches = fill.order_no == order_no
                 if self._normalize_identifier(fill.execution_id) is not None:
                     matches = self._normalize_identifier(fill.order_no) == self._normalize_identifier(order_no)
-                if matches:
-                    await self._process_fill_internal(fill, "workflow", notifications)
-                    self._pending_fills.pop(key)
+                if not matches:
+                    continue
+                if not same_date and not self._is_workflow_fill(fill):
+                    # 날짜가 갈린 후보는 원장을 다시 조회해 창 수용 조건(후보 1건 + 종목/
+                    # 매매구분 일치 + 사람 매체코드 아님 + 시각 근접)을 전부 확인한다 —
+                    # 하나라도 어긋나면 여기서 거부되고, 기존대로 타임아웃 경로
+                    # (unknown_api)로 간다.
+                    continue
+                await self._process_fill_internal(fill, "workflow", notifications)
+                self._pending_fills.pop(key)
         await self._emit_fill_notifications(notifications)
     
     async def record_fill(
@@ -566,10 +790,11 @@ class WorkflowPositionTracker:
                 result = await self._process_fill_internal(fill, "workflow", notifications)
             else:
                 # No matching order. Classify by the published media table
-                # (MEDIA_CODES_* above) — never by "not 40":
-                #   human (85 HTS / 22 iPhone / 23 Android / 00 branch) → "manual"
-                #   other (96/LP/SK/SO or unlisted)                    → "other"
-                #   api (40/41/43) or blank                            → buffer below
+                # (MEDIA_CODES_* above — one table for every product), never by
+                # "not 40":
+                #   human (85·60 HTS / 22·23 앱 / 50 MTS / 00 지점 / 51·03 실측) → "manual"
+                #   other (96/LP/SK/SO or unlisted)                             → "other"
+                #   api (40/41/43) or blank                                     → buffer below
                 channel = media_channel(commda_code)
                 if channel == "human":
                     result = await self._process_fill_internal(fill, "manual", notifications)
@@ -617,14 +842,14 @@ class WorkflowPositionTracker:
         if value is None:
             return None
         if isinstance(value, bool) or not isinstance(value, (str, int)):
-            raise ValueError("Execution/order identity must be a string or integer")
+            raise ExecutionIdentityError("Execution/order identity must be a string or integer")
         text = str(value).strip()
         if not text:
             return None
         if re.fullmatch(r"[0-9]+", text):
             return text.lstrip("0") or None
         if re.fullmatch(r"[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?", text):
-            raise ValueError("Numeric execution/order identity must be a positive integer")
+            raise ExecutionIdentityError("Numeric execution/order identity must be a positive integer")
         return text
 
     def _execution_key(self, fill: PendingFill) -> Optional[Tuple[str, ...]]:
@@ -633,7 +858,7 @@ class WorkflowPositionTracker:
             return None
         order_no = self._normalize_identifier(fill.order_no)
         if order_no is None or not fill.order_date:
-            raise ValueError("Explicit execution identity requires an order number and date")
+            raise ExecutionIdentityError("Explicit execution identity requires an order number and date")
         return (self.product, self.provider, self.trading_mode, fill.order_date, order_no, execution_id)
 
     @staticmethod
@@ -642,6 +867,11 @@ class WorkflowPositionTracker:
         # while the first supplied values are retained in execution_payload.
         quantity, price = Decimal(str(fill.quantity)), Decimal(str(fill.price))
         if not quantity.is_finite() or not price.is_finite():
+            # 🔴 일부러 **plain ValueError** 다 — ExecutionIdentityError 가 아니다.
+            # 이건 identity 축이 아니라 체결 사실(수량/가격)이 inf·nan 이라는
+            # 뜻이고, 체결번호를 떼고 다시 넣는다고 나아지지 않는다. 전용 타입으로
+            # 올리면 context.record_workflow_fill 의 폴백이 이걸 삼켜
+            # **체결번호 없이 비유한 값을 원장에 기록**한다. 타입을 바꾸지 말 것.
             raise ValueError("Explicit execution quantity and price must be finite")
         return {
             "symbol": fill.symbol, "exchange": fill.exchange, "side": fill.side,
@@ -675,15 +905,27 @@ class WorkflowPositionTracker:
         return row[0]
 
     def _is_workflow_fill(self, fill: PendingFill) -> bool:
+        """이 체결이 우리가 기록한 워크플로우 주문의 체결인가.
+
+        주문번호 대조 방식은 종전 그대로다 — 명시 체결번호가 있으면 정규화된 주문번호로,
+        없으면 문자열 정확일치로 본다. 날짜는 정확일치 → D±1 창이고, 창 경로는 이 체결의
+        종목·매매구분·매체코드·수량·수신 시각까지 대조한 뒤에만 수용한다. 모듈 상단 규약
+        참조.
+        """
         identity = self._execution_key(fill)
         if identity is None:
-            return self._check_workflow_order(fill.order_no, fill.order_date)
-        with sqlite3.connect(self.db_path) as conn:
-            rows = conn.execute("""
-                SELECT order_no FROM workflow_orders
-                WHERE product = ? AND provider = ? AND trading_mode = ? AND order_date = ?
-            """, identity[:4])
-            return any(self._normalize_identifier(row[0]) == identity[4] for row in rows)
+            return self._check_workflow_order(
+                fill.order_no, fill.order_date,
+                symbol=fill.symbol, side=fill.side,
+                commda_code=fill.commda_code, received_at=fill.received_at,
+                quantity=fill.quantity,
+            )
+        return self._match_workflow_order(
+            identity[4], fill.order_date, mode="normalized",
+            symbol=fill.symbol, side=fill.side,
+            commda_code=fill.commda_code, received_at=fill.received_at,
+            quantity=fill.quantity,
+        ) is not None
 
     async def _process_fill_internal(
         self, fill: PendingFill, classification: str, notifications: list
@@ -887,16 +1129,361 @@ class WorkflowPositionTracker:
 
         return total_realized_pnl, estimate
     
-    def _check_workflow_order(self, order_no: str, order_date: str) -> bool:
-        """워크플로우 주문 여부 확인 (현재 trading_mode 기준)"""
+    @staticmethod
+    def _order_date_window(order_date: Any) -> List[str]:
+        """정확일치가 실패했을 때만 훑는 후보 날짜 — **D-1 과 D+1, 두 칸**.
+
+        두 방향 모두 이 저장소에 근거가 있다(모듈 상단 규약 참조):
+        · **D-1** = 실시간 체결 프레임(AS1/SC1)에 주문일자 필드가 없어 **수신 시각의
+          로컬 날짜**로 채우기 때문이다(설계상 — executor.py 의 AS1/SC1 경로). 자정 직전
+          접수 → 자정 직후 체결이면 주문 기록일이 체결일자보다 하루 앞선다.
+        · **D+1** = LS 가 **야간 세션을 전 영업일로 파일링**하기 때문이다(2026-09-10
+          실측: 00:39:25 KST 접수(로컬 20260910) → CIDBQ02400 OrdDt/ExecDt 20260909 —
+          tests/test_broker_business_date_window.py 헤더). record_order 는 로컬 날짜를
+          쓰고 TC3 체결은 프레임의 ordr_dt(브로커 영업일)를 쓰므로, 이때는 주문 기록일이
+          체결일자보다 하루 뒤가 된다.
+        월말·연말·윤년은 날짜 산술이 알아서 처리한다. 창을 넓힌다고 매칭되는 건 아니다 —
+        수용 조건 여섯(_may_widen_for_media + _accept_widened_match)을 모두 통과해야 한다.
+
+        날짜가 비었거나 YYYYMMDD 형식이 아니면 창을 넓히지 않는다 — 근거 없는 매칭을
+        만들지 않기 위해서다. 문자열이 아닌 값(None/int/datetime 등)도 같은 경로로
+        흡수한다: 예전에는 ``(order_date or "").strip()`` 이 AttributeError 를 던져
+        record_fill 을 통째로 죽였다(2026-09-12 검토 지적 B5).
+        """
+        try:
+            base = datetime.strptime(str(order_date or "").strip(), "%Y%m%d")
+        except (TypeError, ValueError):
+            return []
+        return [
+            (base - timedelta(days=1)).strftime("%Y%m%d"),
+            (base + timedelta(days=1)).strftime("%Y%m%d"),
+        ]
+
+    @staticmethod
+    def _normalize_symbol(value: Any) -> str:
+        """종목 대조용 정규화 — 앞뒤 공백 제거 + 대문자. 비면 빈 문자열."""
+        return str(value or "").strip().upper()
+
+    @staticmethod
+    def _may_widen_for_media(commda_code: Optional[str]) -> bool:
+        """이 매체코드의 체결에 대해 주문일자 창을 넓혀도 되는가.
+
+        창 매칭은 '날짜가 한 칸 어긋났을 것' 이라는 **추론**이다. 프레임이 "이건 사람이
+        낸 주문" 이라고 명시한 체결(MEDIA_CODES_HUMAN — 85·60·22·23·50·00·51·03)을 그
+        추론으로 삼켜서는 안 된다. 브로커 주문번호는 **영업일마다 리셋**되므로 어제 우리
+        번호가 오늘 사용자 HTS 주문에 재발급될 수 있다(2026-09-12 적대적 재검증 실측:
+        우리 D-1 AAPL buy #3 → 다음 날 14:00 HTS 매수 7@250, order_no '3', commda '85'
+        가 종목·side 까지 같아 workflow 로 흡수).
+
+        **정확일치 경로에는 적용하지 않는다** — 거기선 (주문번호, 주문일자) 동시 일치가
+        더 강한 증거이고, 우리 OPEN API 주문이 항상 '40' 을 달고 오지도 않는다.
+        blank('unknown')와 미분류('other')는 사람이라고 단정된 적이 없으므로 넓히기를
+        막지 않는다.
+        """
+        return media_channel(commda_code) != "human"
+
+    @staticmethod
+    def _naive_local(value: Optional[datetime]) -> Optional[datetime]:
+        """tz-aware 든 naive 든 **로컬 naive** 로 맞춘다(간격 계산용).
+
+        원장에 적히는 시각은 ``datetime.now()``(로컬 naive)인데, 호출부가 aware 를 넘길
+        수 있다. 섞이면 뺄셈이 TypeError 로 죽으므로 여기서 한쪽으로 모은다.
+        """
+        if value is None:
+            return None
+        if value.tzinfo is not None:
+            return value.astimezone().replace(tzinfo=None)
+        return value
+
+    @staticmethod
+    def _parse_recorded_timestamp(value: Any) -> Optional[datetime]:
+        """원장에 적힌 ISO 시각 문자열을 datetime 으로. 비었거나 해석 불가면 None.
+
+        추론하지 않는다 — 해석 못 하면 None 을 돌려주고, 호출부가 '증거 없음' 으로
+        취급한다(창 수용 거부).
+        """
+        text = str(value or "").strip()
+        if not text:
+            return None
+        try:
+            return datetime.fromisoformat(text)
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _fill_quantity_within_order(fill_quantity: Any, order_quantity: Any) -> bool:
+        """창 수용 조건 ⑤ — 체결 수량이 주문 수량 이하인가(float 비교).
+
+        우리 주문의 체결(부분·전량)은 주문 수량을 넘을 수 없다. 소수점 주식(0.847972 vs
+        주문 1)을 위해 float 로 비교한다. 원장 수량이 비었거나 0 이하거나 숫자가 아니면,
+        또 체결 수량이 없거나 숫자가 아니거나 유한하지 않으면 **추론 없이 False** —
+        호출부가 창 수용을 거부한다. 창 경로 전용이다(정확일치 경로는 타지 않는다).
+        """
+        try:
+            order_qty = float(order_quantity)
+            fill_qty = float(fill_quantity)
+        except (TypeError, ValueError):
+            return False
+        if not (math.isfinite(order_qty) and math.isfinite(fill_qty)):
+            return False
+        if order_qty <= 0:
+            return False
+        return fill_qty <= order_qty
+
+    def _accept_widened_match(
+        self,
+        candidates: List[Tuple],
+        order_no: str,
+        order_date: str,
+        symbol: Optional[str],
+        side: Optional[str],
+        *,
+        commda_code: Optional[str] = None,
+        received_at: Optional[datetime] = None,
+        quantity: Optional[float] = None,
+    ) -> Optional[Tuple[str, Optional[str], Optional[str]]]:
+        """D±1 창의 후보를 수용할지 판정한다. 수용하면 (주문일자, job_id, node_id).
+
+        ① 후보가 **정확히 1건**일 때만 본다. 2건 이상이면(브로커/원장에서 같은 주문번호가
+           다시 쓰인 경우) 모호하므로 거부하고 기존대로 미매칭 경로로 보낸다.
+        ② 후보의 **종목이 이 체결의 종목과 같아야** 한다. ①은 *우리 원장 안의* 재사용만
+           잡는다 — 제3자 주문번호는 정의상 원장에 없어 후보가 늘 1건이고, 종목 대조가
+           없으면 번호가 우연히 겹친 남의 체결까지 workflow 로 흡수된다(2026-09-12 검토
+           실측: D-1 AAPL buy #86382 뒤 다음 날 TSLA sell commda=85 가 workflow 로 기록).
+           한쪽이라도 종목이 비어 있으면 대조 불가이므로 수용하지 않는다.
+        ③ 양쪽에 매매구분이 있고 서로 다르면 거부한다(한쪽이 비면 대조하지 않는다).
+        ⑤ **수량 상한** — 체결 수량이 후보 주문의 수량(workflow_orders.quantity)을 넘으면
+           거부한다(_fill_quantity_within_order). 우리 주문의 체결(부분·전량)은 주문 수량을
+           넘을 수 없으므로 우리 체결을 놓치는 일이 없고(false-miss 없음), 세션 시각에
+           의존하지 않는다. 브로커 주문번호가 영업일마다 리셋되므로 ①②③④ 를 전부
+           통과하는 재발급이 실제로 존재한다(2026-09-12 재검증 실측: 우리 1주 주문 → 남의
+           7주 체결) — 그 형태를 여기서 잡는다. 비교는 float 로 한다(소수점 주식 0.847972
+           vs 주문 1 → 통과). 원장 수량이 비었거나 0 이거나 숫자가 아니면, 또 체결 수량이
+           없으면 **추론 없이 거부**한다.
+        ⑥ **시각 근접(보조)** — 주문 기록 시각(workflow_orders.created_at)과 체결 수신 시각
+           (PendingFill.received_at)의 간격이 _WIDENED_MATCH_MAX_GAP 이내여야 한다. 이건
+           휴리스틱이다 — 미국주식은 KST 주간(09:00~)에도 거래되므로(저장소 메모리 관측
+           확정) 다음 날 낮 재발급이 몇 시간 뒤일 수 있어 시각만으로는 못 가른다(상수 정의
+           주석 참조). 수량이 우리 주문 이하라 ⑤ 를 통과한 재발급이 임계 밖에서 오면
+           여기가 마지막 방어다. created_at 이 비어 있는 옛 행과 수신 시각이 없는 호출은
+           **추론 없이 거부**한다.
+
+        (④ 매체코드 가드 _may_widen_for_media 는 창을 조회하기 **전에**
+         _match_workflow_order 가 건다 — 사람 채널 체결은 후보를 읽지도 않는다.)
+        """
+        if len(candidates) != 1:
+            if candidates:
+                logger.info(
+                    "주문일자 ±1일 창 후보가 %d건이라 매칭 거부(주문번호=%s, 체결=%s, 후보=%s)",
+                    len(candidates), order_no, order_date,
+                    [row[1] for row in candidates],
+                )
+            return None
+        row = candidates[0]
+        cand_symbol = self._normalize_symbol(row[2])
+        fill_symbol = self._normalize_symbol(symbol)
+        if not cand_symbol or not fill_symbol or cand_symbol != fill_symbol:
+            logger.info(
+                "주문일자 ±1일 창 후보의 종목이 체결과 달라 매칭 거부"
+                "(주문번호=%s, 체결=%s, 주문종목=%r, 체결종목=%r)",
+                order_no, order_date, row[2], symbol,
+            )
+            return None
+        cand_side = str(row[3] or "").strip().lower()
+        fill_side = str(side or "").strip().lower()
+        if cand_side and fill_side and cand_side != fill_side:
+            logger.info(
+                "주문일자 ±1일 창 후보의 매매구분이 체결과 달라 매칭 거부"
+                "(주문번호=%s, 체결=%s, 주문=%s, 체결=%s)",
+                order_no, order_date, cand_side, fill_side,
+            )
+            return None
+        if not self._fill_quantity_within_order(quantity, row[7]):
+            logger.info(
+                "주문일자 ±1일 창 후보의 주문 수량을 체결 수량이 넘거나 대조 불가라 매칭 거부"
+                "(주문번호=%s, 체결=%s, 주문수량=%r, 체결수량=%r)",
+                order_no, order_date, row[7], quantity,
+            )
+            return None
+        ordered_at = self._naive_local(self._parse_recorded_timestamp(row[6]))
+        filled_at = self._naive_local(received_at)
+        if ordered_at is None or filled_at is None:
+            logger.info(
+                "주문일자 ±1일 창 수용에 필요한 시각 증거가 없어 매칭 거부"
+                "(주문번호=%s, 체결=%s, 주문기록시각=%r, 체결수신시각=%r)",
+                order_no, order_date, row[6], received_at,
+            )
+            return None
+        gap = abs(filled_at - ordered_at)
+        if gap > _WIDENED_MATCH_MAX_GAP:
+            logger.info(
+                "주문일자 ±1일 창 후보가 체결과 %s 떨어져 있어 매칭 거부"
+                "(임계=%s, 주문번호=%s, 체결=%s)",
+                gap, _WIDENED_MATCH_MAX_GAP, order_no, order_date,
+            )
+            return None
+        logger.info("주문일자 ±1일 창에서 매칭됨(D=%s, 체결=%s, 주문번호=%s, 종목=%s, "
+                    "체결수량=%r/주문수량=%r, 간격=%s)",
+                    row[1], order_date, order_no, cand_symbol, quantity, row[7], gap)
+        return (row[1], row[4], row[5])
+
+    def _order_no_matches(
+        self,
+        target: str,
+        target_norm: Optional[str],
+        row_value: Any,
+        *,
+        mode: str,
+        strict: bool,
+    ) -> bool:
+        """저장된 주문번호가 대상 주문번호와 같은가.
+
+        mode (호출부마다 종전 의미를 그대로 유지한다):
+          - "exact"               : 문자열 정확일치만 (체결번호 없는 분류 경로)
+          - "normalized"          : 0 패딩 정규화 일치만 (명시 체결번호 경로)
+          - "exact_or_normalized" : 둘 중 하나 (lookup_order_identity)
+        strict=True 에서는 정규화 불가한 저장값이 예외로 올라간다 — 그 날짜의 우리 주문
+        기록이 깨졌다는 신호다. 이 의미는 **mode='normalized' 의 정확일치 날짜 조회에만**
+        남겨 둔다(통합 전 그 경로가 그렇게 동작했다). 'exact_or_normalized'(조회 경로)는
+        통합 전 깨진 행 하나를 ``except ValueError: continue`` 로 건너뛰었으므로 strict=
+        False 로 그 행만 건너뛴다 — 안 그러면 깨진 행 하나가 lookup 전체를 죽인다.
+        넓힌 창도 strict=False 다(이웃 날짜에 섞인 깨진 값 하나가 멀쩡한 체결 처리를 죽이지
+        않게 — 넓히기 전보다 나빠지지 않도록).
+        """
+        if mode == "exact":
+            return row_value == target
+        if mode == "exact_or_normalized" and row_value == target:
+            return True
+        if target_norm is None:
+            return False
+        try:
+            return self._normalize_identifier(row_value) == target_norm
+        except ValueError:
+            if strict:
+                raise
+            return False
+
+    def _match_workflow_order(
+        self,
+        order_no: str,
+        order_date: str,
+        *,
+        mode: str = "exact",
+        symbol: Optional[str] = None,
+        side: Optional[str] = None,
+        commda_code: Optional[str] = None,
+        received_at: Optional[datetime] = None,
+        quantity: Optional[float] = None,
+    ) -> Optional[Tuple[str, Optional[str], Optional[str]]]:
+        """워크플로우 주문 매칭 — (주문일자, job_id, node_id) 또는 None.
+
+        분류(_is_workflow_fill)와 식별자 조회(lookup_order_identity)가 공유하는 **유일한**
+        매칭 경로다. 주문번호 대조 mode 만 호출부마다 다르고(모듈 상단 규약 참조), 날짜
+        규약과 창 수용 조건은 공유한다 — 그게 갈리면 classification='workflow' 인데
+        node_id 가 None 인 상태가 생긴다.
+
+        1) 같은 order_date 를 **SQL 등가조건(order_no 포함)** 으로 먼저 친다. 체결 핫패스인
+           mode='exact' 는 여기서 끝나므로 그 날짜 행을 전부 읽어 파이썬에서 비교하지
+           않는다. EXPLAIN QUERY PLAN 실측(2026-09-12): 이 형태는
+           ``SEARCH ... USING INDEX sqlite_autoindex_workflow_orders_1 (order_no=? AND
+           order_date=?)`` 로 UNIQUE(order_no, order_date) 를 등가 탐색하고, order_date 만
+           걸면 ``SEARCH ... USING INDEX idx_orders_lookup_v2 (trading_mode=?)`` 가 되어 그
+           모드의 행을 전부 훑는다. 0 패딩 정규화가 필요한 mode 만 **order_date 로 좁힌
+           뒤** 파이썬 비교를 추가로 돈다. 이 경로의 의미는 종전 그대로이고 종목/매체/수량/
+           시각 대조를 넣지 않는다(국내 SC1 체결 종목코드 'A005930' vs 주문 기록 '005930').
+        2) 실패하면 D±1 창을 본다. 단 프레임이 사람 채널이라고 명시한 체결은 후보를
+           **조회하지도 않고**(_may_widen_for_media), 나머지는 _accept_widened_match 의
+           수용 조건을 모두 통과할 때만 매칭으로 인정한다.
+
+        스코프는 product/provider/trading_mode 다. 통합 전 체결번호 없는 경로는
+        trading_mode 로만 좁혔는데, record_order 가 언제나 이 tracker 의 product/provider
+        로 행을 쓰므로 실제 매칭 결과는 달라지지 않는다(체결번호 있는 경로는 통합 전에도
+        이 스코프였다).
+        """
+        try:
+            target_norm = self._normalize_identifier(order_no)
+        except ValueError:
+            target_norm = None
+        columns = "order_no, order_date, symbol, side, job_id, node_id, created_at, quantity"
+        scope = (self.product, self.provider, self.trading_mode)
         with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            cursor.execute("""
-                SELECT 1 FROM workflow_orders
-                WHERE order_no = ? AND order_date = ? AND trading_mode = ?
-            """, (order_no, order_date, self.trading_mode))
-            return cursor.fetchone() is not None
-    
+            # 1) 정확일치 — UNIQUE(order_no, order_date) 등가 탐색이라 최대 1행.
+            hit = conn.execute(
+                f"""
+                SELECT {columns} FROM workflow_orders
+                WHERE product = ? AND provider = ? AND trading_mode = ?
+                  AND order_date = ? AND order_no = ?
+                """,
+                (*scope, order_date, order_no),
+            ).fetchone()
+            if hit is not None and mode != "normalized":
+                # 'exact'/'exact_or_normalized' 는 문자열 정확일치를 그대로 수용한다.
+                # 'normalized' 는 정규화 결과로만 판정하므로 아래 루프에 맡긴다
+                # (예: 저장값 '000' 은 정규화하면 빈 값이라 매칭이 성립하지 않는다).
+                return (hit[1], hit[4], hit[5])
+            if mode != "exact":
+                rows = conn.execute(
+                    f"""
+                    SELECT {columns} FROM workflow_orders
+                    WHERE product = ? AND provider = ? AND trading_mode = ? AND order_date = ?
+                    """,
+                    (*scope, order_date),
+                ).fetchall()
+                for row in rows:
+                    if self._order_no_matches(order_no, target_norm, row[0],
+                                              mode=mode, strict=(mode == "normalized")):
+                        return (row[1], row[4], row[5])
+
+            if not self._may_widen_for_media(commda_code):
+                # 사람 매체코드 체결이 우리 주문과 정확일치하지 않는 건 **정상**(사용자가
+                # 손으로 낸 주문)이라 debug 다. 아래 거부 로그들(종목/side/시각 불일치)은
+                # '거의 맞을 뻔한' 근접 사례라 info 로 남긴다.
+                logger.debug(
+                    "매체코드 %r 가 사람 채널이라 주문일자 창을 넓히지 않음"
+                    "(주문번호=%s, 체결=%s)", commda_code, order_no, order_date,
+                )
+                return None
+            window = self._order_date_window(order_date)
+            if not window:
+                return None
+            rows = conn.execute(
+                f"""
+                SELECT {columns} FROM workflow_orders
+                WHERE product = ? AND provider = ? AND trading_mode = ?
+                  AND order_date IN ({",".join("?" * len(window))})
+                """,
+                (*scope, *window),
+            ).fetchall()
+        candidates = [row for row in rows
+                      if self._order_no_matches(order_no, target_norm, row[0],
+                                                mode=mode, strict=False)]
+        return self._accept_widened_match(
+            candidates, order_no, order_date, symbol, side,
+            commda_code=commda_code, received_at=received_at, quantity=quantity,
+        )
+
+    def _check_workflow_order(
+        self,
+        order_no: str,
+        order_date: str,
+        *,
+        symbol: Optional[str] = None,
+        side: Optional[str] = None,
+        commda_code: Optional[str] = None,
+        received_at: Optional[datetime] = None,
+        quantity: Optional[float] = None,
+    ) -> bool:
+        """워크플로우 주문 여부 (이 tracker 의 product/provider/trading_mode 기준,
+        주문일자 D±1 창 포함).
+
+        symbol/side/commda_code/received_at/quantity 는 넓힌 창에서만 쓰인다 — 없으면 창
+        경로는 대조할 게 없어 거부되고 정확일치만 남는다(넓히기 전 동작).
+        """
+        return self._match_workflow_order(
+            order_no, order_date, mode="exact", symbol=symbol, side=side,
+            commda_code=commda_code, received_at=received_at, quantity=quantity,
+        ) is not None
+
     def get_workflow_positions(
         self,
         start_date: Optional[str] = None,
@@ -1583,17 +2170,26 @@ class WorkflowPositionTracker:
                 ))
             
             # 2. unknown_api_ratio: 알 수 없는 API 주문 비율
+            # 분모는 리터럴 '40' 이 아니라 **media_channel() 기준**으로 고른다 — 종전
+            # SQL 은 `commda_code = '40'` 하드코딩이라 표(MEDIA_CODES_*)와 어긋났다:
+            #  · TC3(해외선물) 프레임에는 통신매체코드 필드가 없어 이제 빈 문자열을
+            #    싣는데, '40' 고정 분모는 그 행을 통째로 빼서 선물에서는 이 이상탐지가
+            #    **영구히 0행**(절대 발화 안 함)이었다.
+            #  · 41(API)·43(Robo API) 행도 분모에서 빠졌다.
+            # 이제 channel 이 "api"(40/41/43) 또는 "unknown"(빈/미상 매체코드)인 행이
+            # 분모다 = "사람·브로커 채널이 아니어서 API 경로일 수 있는 체결". 동작 변화는
+            # 선물(빈 코드)이 다시 탐지 대상이 된다는 것 하나이고, 임계값(10%)과 감점
+            # 폭(최대 20)은 종전 그대로다. (2026-09-12 적대적 검토 지적 B6)
             cursor.execute("""
-                SELECT
-                    SUM(CASE WHEN classification = 'unknown_api' THEN 1 ELSE 0 END) as unknown_count,
-                    COUNT(*) as total_count
-                FROM trade_history
-                WHERE commda_code = '40' AND trading_mode = ?
+                SELECT commda_code, classification FROM trade_history
+                WHERE trading_mode = ?
             """, (self.trading_mode,))
-            
-            row = cursor.fetchone()
-            if row and row[1] > 0:
-                unknown_count, total_count = row
+
+            scoped = [(code, kind) for code, kind in cursor.fetchall()
+                      if media_channel(code) in ("api", "unknown")]
+            total_count = len(scoped)
+            if total_count > 0:
+                unknown_count = sum(1 for _, kind in scoped if kind == "unknown_api")
                 ratio = unknown_count / total_count
                 if ratio > 0.1:  # 10% 이상이면 이상
                     severity = min(int(ratio * 100), 20)  # 최대 20점 감점
@@ -1925,92 +2521,34 @@ class WorkflowPositionTracker:
         self,
         fill_history: List[Dict[str, Any]],
     ) -> int:
-        """
-        체결내역에서 FIFO 포지션 동기화 (record_fill 호출)
-        
-        연결 끊김 등으로 실시간 체결 이벤트를 놓친 경우,
-        체결내역 API 응답으로 포지션을 생성합니다.
-        
+        """체결내역 기반 FIFO 복구 — **미구현(별도 작업 필요)**. 항상 0 을 반환한다.
+
+        연결 끊김 등으로 실시간 체결을 놓쳤을 때 체결내역 API 응답으로 포지션을
+        되살리려던 경로다. 그러나 이 함수는 **한 번도 동작한 적이 없다**:
+        - 본문이 이 모듈에 존재하지 않는 ``FillEvent`` 를 import 해 호출 즉시
+          ImportError 로 죽었고,
+        - (동기 함수인데) async 인 ``record_fill`` 을 await 없이 위치인자 1개로 불렀고,
+        - 매체코드를 '40' 으로 하드코딩해 브로커가 실제로 준 값을 버렸다.
+        호출부(``context.sync_workflow_fills_from_history``)의 try/except 가 그 예외를
+        삼켜 0 을 돌려줬기 때문에 실패가 조용했다 — 복구된 줄 알았는데 아무것도 안 됐다.
+
+        제대로 고치려면 ``record_fill`` 을 await 해야 하고(=이 함수가 async 가 돼야 하고),
+        그러면 동기 호출부인 context.py/executor.py 시그니처까지 함께 바뀌어야 한다.
+        여기서 자체적으로 이벤트 루프를 돌리는 우회는 쓰지 않는다 — 호출부가 이미 실행
+        중인 루프 안이라 중첩 루프/교착을 만든다. 그래서 지금은 **조용히 실패하지 않게만**
+        만든다: 죽은 import 를 지우고, 즉시 error 로그를 남기고, 0 을 반환한다.
+
         Args:
-            fill_history: 체결내역 API 응답 리스트
-                [{
-                    "order_no": "123",
-                    "order_date": "20260123",
-                    "symbol": "AAPL",
-                    "exchange": "NASDAQ",
-                    "side": "buy",
-                    "quantity": 10,
-                    "price": 192.50,
-                    "fill_time": "093000000"
-                }, ...]
-            
+            fill_history: 체결내역 API 응답 리스트 (현재 소비하지 않는다)
+
         Returns:
-            처리된 체결 수
+            처리된 체결 수 — 언제나 0
         """
-        processed_count = 0
-        
-        with sqlite3.connect(self.db_path) as conn:
-            cursor = conn.cursor()
-            
-            for fill in fill_history:
-                order_no = fill.get("order_no", "")
-                order_date = fill.get("order_date", "")
-                symbol = fill.get("symbol", "")
-                exchange = fill.get("exchange", "NASDAQ")
-                side = fill.get("side", "")
-                quantity = fill.get("quantity", 0)
-                price = fill.get("price", 0)
-                fill_time = fill.get("fill_time", "")
-                
-                if not order_no or not order_date or not symbol or not side:
-                    continue
-                
-                if quantity <= 0 or price <= 0:
-                    continue
-                
-                # 이미 처리된 체결인지 확인 (trade_history에 있는지)
-                cursor.execute("""
-                    SELECT COUNT(*) FROM trade_history
-                    WHERE order_no = ? AND order_date = ? AND trading_mode = ?
-                """, (order_no, order_date, self.trading_mode))
-                
-                if cursor.fetchone()[0] > 0:
-                    # 이미 처리됨
-                    continue
-        
-        # 연결 닫고 record_fill 호출 (별도 트랜잭션)
-        from programgarden.database.workflow_position_tracker import FillEvent
-        
-        for fill in fill_history:
-            order_no = fill.get("order_no", "")
-            order_date = fill.get("order_date", "")
-            symbol = fill.get("symbol", "")
-            exchange = fill.get("exchange", "NASDAQ")
-            side = fill.get("side", "")
-            quantity = fill.get("quantity", 0)
-            price = fill.get("price", 0)
-            fill_time = fill.get("fill_time", "")
-            
-            if not order_no or not symbol or not side or quantity <= 0 or price <= 0:
-                continue
-            
-            fill_event = FillEvent(
-                order_no=order_no,
-                order_date=order_date,
-                symbol=symbol,
-                exchange=exchange,
-                side=side,
-                quantity=quantity,
-                price=price,
-                fill_time=fill_time,
-                commda_code="40",  # OPEN API
-            )
-            
-            try:
-                self.record_fill(fill_event)
-                processed_count += 1
-                logger.info(f"Synced fill from history: {symbol} {side} {quantity}@{price}")
-            except Exception as e:
-                logger.warning(f"Failed to sync fill from history: {order_no} - {e}")
-        
-        return processed_count
+        logger.error(
+            "sync_fills_from_history 는 미구현이다 — 체결내역 %d건을 FIFO 원장에 반영하지 "
+            "않고 건너뛴다. 실시간 체결을 놓친 구간은 워크플로우 집계에서 누락된 채로 "
+            "남는다(복구 경로 없음). record_fill 의 async 호출 + 호출부 시그니처 변경이 "
+            "필요한 별도 작업이다.",
+            len(fill_history or []),
+        )
+        return 0

--- a/src/programgarden/programgarden/database/workflow_risk_tracker.py
+++ b/src/programgarden/programgarden/database/workflow_risk_tracker.py
@@ -26,13 +26,63 @@ import time
 from collections import deque
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from decimal import Decimal, ROUND_HALF_UP
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from pathlib import Path
-from typing import Any, Deque, Dict, FrozenSet, List, Optional, Set, Tuple
+from typing import Any, Deque, Dict, FrozenSet, List, Optional, Set, Tuple, Union
 
 logger = logging.getLogger(__name__)
 
 VALID_FEATURES: Set[str] = {"hwm", "window", "events", "state"}
+
+
+# ============================================================
+# 수량(Decimal) 헬퍼
+# ============================================================
+
+def _to_qty_decimal(value: Any) -> Decimal:
+    """포지션 수량을 Decimal 로 정규화한다.
+
+    수량을 int 로 다루면 소수점 잔량(예: 0.532주)이 0 으로 잘려, 재시작 검증이
+    매번 '수량 변동'으로 오판하고 HWM(트레일링 고점)을 평단으로 되돌린다.
+    가격류가 전부 Decimal 이라 수량도 Decimal 이어야 혼합 산술(Decimal * float)
+    TypeError 도 피한다.
+    (근거: LS 는 해외주식 소수점 주식을 지원한다 — 출처: 오너 진술 2026-09-12.
+     PositionInfo.quantity 도 이미 Decimal — workflow_position_tracker.py:48-49)
+    """
+    if isinstance(value, Decimal):
+        d = value
+    else:
+        try:
+            d = Decimal(str(value))
+        except (InvalidOperation, TypeError, ValueError):
+            # 조용히 0 으로 넘기면 원인을 못 찾으므로 사유를 남긴다.
+            logger.warning(f"RiskTracker: 수량 변환 실패 → 0 으로 처리: {value!r}")
+            return Decimal("0")
+
+    # NaN/Infinity 는 예외를 던지지 않고 통과한다(Decimal(str(float('nan')))
+    # == Decimal('NaN')). 이대로 position_qty 에 들어가면 nan != nan 이 항상 참이라
+    # 재시작마다 '수량 변동'으로 오판해 HWM 이 리셋되고, sqlite 바인딩은 NULL 로
+    # 저장돼 원인도 남지 않는다. 여기서 잘라내고 사유를 남긴다.
+    if not d.is_finite():
+        logger.warning(f"RiskTracker: 수량이 유한수가 아님 → 0 으로 처리: {value!r}")
+        return Decimal("0")
+    return d
+
+
+def _qty_changed(observed: Decimal, remembered: Decimal) -> bool:
+    """재시작 검증에서 포지션 수량이 실제로 바뀌었는지 판정.
+
+    영속 컬럼 position_qty 는 저장 직전 float 로 바인딩되므로(SQLite 가 무손실
+    정수면 INTEGER 로 접고 소수는 REAL 로 둔다), 복원값은 float 왕복을 한 번 거친
+    값이다. 그래서 비교도 같은 float 정밀도에서 한다 — 정수 수량은 기존과 동일하게
+    정확일치(10 vs 10)로 판정되고, 소수 수량(0.532)도 왕복 뒤 그대로 일치한다.
+    브로커가 float 로 표현 불가능한 Decimal(예: Decimal('0.1234567890123456789'))을
+    보고해도 순수 `!=` 비교면 복원값과 항상 달라 매 재시작 리셋되지만, float 정밀도
+    비교는 '변동 없음'으로 옳게 판정한다.
+    평단처럼 0.01 허용오차를 두지 않는 이유: 수량은 체결 단위로 딱 떨어지는 값이라
+    0.01 을 허용하면 실제 소수 체결 변동(0.005주 감소 등)을 '변동 없음'으로 놓친다.
+    """
+    return float(observed) != float(remembered)
 
 
 # ============================================================
@@ -48,7 +98,9 @@ class HWMState:
     hwm_datetime: datetime
     current_price: Decimal
     drawdown_pct: Decimal
-    position_qty: int
+    # 수량은 Decimal — 소수점 잔량을 int 로 자르면 재시작마다 '수량 변동'으로
+    # 오판해 hwm_price 를 평단으로 리셋한다(_to_qty_decimal 주석 참조).
+    position_qty: Decimal
     position_avg_price: Decimal
     dirty: bool = True
 
@@ -181,6 +233,11 @@ class WorkflowRiskTracker:
                     hwm_datetime TEXT NOT NULL,
                     current_price REAL,
                     current_drawdown_pct REAL,
+                    -- 선언은 INTEGER 지만 SQLite 의 INTEGER affinity 는 무손실일
+                    -- 때만 REAL→INTEGER 로 변환하고(10.0→10, typeof 'integer')
+                    -- 소수는 REAL 로 그대로 둔다(0.532·9.5 → typeof 'real').
+                    -- 따라서 기존 정수 행의 저장 포맷은 유지되고 소수 수량도 손실
+                    -- 없이 보존되므로 선언은 바꾸지 않는다.
                     position_qty INTEGER,
                     position_avg_price REAL,
                     trading_mode TEXT NOT NULL DEFAULT 'live',
@@ -239,24 +296,40 @@ class WorkflowRiskTracker:
         symbol: str,
         exchange: str,
         entry_price: float,
-        qty: int,
+        qty: Union[int, float, Decimal],
     ) -> None:
         """매수 체결 시 HWM 등록."""
         if self._hwm is None:
             return
 
         price = Decimal(str(entry_price))
+        # 소수점 체결(0.532주) 대응 + Decimal 가격과의 혼합 산술 TypeError 방지
+        qty_dec = _to_qty_decimal(qty)
         now = datetime.now(timezone.utc)
 
         existing = self._hwm.get(symbol)
         if existing:
             # 추가 매수: 평단가 업데이트, HWM은 유지
-            total_qty = existing.position_qty + qty
-            total_cost = existing.position_avg_price * existing.position_qty + price * qty
-            new_avg = total_cost / total_qty
-            existing.position_qty = total_qty
-            existing.position_avg_price = new_avg
-            existing.dirty = True
+            prev_qty = existing.position_qty
+            total_qty = prev_qty + qty_dec
+            total_cost = existing.position_avg_price * prev_qty + price * qty_dec
+            if total_qty > 0:
+                existing.position_qty = total_qty
+                existing.position_avg_price = total_cost / total_qty
+                existing.dirty = True
+            else:
+                # 수량이 0 으로 정규화된 매수(읽기 실패·NaN → _to_qty_decimal 이 0)가
+                # 같은 종목에 겹치면 total_qty 가 0 이 되어 0/0 나눗셈이 된다
+                # (decimal.InvalidOperation [DivisionUndefined] — register_symbol 호출부가
+                # 통째로 터진다). 평단을 새로 계산할 정보가 없으므로 직전 평단을 유지하고,
+                # 수량만 실제 합계로 갱신한 뒤 사유를 남긴다.
+                existing.position_qty = total_qty
+                existing.dirty = True
+                logger.warning(
+                    f"RiskTracker: 합계 수량이 0 이하라 평단 갱신 불가 → 직전 평단 유지 "
+                    f"(symbol={symbol}, 기존={prev_qty}, 추가={qty_dec}, "
+                    f"합계={total_qty}, 평단={existing.position_avg_price})"
+                )
         else:
             self._hwm[symbol] = HWMState(
                 symbol=symbol,
@@ -265,7 +338,7 @@ class WorkflowRiskTracker:
                 hwm_datetime=now,
                 current_price=price,
                 drawdown_pct=Decimal("0"),
-                position_qty=qty,
+                position_qty=qty_dec,
                 position_avg_price=price,
                 dirty=True,
             )
@@ -404,12 +477,19 @@ class WorkflowRiskTracker:
                                 s.symbol, s.exchange,
                                 float(s.hwm_price), s.hwm_datetime.isoformat(),
                                 float(s.current_price), float(s.drawdown_pct),
-                                s.position_qty, float(s.position_avg_price),
+                                # sqlite3 는 Decimal 바인딩을 거부하므로 저장 직전 float 로
+                                # 변환한다. 실측(2026-09-12, 이 패키지의 지원 런타임인
+                                # Python 3.12.13 · 3.14.5): sqlite3.ProgrammingError
+                                # "Error binding parameter 1: type 'decimal.Decimal' is not supported".
+                                float(s.position_qty), float(s.position_avg_price),
                                 self.trading_mode, now,
                             ),
                         )
 
-            await asyncio.get_event_loop().run_in_executor(None, _write)
+            # get_event_loop() 는 "현재 스레드에 설정된 루프"를 보는 레거시 API 라
+            # (테스트 conftest 처럼) 주변에서 루프를 갈아끼우면 무엇을 잡을지 흔들린다.
+            # 이 코루틴은 항상 실행 중인 루프 위에 있으므로 그 루프를 직접 쓴다.
+            await asyncio.get_running_loop().run_in_executor(None, _write)
 
             for s in dirty_items:
                 s.dirty = False
@@ -443,7 +523,9 @@ class WorkflowRiskTracker:
                         hwm_datetime=datetime.fromisoformat(row["hwm_datetime"]),
                         current_price=Decimal(str(row["current_price"] or row["high_water_mark"])),
                         drawdown_pct=Decimal(str(row["current_drawdown_pct"] or 0)),
-                        position_qty=row["position_qty"] or 0,
+                        # REAL 로 저장된 수량을 Decimal 로 복원. int 로 받으면
+                        # 0.532 → 0 이 돼 재시작 검증이 매번 리셋된다.
+                        position_qty=_to_qty_decimal(row["position_qty"] or 0),
                         position_avg_price=Decimal(str(row["position_avg_price"] or 0)),
                         dirty=False,
                     )
@@ -494,13 +576,17 @@ class WorkflowRiskTracker:
                 ))
             else:
                 pos = pos_map[symbol]
-                pos_qty = getattr(pos, "quantity", None) or (pos.get("quantity") if isinstance(pos, dict) else 0) or 0
+                # PositionInfo.quantity 는 Decimal 이라 int 와 직접 비교하면
+                # Decimal('9.5') != 9 가 항상 참이 돼 매 재시작 리셋된다.
+                pos_qty = _to_qty_decimal(
+                    getattr(pos, "quantity", None) or (pos.get("quantity") if isinstance(pos, dict) else 0) or 0
+                )
                 pos_avg = getattr(pos, "avg_price", None) or (pos.get("avg_price") if isinstance(pos, dict) else 0) or 0
 
-                if pos_qty != state.position_qty or abs(float(pos_avg) - float(state.position_avg_price)) > 0.01:
+                if _qty_changed(pos_qty, state.position_qty) or abs(float(pos_avg) - float(state.position_avg_price)) > 0.01:
                     # 수량/평단 변동 → 리셋
                     old_hwm = state.hwm_price
-                    state.position_qty = int(pos_qty)
+                    state.position_qty = pos_qty
                     state.position_avg_price = Decimal(str(pos_avg))
                     state.hwm_price = Decimal(str(pos_avg))
                     state.hwm_datetime = datetime.now(timezone.utc)
@@ -526,7 +612,13 @@ class WorkflowRiskTracker:
         # 신규 종목 (포지션 있지만 HWM 없는 경우)
         for symbol, pos in pos_map.items():
             if symbol not in self._hwm:
-                pos_qty = getattr(pos, "quantity", None) or (pos.get("quantity") if isinstance(pos, dict) else 0) or 0
+                # 소수 수량 그대로 보존. 신규 등록 자체는 아래 `pos_qty > 0` 게이트가
+                # 절단 전 원본(Decimal('0.532'))으로 판정하므로 예전에도 됐다 —
+                # 깨진 건 저장되는 수량이다. int 절단 시 position_qty 가 0 으로
+                # 저장돼 트레일링 청산의 수량 폴백(hwm.position_qty)이 0 이 된다.
+                pos_qty = _to_qty_decimal(
+                    getattr(pos, "quantity", None) or (pos.get("quantity") if isinstance(pos, dict) else 0) or 0
+                )
                 pos_avg = getattr(pos, "avg_price", None) or (pos.get("avg_price") if isinstance(pos, dict) else 0) or 0
                 exchange = getattr(pos, "exchange", None) or (pos.get("exchange") if isinstance(pos, dict) else "") or ""
 
@@ -539,7 +631,7 @@ class WorkflowRiskTracker:
                         hwm_datetime=datetime.now(timezone.utc),
                         current_price=avg_dec,
                         drawdown_pct=Decimal("0"),
-                        position_qty=int(pos_qty),
+                        position_qty=pos_qty,
                         position_avg_price=avg_dec,
                         dirty=True,
                     )
@@ -983,7 +1075,9 @@ class WorkflowRiskTracker:
                         s.symbol, s.exchange,
                         float(s.hwm_price), s.hwm_datetime.isoformat(),
                         float(s.current_price), float(s.drawdown_pct),
-                        s.position_qty, float(s.position_avg_price),
+                        # sqlite3 는 Decimal 바인딩을 거부(ProgrammingError) → float 변환
+                        # (flush_to_db 와 동일 — 관측 근거는 그쪽 주석)
+                        float(s.position_qty), float(s.position_avg_price),
                         self.trading_mode, now,
                     ),
                 )

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -85,6 +85,77 @@ def _qty_num(value: Any, default: int = 0):
     return int(f) if f.is_integer() else f
 
 
+def _whole_unit_quantity(value: Any) -> Optional[int]:
+    """정수 수량이면 int 로, 아니면 None — **자르지 않는다**.
+
+    정정 TR 세 개는 수량 필드를 모두 **정수**로 선언한다:
+      · COSAT00311 blocks.py:79 ``OrdQty: int``  ("Revised order quantity in shares")
+      · CIDBT00900 blocks.py:130 ``OrdQty: int`` ("Revised order quantity in contracts")
+      · CSPAT00701 blocks.py:74 ``OrdQty: int``  ("New order quantity in shares")
+    그런데 해외주식은 소수점 거래가 실재한다(prod 2026-08-24 IBM 0.847972주 실측 —
+    _qty_num 독스트링). 그래서 ``int(quantity)`` 로 싣으면 0.847972 → **0** 이
+    브로커로 나가고 원장에는 0.847972 가 남아, 이 구조가 지키려던 '와이어=원장'
+    불변식을 스스로 깬다. 자르는 대신 **거부**한다(호출부 _resolve_modify_target).
+
+    bool 은 int 의 서브클래스라 먼저 걷어낸다(True 를 수량 1 로 받으면 안 된다).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number or number in (float("inf"), float("-inf")):
+        return None
+    return int(number) if number.is_integer() else None
+
+
+def _usable_execution_identity(order_no: Any, order_date: Any) -> bool:
+    """체결 프레임의 (주문번호, 주문일자)가 원장 execution identity 키로 쓸 수 있나.
+
+    원장은 체결번호(execution_id)를 실으면 (product, provider, trading_mode,
+    order_date, order_no, execution_id) 로 중복방지 키를 만드는데
+    (workflow_position_tracker._execution_key), 그때 주문번호도 정규화한다.
+    정규화가 None 을 주거나 ValueError 를 올리면, **또는 order_date 가 비면**
+    _execution_key 가
+    ValueError("Explicit execution identity requires an order number and date")
+    를 올린다. 그래서 체결번호를 싣기 전에 여기서 미리 확인하고, 못 쓰면
+    체결번호 없이 종전 경로로 안전 강등한다.
+
+    ⚠️ 이건 **최종 방어선이 아니라 '가능하면 미리 거른다' 는 최적화**다.
+    이 함수는 (주문번호, 주문일자) 축만 보고 **체결번호 자체는 보지 않는다**
+    (프레임 값을 읽는 시점이 호출부마다 다르기 때문) — 체결번호가 "0.0"/"-0"
+    같은 비정수 수치 문자열이면 여기를 통과하고도 _execution_key 가 ValueError 를
+    올린다. 그 부류 전체는 context.record_workflow_fill 이 닫는다 — identity 관련
+    ValueError 를 잡아 체결번호 없이 한 번 더 기록하고 warning 을 남긴다
+    (중복방지만 포기, 체결은 보존). 여기서 거르는 이유는 그 재시도/경고를
+    안 만들고 끝내기 위해서다.
+
+    주문일자까지 보는 이유: 프레임에서 주문일자를 읽는 경로가
+    `getattr(body, 'ordr_dt', <로컬날짜>)`(TC3/TC2) 인데, getattr 의 기본값은
+    **속성이 아예 없을 때만** 쓰인다 — 브로커가 `ordr_dt=""` 를 실어 보내면
+    빈 문자열이 그대로 흘러 `not fill.order_date` 분기에 걸린다. 여기서
+    로컬 날짜를 대신 채워 넣지는 않는다(프레임이 말하지 않은 주문일자를
+    지어내면 원장 대조 키가 거짓이 된다) — 중복방지만 포기한다.
+
+    주문번호 판정은 tracker._normalize_identifier 의 규칙을 그대로 따른다
+    (사설 메서드를 건드리지 않으려고 최소 복제): 빈 값/0-only 는 식별자가 아니고,
+    정수가 아닌 수치 문자열(예: "12.5")은 그쪽에서 ValueError 다.
+    """
+    if not str(order_date or "").strip():
+        return False
+    text = str(order_no or "").strip()
+    if not text:
+        return False
+    if re.fullmatch(r"[0-9]+", text):
+        return bool(text.lstrip("0"))
+    if re.fullmatch(r"[+-]?[0-9]+(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?", text):
+        return False
+    return True
+
+
 def _safe_print(*args: Any, **kwargs: Any) -> None:
     """Emit console output without ever letting it abort the caller.
 
@@ -4547,12 +4618,42 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 
                 # 필요한 필드 추출
                 order_no = str(getattr(body, 'sOrdNo', ''))
-                execution_id = getattr(body, 'sExecNO', None)
                 order_date = datetime.now().strftime('%Y%m%d')  # AS1에는 sOrdDt 없음
+                # E3: 체결번호는 **주문번호를 원장 키로 쓸 수 있을 때만** 싣는다.
+                # AS1 의 sOrdNo 는 int 라(SDK overseas_stock/real/AS1/blocks.py:374) 0 이 오면 str() 이 '0' 이 되고,
+                # _normalize_identifier 가 그걸 None 으로 접어 _execution_key 가
+                # ValueError 를 올린다. 그럴 땐 중복방지를 포기하고 종전 경로로
+                # 안전 강등한다. SC1(execno)·TC3(ccls_no)과 동일 패턴.
+                # (이건 최적화다 — 뚫려도 context.record_workflow_fill 이 identity
+                #  ValueError 를 잡아 체결번호 없이 다시 기록한다.)
                 symbol = getattr(body, 'sShtnIsuNo', getattr(body, 'sIsuNo', ''))
                 market_code = getattr(body, 'sOrdMktCode', '82')
                 side_code = getattr(body, 'sOrdPtnCode', '')  # 01: 매도, 02: 매수
-                fill_time = getattr(body, 'proctm', datetime.now().strftime('%H%M%S000'))
+                # 체결시각은 sExecTime(체결시각) → sRcptExecTime(거래소수신체결시각)
+                # 순으로만 읽는다. 종전에는 proctm 을 썼는데 proctm 은 **AP처리시간**
+                # (증권사 서버 처리시각, 9자리 HHMMSSmmm)이라 거래소 체결시각과 다른
+                # 값이다(출처: 오너 진술 2026-09-12). SDK 만으로도 확정된다 —
+                # blocks.py:91 이 proctm 구간을 'System / WS frame header fields
+                # (shared across AS0~AS4)' 로, :317 이 sExecTime 구간을
+                # 'Execution-specific fields (AS1)' 로 명시한다(sExecTime=:644,
+                # sRcptExecTime=:650). 국내 SC1 은 이미 exectime(체결시각)을 쓰고
+                # 있었으므로 이 수정으로 상품 간 의미도 일치한다.
+                #
+                # 🔴 폴백을 만들지 않는다. proctm 도, `datetime.now()` 합성값도 쓰지
+                # 않는다. 소비자(pg-worker app/order_fill_updates.py)가
+                # `order_date + fill_time` 을 시장 세션 타임존으로 읽어 executed_at 을
+                # **계산된 체결시각**으로 확정하고, 그럴 때는 executed_at_source 태그도
+                # 붙이지 않는다. 파드에는 TZ env 가 없어 now() 는 UTC 벽시계이므로,
+                # 합성 9자리를 Asia/Seoul 로 읽으면 9시간 과거가 되면서도 "계산된 값"
+                # 으로 보인다. 값이 없으면 **빈 문자열**로 내보내 pg-worker 의
+                # `and fill_time` 가드가 걸리게 하고, 그쪽이 received_at 폴백을
+                # executed_at_source="received_at" 으로 정직하게 표시하게 한다.
+                # (두 체결시각 필드의 자릿수/타임존은 SDK 에 선언돼 있지 않고 우리도
+                #  미관측이다 — examples 는 6자리 '093015'.)
+                fill_time = (
+                    str(getattr(body, 'sExecTime', '') or '').strip()
+                    or str(getattr(body, 'sRcptExecTime', '') or '').strip()
+                )
                 
                 # 시장코드 → 거래소 변환
                 exchange_map = {'81': 'NYSE', '82': 'NASDAQ', '83': 'AMEX'}
@@ -4599,7 +4700,11 @@ class BrokerNodeExecutor(NodeExecutorBase):
                         # 우리 주문과 일치하면 매체코드 무관하게 workflow 로 분류되고,
                         # 일치하지 않는 계좌 내 타 체결만 이 코드로 HTS/타 API 를 가른다.
                         commda_code=getattr(body, 'sCommdaCode', ''),
-                        execution_id=execution_id,
+                        # 위 E3 가드 — 주문번호/주문일자가 원장 키로 못 쓰이면 None.
+                        execution_id=(
+                            getattr(body, 'sExecNO', None)
+                            if _usable_execution_identity(order_no, order_date) else None
+                        ),
                         account_avg_price=account_avg_price,
                     )
 
@@ -4747,7 +4852,12 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 quantity = int(getattr(body, 'ccls_q', 0) or 0)
                 price_str = str(getattr(body, 'ccls_prc', '0') or '0')
                 price = float(price_str.strip()) if price_str.strip() else 0.0
-                fill_time = getattr(body, 'ccls_tm', datetime.now().strftime('%H%M%S000'))
+                # 체결시각은 프레임의 ccls_tm 만 쓴다 — 없으면 빈 문자열.
+                # 종전 `or datetime.now().strftime('%H%M%S000')` 합성 폴백은
+                # 파드 로컬(UTC) 벽시계를 브로커 체결시각과 같은 9자리 모양으로
+                # 내보내 하류(pg-worker)가 그것을 '계산된 체결시각'으로 승격시켰다.
+                # 빈 값이면 하류가 received_at 폴백을 태그와 함께 쓴다.
+                fill_time = str(getattr(body, 'ccls_tm', '') or '').strip()
 
                 logger.info(f"[TC3] 체결: svc_id={svc_id}, order_no={order_no}, symbol={symbol}, side={side}, qty={quantity}, price={price}")
 
@@ -4764,9 +4874,36 @@ class BrokerNodeExecutor(NodeExecutorBase):
                                 price=price,
                                 fill_time=fill_time,
                                 # 선물 체결 프레임(TC3)에는 통신매체코드 필드가 없다
-                                # (blocks.py 에 commda/media 없음). 이 경로는 우리
-                                # 주문의 체결이므로 OPEN API 기본값 '40' 을 유지한다.
-                                commda_code='40',
+                                # (blocks.py 에 commda/media 없음). 종전에는 '40'(OPEN
+                                # API)을 채웠는데, 그건 프레임이 말하지 않은 값을
+                                # 원장에 증거처럼 남기는 것이다 — tracker 의
+                                # detect_anomalies 가 `WHERE commda_code='40'` 을
+                                # unknown_api 비율의 분모로 써서 trust_score 에 실제로
+                                # 영향이 간다. 그래서 '프레임이 아무 말도 안 했다' 를
+                                # 그대로 빈 문자열로 남긴다. media_channel('') 은
+                                # 'unknown' 이고, tracker 의 record_fill 은 unknown 과
+                                # api 를 같은 버퍼 분기로 보내므로 분류 결과는 현행과
+                                # 동일하다. AS1 이 먼저 하드코딩을 폐기한 패턴과 같다.
+                                commda_code='',
+                                # 체결번호(ccls_no — SDK overseas_futureoption/real/TC3/blocks.py 의
+                                # '체결번호(Fill number)' 필드) — 원장
+                                # 중복방지(execution_id 부분 유니크 인덱스)의 유일한
+                                # 키다. 이건 REST 대사용 식별자 alias 를 지어내는 게
+                                # 아니라 프레임이 이미 싣고 있는 자기 필드를 읽는
+                                # 것이다. 1주문이 분할체결되면 체결번호가 N개 발급되므로
+                                # (출처: 오너 진술 2026-09-12) 같은 프레임 재전달만
+                                # 걸러지고 진짜 분할체결은 보존된다.
+                                # E3: 주문번호가 빈 프레임에서는 싣지 않는다 —
+                                # _execution_key 가 order_no 정규화를 요구하고
+                                # 실패 시 ValueError 를 올린다. 그럴 땐 중복방지를
+                                # 포기하고 종전 경로로 안전 강등한다. (최종 방어선은
+                                # context.record_workflow_fill 의 identity ValueError
+                                # 폴백이다 — 여긴 그걸 미리 거르는 최적화.)
+                                execution_id=(
+                                    getattr(body, 'ccls_no', None)
+                                    if _usable_execution_identity(order_no, order_date)
+                                    else None
+                                ),
                             ),
                             loop
                         )
@@ -4837,9 +4974,24 @@ class BrokerNodeExecutor(NodeExecutorBase):
                     symbol = raw_symbol.lstrip('A') if raw_symbol.startswith('A') else raw_symbol
                     bns_tp = getattr(body, 'bnstp', '')  # 1:매도, 2:매수
                     side = 'buy' if bns_tp == '2' else 'sell'
-                    fill_time = getattr(body, 'exectime', datetime.now().strftime('%H%M%S000'))
+                    # 체결시각은 프레임의 exectime 만 쓴다 — 없으면 빈 문자열.
+                    # (TC3/AS1 과 같은 이유. 합성 9자리는 pg-worker 가 Asia/Seoul 로
+                    #  읽어 '계산된 체결시각' 으로 확정해버린다.)
+                    fill_time = str(getattr(body, 'exectime', '') or '').strip()
 
                     media_code = getattr(body, 'commdacode', '')
+
+                    # E3: 체결번호는 **주문번호가 있을 때만** 싣는다.
+                    # 원장의 execution identity 키는 (product, provider,
+                    # trading_mode, order_date, order_no, execution_id) 라
+                    # (workflow_position_tracker._execution_key), 주문번호가 비면
+                    # ValueError 를 올린다. 주문번호가 없는 프레임은 중복방지를
+                    # 포기하고 종전 경로로 안전 강등한다. (최종 방어선은
+                    # context.record_workflow_fill 의 identity ValueError 폴백.)
+                    execution_no = (
+                        getattr(body, 'execno', None)
+                        if _usable_execution_identity(order_no, order_date) else None
+                    )
 
                     async def record_and_refresh():
                         """체결 기록 후 AccountTracker refresh"""
@@ -4855,7 +5007,21 @@ class BrokerNodeExecutor(NodeExecutorBase):
                             # SC1 프레임의 통신매체코드(commdacode)를 그대로 넘긴다.
                             # 우리 주문과 일치하면 workflow, 아니면 이 코드로
                             # HTS(manual)/타 API(unknown_api)를 가른다.
+                            # 국내 매체코드 의미는 40/41=오픈API·50=MTS·60=HTS·
+                            # 00=지점(유선) — **출처는 오너 진술(2026-09-12)이며
+                            # 저장소 SDK 에는 국내 매체코드 enum 이 선언돼 있지 않고
+                            # 우리도 라이브 미관측**이다(그래서 여기서 코드를
+                            # 해석하지 않고 표(MEDIA_CODES_*)에만 맡긴다).
                             commda_code=media_code,
+                            # 체결번호(execno, SDK korea_stock/real/SC1/blocks.py:147)
+                            # — 원장 중복방지(execution_id 부분 유니크 인덱스)의
+                            # 유일한 키. 종전에는 프레임이 싣고 있는데도 안 읽어서
+                            # 국내주식은 중복방지가 통째로 비활성이었고, 같은 프레임이
+                            # 재전달되면 FIFO 가 이중계상됐다. AS1(sExecNO)과 동일 패턴.
+                            # 1주문 분할체결 시 체결번호는 N개로 발급되므로
+                            # (출처: 오너 진술 2026-09-12) 진짜 분할체결은 보존된다.
+                            # order_no 가 빈 프레임에서는 None 이다(위 E3 가드).
+                            execution_id=execution_no,
                         )
 
                         # AccountTracker refresh로 PnL 이벤트 강제 트리거
@@ -7036,16 +7202,51 @@ class RealAccountNodeExecutor(NodeExecutorBase):
         open_orders = {}
         if hasattr(tracker, 'get_open_orders'):
             for order_no, order in tracker.get_open_orders().items():
+                # 🔴 exchange 가 비는 건 **브로커가 안 줘서가 아니라 SDK 매핑이
+                # 버려서**다. 브로커 응답 COSAQ00102OutBlock3 에는 주문시장코드가
+                # 있다(SDK overseas_stock/accno/COSAQ00102/blocks.py:534 OrdMktCode
+                # — "'81' = NYSE, '82' = NASDAQ"). 그런데 그 행을 StockOpenOrder 로
+                # 옮기는 SDK 매핑(overseas_stock/extension/tracker.py:385-398)이
+                # OrdMktCode 를 읽지 않고, 모델에도 자리가 없다
+                # (extension/models.py:189-226: order_no/symbol/symbol_name/
+                # order_type/order_qty/order_price/executed_qty/remaining_qty/
+                # order_time/order_status/currency_code/last_updated 뿐).
+                # 즉 이 값은 "거래소가 빈 주문" 도, "브로커가 말하지 않음" 도 아니고
+                # **중간 매핑에서 유실**이다. 키 자체는 포트 스키마(ORDER_LIST_FIELDS
+                # 에 exchange 선언)와 형제 경로(선물/국내)의 모양을 지키려고 남기되,
+                # 소비자가 빈 문자열을 사실로 오해하지 않도록 사유를 같은 dict 에
+                # 싣는다(안 보낸 필드는 '안 보냄' 으로 표시하는 저장소 규약).
+                # 독출 자체는 남겨둔다 — SDK 모델에 market_code 가 생기면 그때는
+                # 사유 없이 실제 값이 나가야 한다(근본 수정은 finance 패키지 몫).
+                exchange_value = str(
+                    getattr(order, 'exchange_code', '')
+                    or getattr(order, 'market_code', '')
+                    or ''
+                )
                 open_orders[order_no] = {
                     "order_no": order_no,
                     "symbol": getattr(order, 'symbol', ''),
-                    "exchange": getattr(order, 'exchange_code', getattr(order, 'market_code', '')),
+                    "exchange": exchange_value,
                     "order_type": getattr(order, 'order_type', ''),
                     "order_price": float(getattr(order, 'order_price', 0)),
-                    "order_qty": int(getattr(order, 'order_qty', 0)),
-                    "filled_qty": int(getattr(order, 'filled_qty', 0)),
-                    "remaining_qty": int(getattr(order, 'remaining_qty', getattr(order, 'order_qty', 0)) or 0),
+                    # SDK StockOpenOrder 의 수량은 int | float 다
+                    # (overseas_stock/extension/models.py:204·210·213 "소수점 가능").
+                    # LS 는 해외주식 소수점 거래를 지원하고(출처: 오너 진술
+                    # 2026-09-12), prod 실측도 있다(2026-08-24 IBM 0.847972주 —
+                    # _qty_num 독스트링). int() 로 자르면 1주 미만 주문이 통째
+                    # 0 이 돼 미체결이 조용히 사라진다 — 형제 경로
+                    # OpenOrdersNode(_ls_overseas_stock)가 이미 _qty_num 을 쓰는 것과
+                    # 맞춘다. 또 체결수량 필드명은 filled_qty 가 아니라
+                    # **executed_qty** 라(models.py:210) 종전 이름으로는 항상 0 이었다
+                    # (국내판은 executed_qty 를 올바르게 읽고 있다).
+                    "order_qty": _qty_num(getattr(order, 'order_qty', 0)),
+                    "filled_qty": _qty_num(getattr(order, 'executed_qty', 0)),
+                    "remaining_qty": _qty_num(getattr(order, 'remaining_qty', getattr(order, 'order_qty', 0)) or 0),
                 }
+                if not exchange_value:
+                    open_orders[order_no]["exchange_unavailable_reason"] = (
+                        "dropped_by_sdk_open_order_mapping"
+                    )
         
         return {
             "held_symbols": held_symbols,
@@ -15833,6 +16034,38 @@ class NewOrderNodeExecutor(NodeExecutorBase):
                 node_id
             )
 
+            # FIFO/체결분류용 원장 기록 — 해외주식(_execute_overseas_stock)·해외선물과
+            # 같은 규약. 종전에는 국내주식만 이 호출이 빠져 있어서 SC1 체결이
+            # `_check_workflow_order` 에서 항상 False 가 되고, 남은 기준이 매체코드뿐이라
+            # 'workflow' 분류가 한 건도 생기지 않았다 — personal_metrics 승률·손익비에서
+            # 국내주식 체결이 전량 누락된다.
+            # 🔴 주문일자는 브로커 날짜가 아니라 **로컬 날짜**여야 한다 — 체결
+            # 대조가 (order_no, order_date) 로 이뤄지고, SC1 프레임에는 주문일자
+            # 필드가 없어 수신 시점 로컬 날짜로 채워지기 때문이다(해외주식
+            # `_sync_positions_from_executions` 의 🔴 주석과 같은 근거).
+            # 가격은 브로커에 실제로 보낸 값(ord_prc) — 시장가면 0.0 이고,
+            # 체결 시 update_workflow_order_fill_price 가 실체결가로 채운다.
+            # Legacy stores remain best effort; their failure cannot revoke ACK.
+            # (해외선물 경로와 같은 규약 — 원장 기록 실패가 이미 브로커에
+            #  접수된 주문을 '실패' 로 뒤집으면 안 된다. 이 블록이 없으면 예외가
+            #  메서드 전체 try 로 올라가 _order_result(False, ...) 가 된다.)
+            try:
+                context.record_workflow_order(
+                    order_no=order_no,
+                    order_date=datetime.now().strftime("%Y%m%d"),
+                    symbol=symbol,
+                    exchange="KRX",
+                    side=side,
+                    quantity=qty,
+                    price=ord_prc,
+                    node_id=node_id,
+                )
+            except Exception as ledger_err:
+                logger.warning(
+                    "Korea stock order ledger write failed (order accepted): %s",
+                    ledger_err,
+                )
+
             result = self._order_result(
                 True, symbol, "KRX", side, qty, price
             )
@@ -16041,6 +16274,14 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
         exchange = config.get("exchange", "KRX" if product == "korea_stock" else "NASDAQ")
         new_quantity = config.get("new_quantity")
         new_price = config.get("new_price")
+        # ⚠️ 잔재값이다 — ModifyOrder 계열 노드 스키마에 side 필드가 없어
+        # (core/programgarden_core/nodes/order.py:245-263) 노드로 들어오면 항상
+        # 기본값 "buy" 다. 세 정정 경로 어디도 이 **변수**로 방향을 정하지 않는다.
+        # 방향은 원 주문 원장 행에서 승계하고(_resolve_modify_target), 원장이
+        # 없거나 행이 없을 때만 **config 에 실제로 실린** side 를 쓴다 — 그건 각
+        # 정정 메서드가 `config.get("side")` 로 기본값 없이 직접 읽는다(여기서
+        # 기본값을 먹인 이 변수를 넘기면 '호출자가 말한 값' 과 '기본값' 을 구분할
+        # 수 없다). 시그니처 호환을 위해서만 넘긴다.
         side = config.get("side", "buy")
         
         if not original_order_id:
@@ -16100,6 +16341,337 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
             context.log("error", f"{node_type}: Unexpected error: {e}", node_id)
             return self._error_result(str(e))
 
+    def _resolve_modify_target(
+        self,
+        context: ExecutionContext,
+        *,
+        product_label: str,
+        original_order_id: Any,
+        symbol: str,
+        exchange: str,
+        new_quantity: Optional[int],
+        new_price: Optional[float],
+        requires_side: bool,
+        explicit_side: Any = None,
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+        """정정의 **실효 주문**(방향/수량/가격/종목/거래소)을 한 번에 확정한다.
+
+        브로커 요청과 원장 기록이 **같은 값**을 쓰게 하려고 한 곳에서만 푼다.
+        종전에는 원장만 원 주문 값을 승계하고(아래) 와이어는 ``new_quantity or 0``
+        / ``new_price or 0.0`` 이라, 수량만 정정하면 브로커에는 가격 0 이 나가고
+        원장에는 원가격이 적히는 **불일치**가 생겼다.
+
+        🔴 방향(side)은 config 에서 읽으면 안 된다. ModifyOrder 계열 노드 스키마에는
+        side 필드가 아예 없어(core/programgarden_core/nodes/order.py:245-263 =
+        connection / original_order_id / symbol / exchange) 호출부의
+        ``config.get("side", "buy")`` 는 세 경로 모두 사실상 항상 "buy" 다.
+        그 값은 두 곳으로 흘렀다:
+          1. 해외선물 정정 요청의 ``BnsTpCode``(CIDBT00900) — 매도 선물 주문을
+             정정해도 매수로 나갔다. (불일치 BnsTpCode 를 LS 가 어떻게 처리하는지는
+             **미관측**이다. 여기서 고치는 근거는 그 값이 *존재할 수 없는 config
+             키*에서 왔다는 사실 하나뿐이다.)
+          2. 원장 기록 → risk_tracker.register_symbol(entry_price, qty) — 보유하지도
+             않은 종목에 롱 HWM 이 생기고, 그 HWM 이 이후 그 종목의 신규 매수를
+             drawdown 게이트(check_drawdown_threshold)로 막았다.
+        그래서 방향은 **추측하지 않고 원 주문 원장 행에서 승계**한다.
+
+        수량/가격을 0 으로 치환하지 않는 근거(SDK 전수 확인, 2026-09-12):
+        세 정정 TR 어디에도 '0 = 변경 없음' 규약이 없다.
+          - COSAT00311 blocks.py:79-92 — OrdQty "Revised order quantity in shares",
+            OvrsOrdPrc "Revised order price ...". 예제
+            example/overseas_stock/run_COSAT00311.py:36-37 은 OrdQty=1,
+            OvrsOrdPrc=2.62 로 **실제 값**을 싣는다.
+          - CIDBT00900 blocks.py:110-133 — OvrsDrvtOrdPrc "Revised limit order
+            price", OrdQty "Revised order quantity in contracts. Example script
+            uses 1". 예제 example/overseas_futureoption/run_CIDBT00900.py:39-41 도
+            OvrsDrvtOrdPrc=0.64935, OrdQty=1.
+          - CSPAT00701 blocks.py:100-107 — OrdPrc 는 오히려 0 에 **다른 뜻**이
+            달려 있다: "Use 0 for market orders ('03') and other non-limit price
+            types". 지정가('00')로 0 을 보내면 '변경 없음' 이 아니라 가격 0 이다.
+            예제 example/korea_stock/run_CSPAT00701.py:32-35 도 OrdQty=1, OrdPrc=100.
+        노드 스키마도 같은 약속을 한다 — nodes/order.py:766-772
+        "정정할 수량 (변경하지 않으면 기존 수량 유지)". 그 '유지'를 실제로
+        수행하는 곳이 여기다: 안 바꾼 필드는 **원 주문 값을 그대로 다시 싣는다**.
+
+        🔴 '원장에 행이 없다' 와 '원장 자체가 없다' 는 다른 실패다.
+        트래커는 워크플로우에 PnL 리스너가 하나라도 있을 때만 만들어진다
+        (context.init_workflow_position_tracker 의
+        ``any(hasattr(l, 'on_workflow_pnl_update') ...)`` 게이트, 또는 초기화
+        예외). 리스너 0개로 엔진을 라이브러리처럼 직접 구동하면 트래커가 None 이라
+        record_workflow_order 가 no-op → 원장에 행이 생길 수 없고 →
+        find_workflow_order 는 **영원히** None 이다. 그 구성에서 방향을 원장에서만
+        찾으면 해외선물 정정이 전면 불능이 된다(매수든 매도든, 수량·가격을 다
+        줘도 브로커에 닿지 못한다). 그래서 두 경우의 사유 코드를 가른다:
+          · ``ledger_unavailable``       — 원장 자체가 없다(구성 문제).
+          · ``original_order_not_found`` — 원장은 있는데 그 주문 행이 없다.
+
+        그리고 **호출자가 side 를 실제로 준 경우에는 그 값을 쓴다** — 추측이 아니라
+        사용자가 알려준 값이다. ModifyOrder 노드 스키마에는 side 가 없지만
+        (core/programgarden_core/nodes/order.py:245-263) 라이브러리를 직접 부르는
+        호출자는 config 에 넣을 수 있다. 단 ``config.get("side", "buy")`` 의
+        **기본값**은 호출자가 준 값이 아니므로 여기까지 오지 않는다 — 세 정정
+        메서드가 ``config.get("side")`` 를 그대로(기본값 없이) 넘긴다. 원장 행이
+        있으면 원장이 이긴다(그건 우리가 실제로 브로커에 보낸 값의 기록이다).
+
+        ⚠️ 못 찾았을 때 종전처럼 'buy' 로 되돌리지 않는 이유: 매도 주문 정정에
+        매수 구분(BnsTpCode='2')을 보내는 건 실계좌 위험이고(LS 가 불일치
+        BnsTpCode 를 어떻게 처리하는지는 **미관측**이다), 원장에도 유령 롱 HWM 이
+        남는다. 조용히 틀린 방향으로 나가는 것보다 사유를 달고 실패하는 편이 낫다.
+
+        수량은 **정수만** 싣는다 — 세 TR 의 수량 필드가 모두 ``OrdQty: int``
+        (COSAT00311 blocks.py:79 / CIDBT00900 blocks.py:130 / CSPAT00701
+        blocks.py:74)인데 해외주식은 소수점 거래가 실재한다(prod 2026-08-24 IBM
+        0.847972주). ``int()`` 로 자르면 브로커엔 0, 원장엔 0.847972 가 남아
+        이 구조의 '와이어=원장' 불변식이 깨지므로 자르지 않고 거부한다
+        (사유 ``non_integer_quantity``). 근거는 _whole_unit_quantity 참조.
+
+        **승계 가격**도 0 이하면 거부한다(사유 ``non_positive_inherited_price``).
+        원장 price 는 '브로커에 실제로 보낸 값' 이라 시장가 신규주문은 0.0 으로
+        적힌다 — 국내주식 `_execute_korea_stock` 의 ``ord_prc = 0.0 if
+        ordprc_ptn_code == "03"`` → ``record_workflow_order(price=ord_prc)``,
+        해외주식 매도 시장가도 ``price = 0.0`` 을 그대로 기록한다. 체결 전
+        (= 정정 가능한 상태)에는 update_workflow_order_fill_price 가 아직 실체결가를
+        채우지 않았으므로 그 0.0 이 승계값이 된다. 그 값을 지정가('00') 정정에
+        실으면 '변경 없음' 이 아니라 **가격 0 주문**이다 — CSPAT00701
+        blocks.py:100-107 은 0 을 시장가('03')용 값으로 명시하고, 세 정정 TR
+        어디에도 '0 = 유지' 규약이 없다(위 SDK 인용). non_positive_quantity 게이트와
+        같은 모양의 구멍이 가격 축에 있었던 것이라 같은 자리에서 막는다.
+
+        ⚠️ 이 게이트는 **승계값에만** 건다(``new_price is None`` 일 때). 호출자가
+        ``new_price=0`` 을 명시적으로 준 경우는 막지 않는다 — 그건 호출자의
+        진술이고, CSPAT00701 에서는 시장가 유형(``price_type_code="03"``)과 함께
+        유효할 수 있다. 그 조합(유형 코드 × 가격 0)의 유효성은 우리가 판정하지
+        않는다 — 호출자가 준 값을 그대로 싣는다.
+
+        Returns:
+            (resolved, error). resolved 는
+            {"order_date", "side", "quantity", "price", "symbol", "exchange",
+             "side_known", "side_source"}. error 가 있으면 정정을 **보내지 않는다**.
+        """
+        order_date = datetime.now().strftime("%Y%m%d")
+        ledger_available = context.has_workflow_order_ledger()
+        original: Optional[Dict[str, Any]] = None
+        try:
+            # 종목까지 넘긴다 — 자정을 관통한 정정은 원장 행이 D±1 에 있고,
+            # 그 창 후보를 가르는 기준이 종목이다(브로커 주문번호는 영업일마다
+            # 리셋되므로 과거 날짜의 동명 번호가 있다). context.find_workflow_order 참조.
+            found = context.find_workflow_order(
+                str(original_order_id), order_date, symbol=symbol,
+            )
+            if isinstance(found, dict):
+                original = found
+        except Exception as lookup_err:
+            # 조회는 best-effort 다. 실패하면 '못 찾음' 과 같이 취급하고,
+            # 아래 게이트가 방향/미변경 필드를 못 풀면 정정을 거른다.
+            logger.warning(
+                "Modify (%s): ledger lookup failed for original order %s: %s",
+                product_label, original_order_id, lookup_err,
+            )
+
+        side = original.get("side") if original else None
+        if side not in ("buy", "sell"):
+            side = None
+        side_source = "ledger" if side is not None else None
+
+        # 호출자가 **실제로** 준 방향(기본값이 아니다 — 호출부가 config.get("side")
+        # 를 기본값 없이 넘긴다). 원장 행이 있으면 원장이 이긴다.
+        caller_side = str(explicit_side).strip().lower() if explicit_side is not None else ""
+        if caller_side not in ("buy", "sell"):
+            caller_side = ""
+        if caller_side:
+            if side is None:
+                side = caller_side
+                side_source = "config"
+                logger.warning(
+                    "Modify (%s): original order %s not found in the ledger; using the "
+                    "caller-supplied side %r from config (not a guess — the caller "
+                    "stated it). ledger_available=%s",
+                    product_label, original_order_id, caller_side, ledger_available,
+                )
+            elif caller_side != side:
+                logger.warning(
+                    "Modify (%s): caller-supplied side %r disagrees with the ledger row "
+                    "for order %s (%r); using the ledger value — it is the record of "
+                    "what we actually sent to the broker",
+                    product_label, caller_side, original_order_id, side,
+                )
+
+        quantity = new_quantity if new_quantity is not None else (
+            original.get("quantity") if original else None
+        )
+        price = new_price if new_price is not None else (
+            original.get("price") if original else None
+        )
+
+        if requires_side and side is None:
+            if not ledger_available:
+                # 원장 자체가 없다 — 이 구성에서는 어떤 주문도 조회될 수 없다.
+                # 종전(4차 이전)에는 여기서 config 기본값 "buy" 가 그대로 나가
+                # 매수 정정만 우연히 동작했다. 방향을 지어내지 않는 대신, 사유를
+                # 갈라 운영자가 '기록 안 된 주문' 과 '원장 없는 구성' 을 구분하게 한다.
+                return None, (
+                    f"ledger_unavailable: cannot resolve the original order direction "
+                    f"for {product_label} modify of order {original_order_id} — this "
+                    f"run has no workflow order ledger (the position tracker is only "
+                    f"created when a listener implements on_workflow_pnl_update, and "
+                    f"init failures leave it unset), so no order row can ever exist. "
+                    f"The modify request carries a mandatory buy/sell code; pass an "
+                    f"explicit 'side' in the node config to modify without a ledger. "
+                    f"Refusing to guess — sending 'buy' for a sell order is a live-account risk."
+                )
+            return None, (
+                f"original_order_not_found: cannot resolve original order direction "
+                f"for {product_label} modify of order {original_order_id} (ledger row "
+                f"not found or has no usable side). The modify request carries a "
+                f"buy/sell code, and the node schema has no side field to fall back "
+                f"on — refusing to guess."
+            )
+
+        if quantity is None or price is None:
+            return None, (
+                f"unchanged_field_unresolved: cannot resolve the unchanged field(s) "
+                f"for {product_label} modify of order {original_order_id} "
+                f"(new_quantity={new_quantity!r}, new_price={new_price!r}, "
+                f"original order not found in the ledger"
+                f"{'; this run has no order ledger at all' if not ledger_available else ''}"
+                f"). Sending 0 is not 'keep the original value' in any of the modify "
+                f"TRs — refusing."
+            )
+
+        whole_quantity = _whole_unit_quantity(quantity)
+        if whole_quantity is not None and whole_quantity <= 0:
+            # 정수이긴 한데 0 이하다. 절단 버그와 **같은 결과**(OrdQty=0)를 내므로
+            # 여기서도 막는다. 사유 코드는 따로 둔다 — 원인이 다르다.
+            return None, (
+                f"non_positive_quantity: cannot modify {product_label} order "
+                f"{original_order_id} with quantity {quantity!r} — a modify with "
+                f"OrdQty<=0 is not a quantity change, and none of the modify TRs "
+                f"give 0 a 'keep the original' meaning."
+            )
+        if whole_quantity is None:
+            return None, (
+                f"non_integer_quantity: cannot modify {product_label} order "
+                f"{original_order_id} with quantity {quantity!r} — every modify TR "
+                f"declares a whole-unit order quantity (COSAT00311 blocks.py:79 "
+                f"'OrdQty: int' / CIDBT00900 blocks.py:130 'OrdQty: int' / "
+                f"CSPAT00701 blocks.py:74 'OrdQty: int'), and LS overseas stock "
+                f"fractional orders do exist (prod 2026-08-24 IBM 0.847972 shares). "
+                f"Truncating would send OrdQty=0 to the broker while the ledger keeps "
+                f"the fraction — refusing instead of silently truncating."
+            )
+
+        if new_price is None:
+            # 승계 가격 게이트 — 호출자가 new_price 를 주지 않아 원장 값을 다시
+            # 싣는 경우에만 본다. 원장 price 는 '브로커에 보낸 값' 이라 시장가
+            # 신규주문은 0.0 으로 적혀 있고(국내 ord_prc / 해외 매도 시장가),
+            # 체결 전이라 실체결가로 덮이지도 않았다. 그 0 을 정정에 실으면
+            # 지정가 가격 0 주문이 된다(CSPAT00701 blocks.py:100-107 — 0 은
+            # 시장가용 값이지 '유지' 가 아니다). non_positive_quantity 와 같은
+            # 근거로 여기서 거부한다.
+            #
+            # 호출자가 new_price=0 을 **명시**한 경우는 이 분기에 들어오지 않는다.
+            # 그건 호출자의 진술이고, CSPAT00701 에선 시장가 유형('03')과 함께
+            # 유효할 수 있다 — 그 조합의 유효성은 우리가 판정하지 않는다.
+            #
+            # 원장 price 컬럼은 REAL 이라 float/None 만 온다(None 은 위
+            # unchanged_field_unresolved 가 이미 걸렀다). 그래도 숫자가 아니면
+            # 여기서 단정하지 않고 종전처럼 호출부의 float() 에 맡긴다.
+            try:
+                inherited_price = float(price)
+            except (TypeError, ValueError):
+                inherited_price = None
+            if inherited_price is not None and inherited_price <= 0:
+                return None, (
+                    f"non_positive_inherited_price: cannot modify {product_label} order "
+                    f"{original_order_id} by inheriting its ledger price {price!r} — "
+                    f"the ledger records the price actually sent to the broker, and a "
+                    f"market order is sent with price 0 (CSPAT00701 blocks.py:100-107 "
+                    f"'Use 0 for market orders'), so re-sending it as a limit modify "
+                    f"would place a price-0 order, not keep the original. "
+                    f"시장가로 낸 주문은 가격을 승계할 수 없다 — new_price 를 명시하라."
+                )
+
+        return {
+            "order_date": order_date,
+            # 브로커에 싣는 값과 원장에 적는 값이 **같은 객체**에서 나가야 하므로
+            # 여기서 정수로 확정한다(호출부는 다시 int() 로 감싸지 않는다).
+            "quantity": whole_quantity,
+            "side": side,
+            "price": price,
+            "symbol": (original.get("symbol") if original else None) or symbol,
+            "exchange": (original.get("exchange") if original else None) or exchange,
+            "side_known": side is not None,
+            "side_source": side_source,
+        }, None
+
+    def _record_modified_order(
+        self,
+        context: ExecutionContext,
+        *,
+        product_label: str,
+        resolved: Dict[str, Any],
+        new_order_no: str,
+        node_id: str,
+    ) -> None:
+        """정정으로 발급된 **새 주문번호**를 원장에 남긴다(값은 resolved 그대로).
+
+        정정 후 체결은 새 주문번호로 오므로, 이 행이 없으면 우리 체결이
+        (order_no, order_date) 대조에 실패해 manual/unknown_api 로 오분류된다.
+        원 주문 행은 지우지 않는다 — 원 주문의 잔여 체결이 늦게 도착할 수 있고,
+        record_order 는 INSERT OR IGNORE 라 재기록도 안전하다.
+
+        기록값은 브로커에 실제로 보낸 값(_resolve_modify_target 의 resolved)과
+        **같은 객체**에서 온다 — 원장과 와이어가 갈리지 않게 하는 게 이 구조의
+        목적이다.
+
+        방향을 끝내 못 푼 경우(해외주식/국내는 요청에 방향이 안 들어가므로 정정
+        자체는 나갈 수 있다)에는 **행을 남기지 않는다**: 체결 분류는
+        (order_no, order_date) 로만 이뤄지므로, 방향을 모르는 채 "buy" 로 박아
+        유령 롱 HWM 을 만드는 것보다 기록을 건너뛰는 편이 안전하다.
+        (호출자가 config 로 방향을 명시했다면 그건 추측이 아니므로 기록한다 —
+        resolved["side_source"] == "config".)
+
+        정정은 새 포지션이 아니므로 register_risk=False 로 리스크 트래커
+        부수효과를 끈다(HWM 이중계상·미체결 매도 정정으로 인한 HWM 조기 해제 방지).
+        원 주문이 이미 HWM 을 등록해 둔 상태라 정정이 추가로 할 일은 없다.
+
+        기록 실패는 절대 정정 자체를 실패로 만들지 않는다 — Legacy stores remain
+        best effort; their failure cannot revoke ACK(해외선물 신규주문 경로와 같은 규약).
+        """
+        try:
+            if not resolved.get("side_known"):
+                logger.warning(
+                    "Modify (%s): original order direction unknown; skipping ledger "
+                    "row for new order %s (recording it as 'buy' would register a "
+                    "phantom long HWM)",
+                    product_label, new_order_no,
+                )
+                return
+            if resolved.get("side_source") == "config":
+                logger.info(
+                    "Modify (%s): recording new order %s with the caller-supplied "
+                    "side %r (no ledger row for the original order)",
+                    product_label, new_order_no, resolved.get("side"),
+                )
+
+            context.record_workflow_order(
+                order_no=new_order_no,
+                order_date=resolved["order_date"],
+                symbol=resolved["symbol"],
+                exchange=resolved["exchange"],
+                side=resolved["side"],
+                quantity=resolved["quantity"],
+                price=resolved["price"],
+                node_id=node_id,
+                register_risk=False,
+            )
+        except Exception as ledger_err:
+            logger.warning(
+                "Modify (%s): ledger write failed for new order %s (modify already "
+                "accepted by broker): %s",
+                product_label, new_order_no, ledger_err,
+            )
+
     async def _modify_overseas_stock(
         self,
         ls,
@@ -16113,10 +16685,39 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
         context: ExecutionContext,
         node_id: str,
     ) -> Dict[str, Any]:
-        """해외주식 정정주문 실행 (COSAT00311)"""
+        """해외주식 정정주문 실행 (COSAT00311)
+
+        ⚠️ ``side`` **인자**는 브로커 요청에도 원장 기록에도 쓰지 않는다. ModifyOrder
+        노드 스키마에 side 필드가 없어(core/programgarden_core/nodes/order.py:
+        245-263) 호출부의 ``config.get("side", "buy")`` 가 사실상 항상 "buy" 이기
+        때문이다(COSAT00311 자체는 매매구분을 받지 않는다 — blocks.py:55-95).
+        원장 방향은 원 주문 행에서 승계하고, 행이 없으면 **config 에 실제로 실린**
+        side 만 쓴다(``config.get("side")`` — 기본값 없이 읽으므로 노드 경로에서는
+        None 이다). 인자는 시그니처 호환을 위해 남겨둔다.
+
+        수량/가격은 **실효값**을 싣는다 — 안 바꾼 필드에 0 을 보내지 않는다.
+        근거는 _resolve_modify_target 독스트링(SDK blocks/example 인용).
+        """
         from programgarden_finance.ls.overseas_stock.order.COSAT00311.blocks import COSAT00311InBlock1
 
-        
+        resolved, resolve_error = self._resolve_modify_target(
+            context,
+            product_label="overseas_stock",
+            original_order_id=original_order_id,
+            symbol=symbol,
+            exchange=exchange,
+            new_quantity=new_quantity,
+            new_price=new_price,
+            # COSAT00311 에는 매매구분 필드가 없다 → 방향을 몰라도 요청은 나갈 수
+            # 있다(원장 행만 건너뛴다).
+            requires_side=False,
+            # 기본값 없이 넘긴다 — 호출자가 실제로 실어 보낸 경우만 쓴다.
+            explicit_side=config.get("side"),
+        )
+        if resolve_error:
+            context.log("error", f"Modify order blocked: {resolve_error}", node_id)
+            return self._error_result(resolve_error)
+
         # 시장 코드 결정
         ord_mkt_code = self.STOCK_MARKET_CODES.get(exchange, "82")
         
@@ -16131,8 +16732,12 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
                     OrgOrdNo=int(original_order_id),
                     OrdMktCode=ord_mkt_code,
                     IsuNo=symbol,
-                    OrdQty=new_quantity or 0,
-                    OvrsOrdPrc=new_price or 0.0,
+                    # resolved["quantity"] 는 이미 정수로 확정돼 있다
+                    # (_resolve_modify_target 의 non_integer_quantity 게이트).
+                    # 여기서 다시 int() 로 감싸면 그 게이트를 우회해 소수 수량을
+                    # 조용히 0 으로 자른다 — 감싸지 말 것.
+                    OrdQty=resolved["quantity"],
+                    OvrsOrdPrc=float(resolved["price"]),
                     OrdprcPtnCode=ordprc_ptn_code,
                 ),
             )
@@ -16180,7 +16785,17 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
                 f"Order modified: {symbol} original={original_order_id} → new={new_order_no}",
                 node_id
             )
-            
+
+            # 원장 기록(브로커에 보낸 것과 **같은** resolved 값) — 상세 규약은
+            # _resolve_modify_target / _record_modified_order 독스트링 참고.
+            self._record_modified_order(
+                context,
+                product_label="overseas_stock",
+                resolved=resolved,
+                new_order_no=new_order_no,
+                node_id=node_id,
+            )
+
             return {
                 "modify_result": {
                     "success": True,
@@ -16223,14 +16838,47 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
         context: ExecutionContext,
         node_id: str,
     ) -> Dict[str, Any]:
-        """해외선물 정정주문 실행 (CIDBT00900)"""
+        """해외선물 정정주문 실행 (CIDBT00900)
+
+        ⚠️ ``side`` **인자**는 쓰지 않는다. ModifyOrder 노드 스키마에 side 필드가 없어
+        (core/programgarden_core/nodes/order.py:245-263) 호출부의
+        ``config.get("side", "buy")`` 가 사실상 항상 "buy" 라, 이 TR 의
+        ``BnsTpCode``(blocks.py:88-93 "'1' = sell, '2' = buy")에 매도 주문을
+        정정할 때도 매수가 실렸다. 방향은 원 주문 원장 행에서 승계한다.
+
+        원장 행이 없을 때의 처리는 두 갈래다:
+          · ``config`` 에 side 가 **실제로** 실려 있으면(라이브러리 직접 호출자)
+            그 값을 쓴다 — 추측이 아니라 호출자가 알려준 값이다.
+          · 아니면 추측하지 않고 **정정 요청 자체를 거른다**. 사유는 원장 자체가
+            없는 구성이면 ``ledger_unavailable``, 원장은 있는데 행이 없으면
+            ``original_order_not_found`` 로 갈라 준다.
+        """
         from programgarden_finance.ls.overseas_futureoption.order.CIDBT00900.blocks import CIDBT00900InBlock1
 
         from datetime import datetime
-        
-        # 매매구분코드: 1=매도, 2=매수
-        bns_tp_code = "1" if side == "sell" else "2"
-        
+
+        resolved, resolve_error = self._resolve_modify_target(
+            context,
+            product_label="overseas_futures",
+            original_order_id=original_order_id,
+            symbol=symbol,
+            exchange=exchange,
+            new_quantity=new_quantity,
+            new_price=new_price,
+            # CIDBT00900 은 매매구분(BnsTpCode)을 **필수**로 받는다 → 방향을 모르면
+            # 보낼 수 없다.
+            requires_side=True,
+            # 원장에 행이 없어도(특히 원장 자체가 없는 구성) 호출자가 방향을
+            # 명시했으면 그 값을 쓴다 — 추측이 아니라 사용자가 알려준 값이다.
+            explicit_side=config.get("side"),
+        )
+        if resolve_error:
+            context.log("error", f"Modify futures order blocked: {resolve_error}", node_id)
+            return self._error_result(resolve_error)
+
+        # 매매구분코드: 1=매도, 2=매수 (원 주문 원장 행에서 승계 — config 아님)
+        bns_tp_code = "1" if resolved["side"] == "sell" else "2"
+
         today = datetime.now().strftime("%Y%m%d")
         expiry_month = config.get("expiry_month", "")
         exchange_code = config.get("exchange_code", exchange)
@@ -16246,9 +16894,9 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
                     BnsTpCode=bns_tp_code,
                     FutsOrdPtnCode="2",  # 지정가
                     CrcyCodeVal="",
-                    OvrsDrvtOrdPrc=new_price or 0.0,
+                    OvrsDrvtOrdPrc=float(resolved["price"]),
                     CndiOrdPrc=0.0,
-                    OrdQty=new_quantity or 0,
+                    OrdQty=resolved["quantity"],   # 정수 확정값 — int() 재감싸기 금지
                     OvrsDrvtPrdtCode="000000",
                     DueYymm=expiry_month,
                     ExchCode=exchange_code,
@@ -16299,7 +16947,16 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
                 f"Futures order modified: {symbol} original={original_order_id} → new={new_order_no}",
                 node_id
             )
-            
+
+            # 원장 기록(브로커에 보낸 것과 **같은** resolved 값).
+            self._record_modified_order(
+                context,
+                product_label="overseas_futures",
+                resolved=resolved,
+                new_order_no=new_order_no,
+                node_id=node_id,
+            )
+
             return {
                 "modify_result": {
                     "success": True,
@@ -16340,8 +16997,32 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
         context: ExecutionContext,
         node_id: str,
     ) -> Dict[str, Any]:
-        """국내주식 정정주문 실행 (CSPAT00701)"""
+        """국내주식 정정주문 실행 (CSPAT00701)
+
+        CSPAT00701 은 매매구분을 받지 않는다(blocks.py:55-107 — OrgOrdNo/IsuNo/
+        OrdQty/OrdprcPtnCode/OrdCndiTpCode/OrdPrc). 그래서 방향을 몰라도 요청은
+        나가고, 원장 행만 건너뛴다.
+
+        가격/수량은 **실효값**을 싣는다. 특히 OrdPrc 는 0 이 '변경 없음' 이 아니라
+        **시장가용 값**이다(blocks.py:100-107 "Use 0 for market orders ('03') and
+        other non-limit price types") — 지정가('00')로 0 을 보내면 가격 0 이다.
+        """
         from programgarden_finance.ls.korea_stock.order.CSPAT00701.blocks import CSPAT00701InBlock1
+
+        resolved, resolve_error = self._resolve_modify_target(
+            context,
+            product_label="korea_stock",
+            original_order_id=original_order_id,
+            symbol=symbol,
+            exchange="KRX",
+            new_quantity=new_quantity,
+            new_price=new_price,
+            requires_side=False,
+            explicit_side=config.get("side"),
+        )
+        if resolve_error:
+            context.log("error", f"Korea stock modify order blocked: {resolve_error}", node_id)
+            return self._error_result(resolve_error)
 
         # 호가유형코드 (기본: 지정가)
         ordprc_ptn_code = config.get("price_type_code", "00")
@@ -16350,9 +17031,9 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
             body = CSPAT00701InBlock1(
                 OrgOrdNo=int(original_order_id),
                 IsuNo=symbol,
-                OrdQty=new_quantity or 0,
+                OrdQty=resolved["quantity"],   # 정수 확정값 — int() 재감싸기 금지
                 OrdprcPtnCode=ordprc_ptn_code,
-                OrdPrc=float(new_price) if new_price else 0.0,
+                OrdPrc=float(resolved["price"]),
             )
 
             order_api = ls.korea_stock().order().cspat00701(body=body)
@@ -16398,6 +17079,17 @@ class ModifyOrderNodeExecutor(NodeExecutorBase):
                 "info",
                 f"Korea stock order modified: {symbol} original={original_order_id} → new={new_order_no}",
                 node_id
+            )
+
+            # 원장 기록(브로커에 보낸 것과 **같은** resolved 값).
+            # 종전에는 config.get("side", "buy") 를 썼는데, ModifyOrder 노드에는
+            # side 필드 자체가 없어 항상 "buy" 였다(유령 롱 HWM).
+            self._record_modified_order(
+                context,
+                product_label="korea_stock",
+                resolved=resolved,
+                new_order_no=new_order_no,
+                node_id=node_id,
             )
 
             return {

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.36.0"
+version = "1.37.0"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
@@ -37,8 +37,8 @@ litellm = ">=1.40.0"
 # (1.26.0 이후로도 context.py 는 WorkflowPnLEvent(**event_data) 에 personal_metrics
 #  를 무조건 실으므로 그 하한 근거도 이 상한에 포함된다.)
 programgarden-core = "^1.28.0"
-programgarden-finance = "^1.9.5"
-programgarden-community = "^1.15.0"
+programgarden-finance = "^1.9.6"
+programgarden-community = "^1.15.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/src/programgarden/tests/test_futures_tc3_side.py
+++ b/src/programgarden/tests/test_futures_tc3_side.py
@@ -33,7 +33,7 @@ class MemorySocket:
         pass
 
 
-def tc3_packet(side):
+def tc3_packet(side, **overrides):
     body = {
         name: "" for name, field in TC3RealResponseBody.model_fields.items()
         if field.is_required()
@@ -44,13 +44,14 @@ def tc3_packet(side):
         ccls_q="2", ccls_prc="100.25", ccls_no="000777",
         ccls_dt="20260910", ccls_tm="001500",
     )
+    body.update(overrides)
     return {
         "header": {"tr_cd": "TC3", "rsp_cd": "00000", "rsp_msg": "synthetic"},
         "body": body,
     }
 
 
-async def deliver_tc3(monkeypatch, side, *, managed=False, shutdown=False):
+async def deliver_tc3(monkeypatch, side, *, managed=False, shutdown=False, **overrides):
     socket = MemorySocket()
     connect = Mock(return_value=socket)
     monkeypatch.setattr("programgarden_finance.ls.real_base.connect", connect)
@@ -95,7 +96,7 @@ async def deliver_tc3(monkeypatch, side, *, managed=False, shutdown=False):
                 loop.call_soon_threadsafe(processed.set)
 
         real.TC3().on_tc3_message(observe)
-        await socket.messages.put(json.dumps(tc3_packet(side)))
+        await socket.messages.put(json.dumps(tc3_packet(side, **overrides)))
         await asyncio.wait_for(processed.wait(), timeout=2)
         # The callback has finished on the SDK thread. Drain every submitted
         # coroutine so a skipped event cannot appear successful due to a race.
@@ -126,10 +127,21 @@ async def test_tc3_sdk_side_and_managed_reconciliation_guard(monkeypatch, caplog
         assert writes == [{
             "order_no": "000123", "order_date": "20260909", "symbol": "SYNTHETIC",
             "exchange": "FUTURES", "side": expected, "quantity": 2, "price": 100.25,
-            "fill_time": "001500", "commda_code": "40",
+            # TC3 프레임에는 통신매체코드 필드가 없다. 종전에는 '40'(OPEN API)을
+            # 하드코딩해 프레임이 말하지 않은 값을 원장에 남겼고, tracker 의
+            # detect_anomalies 가 그 '40' 을 unknown_api 비율의 분모로 써서
+            # trust_score 까지 흔들렸다. 이제 빈 문자열('프레임이 말하지 않음')이며
+            # media_channel('')='unknown' 은 api 와 같은 버퍼 분기라 분류는 그대로다.
+            "fill_time": "001500", "commda_code": "",
+            # 체결번호는 TC3 프레임 자신의 ccls_no 필드를 그대로 읽은 값이다.
+            # (종전 단언은 `"execution_id" not in writes[0]` 이었다. 그 취지는
+            #  "TC3 식별자를 REST 대사 식별자의 alias 로 지어내지 말라" 였는데,
+            #  여기서 싣는 건 alias 추론이 아니라 프레임 필드 독출이므로 그 취지와
+            #  충돌하지 않는다. 이 값이 없으면 원장의 execution_id 부분 유니크
+            #  인덱스가 선물에서 통째로 비활성이라 같은 프레임 재전달이 FIFO 에
+            #  이중계상된다.)
+            "execution_id": "000777",
         }]
-        # This fix does not invent TC3/REST execution identity or time aliases.
-        assert "execution_id" not in writes[0]
 
 
 @pytest.mark.asyncio
@@ -138,3 +150,70 @@ async def test_tc3_after_shutdown_never_schedules_inventory_write(monkeypatch, s
     writes, scheduled = await deliver_tc3(monkeypatch, side, shutdown=True)
     assert writes == []
     assert scheduled == 0
+
+
+@pytest.mark.asyncio
+async def test_tc3_without_order_number_keeps_the_fill_and_drops_execution_id(monkeypatch):
+    """주문번호가 빈 TC3 프레임은 체결번호를 싣지 않고 **체결을 유지**한다.
+
+    원장의 execution identity 키는 (product, provider, trading_mode, order_date,
+    order_no, execution_id) 다(workflow_position_tracker._execution_key). 체결번호만
+    있고 주문번호가 비면 그 키 생성이 ValueError 를 올리고, 그 예외를
+    context.record_workflow_fill 의 try 가 삼켜 **체결이 통째로 유실**된다
+    ("error" 반환). 그래서 이럴 때는 중복방지를 포기하고 종전 경로로 안전
+    강등한다 — 체결 자체를 버리는 것보다 낫다.
+    """
+    writes, scheduled = await deliver_tc3(monkeypatch, "2", ordr_no="")
+
+    assert scheduled == 1, "주문번호가 없다고 체결을 통째로 버리면 안 된다"
+    assert writes[0]["order_no"] == ""
+    assert writes[0]["execution_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_tc3_all_zero_order_number_also_drops_execution_id(monkeypatch):
+    """'0'/'000' 도 식별자가 아니다 — tracker._normalize_identifier 가 0-패딩을
+    벗겨 None 으로 접기 때문에 빈 주문번호와 같은 ValueError 경로다."""
+    writes, scheduled = await deliver_tc3(monkeypatch, "2", ordr_no="000")
+
+    assert scheduled == 1
+    assert writes[0]["execution_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_tc3_missing_fill_time_is_empty_not_synthesized(monkeypatch):
+    """체결시각이 없으면 **빈 문자열**이다 — 로컬 시계를 합성하지 않는다.
+
+    종전에는 `or datetime.now().strftime('%H%M%S000')` 으로 파드 로컬(UTC) 벽시계를
+    브로커 체결시각과 **같은 9자리 모양**으로 내보냈다. 소비자(pg-worker
+    app/order_fill_updates.py)는 그 9자리를 시장 세션 타임존으로 읽어 executed_at 을
+    '계산된 체결시각' 으로 확정하고 executed_at_source 태그도 붙이지 않는다.
+    빈 문자열이면 그쪽 `and fill_time` 가드가 걸려 정직한 received_at 폴백이 된다.
+    """
+    writes, scheduled = await deliver_tc3(monkeypatch, "2", ccls_tm="")
+
+    assert scheduled == 1
+    assert writes[0]["fill_time"] == ""
+
+
+@pytest.mark.asyncio
+async def test_tc3_blank_order_date_keeps_the_fill_and_drops_execution_id(monkeypatch):
+    """주문일자가 **빈 문자열**인 TC3 프레임도 체결을 잃지 않는다.
+
+    executor 는 주문일자를 `getattr(body, 'ordr_dt', <로컬날짜>)` 로 읽는데,
+    getattr 의 기본값은 **속성이 아예 없을 때만** 쓰인다 — 브로커가 `ordr_dt=""`
+    를 실어 보내면 빈 문자열이 그대로 흐른다. 원장의 execution identity 키는
+    order_no 뿐 아니라 order_date 도 요구해서
+    (workflow_position_tracker._execution_key: `if order_no is None or not
+    fill.order_date: raise ValueError`), 주문번호가 멀쩡해도 날짜가 비면 같은
+    ValueError 경로로 **체결이 통째로 유실**된다(record_workflow_fill 의 try 가
+    삼킴). 그래서 가드는 (주문번호, 주문일자)를 함께 본다. 여기서 로컬 날짜를
+    지어내 채우지는 않는다 — 프레임이 말하지 않은 주문일자는 원장 대조 키를
+    거짓으로 만든다.
+    """
+    writes, scheduled = await deliver_tc3(monkeypatch, "2", ordr_dt="")
+
+    assert scheduled == 1, "주문일자가 없다고 체결을 통째로 버리면 안 된다"
+    assert writes[0]["order_date"] == ""
+    assert writes[0]["order_no"] == "000123", "주문번호는 멀쩡한 프레임이다"
+    assert writes[0]["execution_id"] is None

--- a/src/programgarden/tests/test_korea_stock_executor.py
+++ b/src/programgarden/tests/test_korea_stock_executor.py
@@ -711,6 +711,147 @@ class TestKoreaStockNewOrderExecutor:
         assert result["order_result"]["success"] is True
 
     @pytest.mark.asyncio
+    async def test_new_order_records_workflow_order_ledger(self):
+        """신규주문 성공 시 원장(record_workflow_order)에 기록되어야 한다.
+
+        이 호출이 빠져 있으면 SC1 체결이 `_check_workflow_order` 에서 항상 False 가
+        되고, 남는 판단 기준이 매체코드뿐이라 'workflow' 분류가 한 건도 생기지
+        않는다 — personal_metrics 승률·손익비에서 국내주식 체결이 전량 누락된다.
+        주문일자는 브로커 날짜가 아니라 **로컬 날짜**여야 한다(체결 대조가
+        (order_no, order_date) 로 이뤄지고 SC1 프레임에는 주문일자가 없다).
+        """
+        from datetime import datetime
+
+        executor = self._make_executor()
+        ctx = _make_mock_context()
+        ls = MagicMock()
+
+        resp = MagicMock()
+        resp.error_msg = None
+        resp.block2 = MagicMock()
+        resp.block2.OrdNo = 99003
+
+        mock_order_api = MagicMock()
+        mock_order_api.req_async = AsyncMock(return_value=resp)
+
+        mock_order = MagicMock()
+        mock_order.cspat00601 = MagicMock(return_value=mock_order_api)
+        mock_ks = MagicMock()
+        mock_ks.order = MagicMock(return_value=mock_order)
+        ls.korea_stock = MagicMock(return_value=mock_ks)
+
+        order = {"symbol": "005930", "quantity": 10, "price": 65000}
+        result = await executor._execute_korea_stock(
+            ls, order, "buy", "limit", {}, ctx, "ord-ledger"
+        )
+
+        assert result["order_result"]["success"] is True
+        ctx.record_workflow_order.assert_called_once()
+        kwargs = ctx.record_workflow_order.call_args.kwargs
+        assert kwargs["order_no"] == "99003"
+        assert kwargs["order_date"] == datetime.now().strftime("%Y%m%d")
+        assert kwargs["symbol"] == "005930"
+        assert kwargs["exchange"] == "KRX"
+        assert kwargs["side"] == "buy"
+        assert kwargs["quantity"] == 10
+        assert kwargs["price"] == 65000.0
+        assert kwargs["node_id"] == "ord-ledger"
+
+    @pytest.mark.asyncio
+    async def test_new_order_market_records_zero_price_not_requested_price(self):
+        """시장가는 브로커에 보낸 값(0.0)을 기록한다 — 체결 시 실체결가로 갱신된다."""
+        executor = self._make_executor()
+        ctx = _make_mock_context()
+        ls = MagicMock()
+
+        resp = MagicMock()
+        resp.error_msg = None
+        resp.block2 = MagicMock()
+        resp.block2.OrdNo = 99004
+
+        mock_order_api = MagicMock()
+        mock_order_api.req_async = AsyncMock(return_value=resp)
+
+        mock_order = MagicMock()
+        mock_order.cspat00601 = MagicMock(return_value=mock_order_api)
+        mock_ks = MagicMock()
+        mock_ks.order = MagicMock(return_value=mock_order)
+        ls.korea_stock = MagicMock(return_value=mock_ks)
+
+        order = {"symbol": "005930", "quantity": 10, "price": 65000}
+        await executor._execute_korea_stock(
+            ls, order, "sell", "market", {}, ctx, "ord-market"
+        )
+
+        assert ctx.record_workflow_order.call_args.kwargs["price"] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_new_order_failure_does_not_record_ledger(self):
+        """거부/빈 주문번호는 원장에 남기지 않는다(존재하지 않는 주문의 유령 행 금지)."""
+        executor = self._make_executor()
+        ctx = _make_mock_context()
+        ls = MagicMock()
+
+        resp = MagicMock()
+        resp.error_msg = None
+        resp.rsp_cd = "40300"
+        resp.rsp_msg = "주문가능금액 부족"
+        resp.block2 = None
+
+        mock_order_api = MagicMock()
+        mock_order_api.req_async = AsyncMock(return_value=resp)
+
+        mock_order = MagicMock()
+        mock_order.cspat00601 = MagicMock(return_value=mock_order_api)
+        mock_ks = MagicMock()
+        mock_ks.order = MagicMock(return_value=mock_order)
+        ls.korea_stock = MagicMock(return_value=mock_ks)
+
+        order = {"symbol": "005930", "quantity": 10, "price": 65000}
+        result = await executor._execute_korea_stock(
+            ls, order, "buy", "limit", {}, ctx, "ord-reject"
+        )
+
+        assert result["order_result"]["success"] is False
+        ctx.record_workflow_order.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ledger_write_failure_cannot_revoke_accepted_order(self):
+        """원장 기록이 실패해도 이미 접수된 주문을 실패로 뒤집지 않는다.
+
+        Legacy stores remain best effort; their failure cannot revoke ACK —
+        해외선물 신규주문 경로가 쓰는 규약과 같다. 이 호출이 메서드 전체 try 안에
+        벌거벗고 있으면 예외가 올라가 `_order_result(False, ...)` 가 되고,
+        브로커에는 실제로 들어간 주문이 워크플로우에는 '실패' 로 보인다.
+        """
+        executor = self._make_executor()
+        ctx = _make_mock_context()
+        ctx.record_workflow_order = MagicMock(side_effect=RuntimeError("ledger down"))
+        ls = MagicMock()
+
+        resp = MagicMock()
+        resp.error_msg = None
+        resp.block2 = MagicMock()
+        resp.block2.OrdNo = 99005
+
+        mock_order_api = MagicMock()
+        mock_order_api.req_async = AsyncMock(return_value=resp)
+
+        mock_order = MagicMock()
+        mock_order.cspat00601 = MagicMock(return_value=mock_order_api)
+        mock_ks = MagicMock()
+        mock_ks.order = MagicMock(return_value=mock_order)
+        ls.korea_stock = MagicMock(return_value=mock_ks)
+
+        order = {"symbol": "005930", "quantity": 10, "price": 65000}
+        result = await executor._execute_korea_stock(
+            ls, order, "buy", "limit", {}, ctx, "ord-ledger-fail"
+        )
+
+        assert result["order_result"]["success"] is True
+        assert result["order_result"]["order_id"] == "99005"
+
+    @pytest.mark.asyncio
     async def test_new_order_api_error(self):
         """주문 API 에러 시 success=False"""
         executor = self._make_executor()

--- a/src/programgarden/tests/test_korea_stock_pnl_tracking.py
+++ b/src/programgarden/tests/test_korea_stock_pnl_tracking.py
@@ -77,6 +77,9 @@ def _make_sc1_body(**kwargs):
         "execprc": "55000",
         "execqty": "10",
         "exectime": "093012000",
+        # 체결번호 — SC1 프레임(SDK korea_stock/real/SC1/blocks.py:147 execno)이
+        # 항상 싣는 필드. 원장 중복방지(execution_id)의 유일한 키라 기본값에 둔다.
+        "execno": "7654321",
         "mdfycnfqty": "0",
         "mdfycnfprc": "0",
         "orgordno": "",
@@ -466,6 +469,115 @@ class TestSubscribeKoreaStockFillEvents:
         assert call_kwargs["quantity"] == 5
         assert call_kwargs["price"] == 88000.0
         assert call_kwargs["fill_time"] == "141530000"
+
+    @pytest.mark.asyncio
+    async def test_fill_event_forwards_frame_execution_number(self):
+        """SC1 프레임의 체결번호(execno)가 execution_id 로 그대로 실려야 한다.
+
+        종전에는 프레임이 싣고 있는데도 읽지 않아 국내주식은 원장의
+        execution_id 부분 유니크 인덱스(중복방지)가 통째로 비활성이었고, 같은
+        프레임이 재전달되면 FIFO 가 이중계상됐다. 체결번호는 체결 성립 시
+        발행되며 1주문 분할체결이면 N개로 발급되므로(출처: 오너 진술 2026-09-12)
+        이 키는 '같은 체결의 재전달' 만 걸러내고 진짜 분할체결은 보존한다.
+        """
+        executor = _get_executor()
+        context = _make_mock_context()
+        mock_ls, _, _, mock_sc1 = _make_mock_ls()
+
+        on_sc1 = await self._setup_and_get_sc1_callback(executor, context, mock_ls, mock_sc1)
+
+        resp = MagicMock()
+        resp.body = _make_sc1_body(ordxctptncode="11", execno="0000042")
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_run:
+            futures = []
+            mock_run.side_effect = lambda c, l: futures.append(c) or MagicMock()
+            on_sc1(resp)
+
+        await futures[0]
+
+        assert context.record_workflow_fill.call_args.kwargs["execution_id"] == "0000042"
+
+    @pytest.mark.asyncio
+    async def test_fill_without_order_number_keeps_fill_and_drops_execution_id(self):
+        """주문번호가 빈 SC1 프레임은 체결번호를 싣지 않고 **체결을 유지**한다.
+
+        원장의 execution identity 키는 (product, provider, trading_mode,
+        order_date, order_no, execution_id) 다
+        (workflow_position_tracker._execution_key). 체결번호만 있고 주문번호가
+        비면 그 키 생성이 ValueError 를 올리고, 그 예외를
+        context.record_workflow_fill 의 try 가 삼켜 **체결이 통째로 유실**된다
+        ("error" 반환). 이럴 때는 중복방지를 포기하고 종전 경로로 안전 강등한다.
+        """
+        executor = _get_executor()
+        context = _make_mock_context()
+        mock_ls, _, _, mock_sc1 = _make_mock_ls()
+
+        on_sc1 = await self._setup_and_get_sc1_callback(executor, context, mock_ls, mock_sc1)
+
+        resp = MagicMock()
+        resp.body = _make_sc1_body(ordxctptncode="11", ordno="", execno="7654321")
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_run:
+            futures = []
+            mock_run.side_effect = lambda c, l: futures.append(c) or MagicMock()
+            on_sc1(resp)
+
+        assert futures, "주문번호가 없다고 체결을 통째로 버리면 안 된다"
+        await futures[0]
+
+        kwargs = context.record_workflow_fill.call_args.kwargs
+        assert kwargs["order_no"] == ""
+        assert kwargs["execution_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_fill_all_zero_order_number_drops_execution_id(self):
+        """'0'/'0000000' 도 식별자가 아니다 — tracker._normalize_identifier 가
+        0-패딩을 벗겨 None 으로 접으므로 빈 주문번호와 같은 ValueError 경로다."""
+        executor = _get_executor()
+        context = _make_mock_context()
+        mock_ls, _, _, mock_sc1 = _make_mock_ls()
+
+        on_sc1 = await self._setup_and_get_sc1_callback(executor, context, mock_ls, mock_sc1)
+
+        resp = MagicMock()
+        resp.body = _make_sc1_body(ordxctptncode="11", ordno="0000000")
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_run:
+            futures = []
+            mock_run.side_effect = lambda c, l: futures.append(c) or MagicMock()
+            on_sc1(resp)
+
+        await futures[0]
+        assert context.record_workflow_fill.call_args.kwargs["execution_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_missing_fill_time_is_empty_not_synthesized(self):
+        """체결시각이 없으면 **빈 문자열**이다 — 로컬 시계를 합성하지 않는다.
+
+        종전 `or datetime.now().strftime('%H%M%S000')` 은 파드 로컬(UTC) 벽시계를
+        브로커 체결시각과 같은 9자리 모양으로 내보냈고, 소비자(pg-worker
+        app/order_fill_updates.py)가 그걸 Asia/Seoul 로 읽어 executed_at 을
+        '계산된 체결시각' 으로 확정했다(executed_at_source 태그도 없이 — 9시간
+        과거가 사실처럼 기록된다). 빈 문자열이면 그쪽 `and fill_time` 가드가
+        걸려 정직한 received_at 폴백이 된다.
+        """
+        executor = _get_executor()
+        context = _make_mock_context()
+        mock_ls, _, _, mock_sc1 = _make_mock_ls()
+
+        on_sc1 = await self._setup_and_get_sc1_callback(executor, context, mock_ls, mock_sc1)
+
+        resp = MagicMock()
+        resp.body = _make_sc1_body(ordxctptncode="11", exectime="")
+
+        with patch("asyncio.run_coroutine_threadsafe") as mock_run:
+            futures = []
+            mock_run.side_effect = lambda c, l: futures.append(c) or MagicMock()
+            on_sc1(resp)
+
+        await futures[0]
+        assert context.record_workflow_fill.call_args.kwargs["fill_time"] == ""
 
     @pytest.mark.asyncio
     async def test_symbol_a_prefix_stripped(self):

--- a/src/programgarden/tests/test_modify_order_empty_guard.py
+++ b/src/programgarden/tests/test_modify_order_empty_guard.py
@@ -13,9 +13,23 @@ import pytest
 from programgarden.executor import CancelOrderNodeExecutor, ModifyOrderNodeExecutor
 
 
-def _make_context():
+def _make_context(side="sell"):
+    """빈-주문번호 가드만 보는 테스트용 컨텍스트.
+
+    정정 경로는 원 주문 원장 행에서 방향/미변경 필드를 승계한다
+    (executor._resolve_modify_target). 해외선물 CIDBT00900 은 매매구분
+    (BnsTpCode)이 필수라 원 주문을 못 찾으면 **정정 요청 자체가 거절**되므로,
+    빈-주문번호 가드(브로커 응답 단계)를 보려면 원장 조회가 성공해야 한다.
+    그래서 여기서는 원 주문 행이 있는 원장을 흉내낸다. 조회 결과가 dict 가
+    아니면(MagicMock 기본값) '원 주문 못 찾음' 으로 취급된다.
+    """
     ctx = MagicMock()
     ctx.log = MagicMock()
+    ctx.find_workflow_order = MagicMock(return_value={
+        "order_no": "ORIG", "order_date": "20260912", "symbol": "ORIG",
+        "exchange": "ORIG", "side": side, "quantity": 1, "price": 1.0,
+        "node_id": "order-node", "job_id": "job",
+    })
     return ctx
 
 

--- a/src/programgarden/tests/test_modify_order_ledger.py
+++ b/src/programgarden/tests/test_modify_order_ledger.py
@@ -1,0 +1,1147 @@
+"""정정(ModifyOrder) 원장 기록 — 방향은 원 주문에서 **승계**, 못 찾으면 기록 안 함.
+
+배경(회귀 방지):
+    정정 후 체결은 브로커가 새로 발급한 주문번호로 온다. 그 번호가 원장에 없으면
+    우리 체결이 (order_no, order_date) 대조에 실패해 manual/unknown_api 로
+    오분류된다 — 그래서 새 주문번호를 원장에 남긴다.
+
+    다만 **방향(side)을 추측해서는 안 된다.** ModifyOrder 계열 노드 스키마에는
+    side 필드가 아예 없어(core/programgarden_core/nodes/order.py:245-263 =
+    connection / original_order_id / symbol / exchange) 세 경로 모두 사실상 항상
+    "buy" 가 된다. 그 값이 context.record_workflow_order →
+    risk_tracker.register_symbol(entry_price=price, qty=quantity) 로 흘러가면
+    보유하지도 않은 종목에 롱 HWM 이 생기고, 그 HWM 이 이후 그 종목의 신규 매수를
+    drawdown 게이트(check_drawdown_threshold, 기본 10%)로 막는다. 수량만 정정하면
+    entry_price=0.0 짜리 HWM 까지 만들어진다.
+
+    그래서 원 주문 원장 행에서 side/symbol/exchange 를 승계하고, 수량/가격도
+    0 으로 치환하지 않고 승계하며, 원 주문을 못 찾으면 아예 기록하지 않는다.
+    정정은 새 포지션이 아니므로 리스크 트래커 부수효과도 끈다(register_risk=False).
+
+    그리고 **브로커 요청(와이어)과 원장이 갈리면 안 된다.** 승계는 원장에서만
+    하고 와이어는 `new_quantity or 0` / `new_price or 0.0` 이던 시기가 있었는데,
+    그러면 수량만 정정했을 때 브로커에는 가격 0 이 나가고 원장에는 원가격이
+    적힌다. 세 정정 TR 어디에도 '0 = 변경 없음' 규약이 없다 — 오히려
+    CSPAT00701 은 OrdPrc 0 에 다른 뜻을 준다(blocks.py:100-107 "Use 0 for market
+    orders ('03')"). SDK 예제도 셋 다 실제 값을 싣는다
+    (run_COSAT00311.py:36-37 / run_CIDBT00900.py:39-41 / run_CSPAT00701.py:32-35).
+    노드 스키마의 약속도 같다 — nodes/order.py:766-772 "변경하지 않으면 기존 수량
+    유지". 그래서 와이어도 실효값(원값 승계)을 싣는다.
+
+    해외선물(CIDBT00900)만은 요청에 **매매구분(BnsTpCode)** 이 들어간다
+    (blocks.py:88-93 "'1' = sell, '2' = buy"). 원 주문을 못 찾아 방향을 모르면
+    추측하지 않고 **정정 요청 자체를 거른다**(브로커에 아무것도 보내지 않는다).
+    ⚠️ LS 가 불일치 BnsTpCode 를 어떻게 처리하는지는 **미관측**이다 — 고치는
+    근거는 그 값이 존재할 수 없는 config 키에서 왔다는 사실뿐이다.
+
+라이브 키 없이 mock LS 응답 + 실제 SQLite 원장으로 3개 정정 경로를 모두 검증한다.
+"""
+
+import logging
+import sqlite3
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.database.workflow_position_tracker import WorkflowPositionTracker
+from programgarden.executor import ModifyOrderNodeExecutor
+
+
+TODAY = datetime.now().strftime("%Y%m%d")
+
+
+# ---------------------------------------------------------------------------
+# 헬퍼
+# ---------------------------------------------------------------------------
+
+def _make_context(tmp_path, product):
+    """실제 ExecutionContext + 실제 SQLite 원장 + mock 리스크 트래커."""
+    ctx = ExecutionContext(job_id="modify-ledger", workflow_id="offline")
+    tracker = WorkflowPositionTracker(
+        str(tmp_path / f"{product}.sqlite"), ctx.job_id, "broker", product=product
+    )
+    ctx._workflow_position_tracker = tracker
+    ctx._workflow_risk_tracker = MagicMock()
+    return ctx, tracker
+
+
+def _ledger_row(tracker, order_no):
+    with sqlite3.connect(tracker.db_path) as conn:
+        return conn.execute(
+            "SELECT order_no, order_date, symbol, exchange, side, quantity, price, node_id "
+            "FROM workflow_orders WHERE order_no = ?",
+            (order_no,),
+        ).fetchone()
+
+
+def _ledger_count(tracker):
+    with sqlite3.connect(tracker.db_path) as conn:
+        return conn.execute("SELECT COUNT(*) FROM workflow_orders").fetchone()[0]
+
+
+def _response(order_no_field, value, *, error_msg=None, rsp_msg="정상처리"):
+    resp = MagicMock()
+    resp.error_msg = error_msg
+    resp.rsp_msg = rsp_msg
+    if value is None:
+        resp.block2 = None
+    else:
+        block2 = MagicMock()
+        setattr(block2, order_no_field, value)
+        resp.block2 = block2
+    return resp
+
+
+def _ls_overseas_stock(response):
+    api = MagicMock()
+    api.req_async = AsyncMock(return_value=response)
+    order = MagicMock()
+    order.cosat00311 = MagicMock(return_value=api)
+    stock = MagicMock()
+    stock.주문 = MagicMock(return_value=order)
+    ls = MagicMock()
+    ls.overseas_stock = MagicMock(return_value=stock)
+    return ls
+
+
+def _ls_overseas_futures(response):
+    api = MagicMock()
+    api.req_async = AsyncMock(return_value=response)
+    order = MagicMock()
+    order.CIDBT00900 = MagicMock(return_value=api)
+    futs = MagicMock()
+    futs.order = MagicMock(return_value=order)
+    ls = MagicMock()
+    ls.overseas_futureoption = MagicMock(return_value=futs)
+    return ls
+
+
+def _ls_korea_stock(response):
+    api = MagicMock()
+    api.req_async = AsyncMock(return_value=response)
+    order = MagicMock()
+    order.cspat00701 = MagicMock(return_value=api)
+    stock = MagicMock()
+    stock.order = MagicMock(return_value=order)
+    ls = MagicMock()
+    ls.korea_stock = MagicMock(return_value=stock)
+    return ls
+
+
+# ---------------------------------------------------------------------------
+# 해외주식
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_overseas_stock_modify_inherits_original_side(tmp_path):
+    """매도 주문을 정정해도 원장 행은 'sell' 이어야 한다(유령 롱 HWM 금지)."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "AAPL", "NASDAQ", "sell", 7, 149.0,
+                         ctx.job_id, "order-node")
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=_ls_overseas_stock(_response("OrdNo", "67890")),
+        original_order_id="12345",
+        symbol="AAPL",
+        exchange="NASDAQ",
+        new_quantity=10,
+        new_price=150.0,
+        side="buy",                    # 호출부 기본값 — 사실이 아니다
+        config={"side": "buy"},
+        context=ctx,
+        node_id="modify-node",
+    )
+
+    assert result["modify_result"]["success"] is True
+    row = _ledger_row(tracker, "67890")
+    assert row is not None, "정정 새 주문번호가 원장에 기록되어야 한다"
+    assert row[4] == "sell", "side 는 config 가 아니라 원 주문에서 승계해야 한다"
+    assert (row[1], row[2], row[3]) == (TODAY, "AAPL", "NASDAQ")
+    assert (row[5], row[6]) == (10, 150.0)
+    assert row[7] == "modify-node"
+    assert _ledger_count(tracker) == 2, "원 주문 행은 남긴다(잔여 체결이 늦게 올 수 있다)"
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_modify_does_not_touch_risk_tracker(tmp_path):
+    """정정은 새 포지션이 아니다 — HWM 등록/해제 어느 쪽도 일으키지 않는다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "AAPL", "NASDAQ", "buy", 7, 149.0,
+                         ctx.job_id, "order-node")
+
+    await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=_ls_overseas_stock(_response("OrdNo", "67890")),
+        original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=10, new_price=150.0, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    assert _ledger_row(tracker, "67890") is not None
+    ctx._workflow_risk_tracker.register_symbol.assert_not_called()
+    ctx._workflow_risk_tracker.unregister_symbol.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_quantity_only_modify_inherits_price(tmp_path):
+    """수량만 정정하면 가격은 원 주문 값을 승계한다(0.0 으로 덮지 않는다)."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "AAPL", "NASDAQ", "buy", 7, 149.0,
+                         ctx.job_id, "order-node")
+
+    await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=_ls_overseas_stock(_response("OrdNo", "67890")),
+        original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=3, new_price=None, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    row = _ledger_row(tracker, "67890")
+    assert (row[5], row[6]) == (3, 149.0)
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_price_only_modify_inherits_quantity(tmp_path):
+    """가격만 정정하면 수량은 원 주문 값을 승계한다(0 으로 덮지 않는다)."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "AAPL", "NASDAQ", "buy", 7, 149.0,
+                         ctx.job_id, "order-node")
+
+    await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=_ls_overseas_stock(_response("OrdNo", "67890")),
+        original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=None, new_price=151.5, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    row = _ledger_row(tracker, "67890")
+    assert (row[5], row[6]) == (7, 151.5)
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_modify_without_original_records_nothing(tmp_path):
+    """원 주문을 원장에서 못 찾으면 기록하지 않는다(방향 추측 금지)."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=_ls_overseas_stock(_response("OrdNo", "67890")),
+        original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=10, new_price=150.0, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    assert result["modify_result"]["success"] is True, "원장 기록 실패가 ACK 를 뒤집으면 안 된다"
+    assert _ledger_count(tracker) == 0
+    ctx._workflow_risk_tracker.register_symbol.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_empty_order_no_records_nothing(tmp_path):
+    """빈 주문번호(거래시간 외 silent no-op)는 원장에 남기지 않는다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "AAPL", "NASDAQ", "buy", 7, 149.0,
+                         ctx.job_id, "order-node")
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=_ls_overseas_stock(_response("OrdNo", "")),
+        original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=10, new_price=150.0, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert _ledger_count(tracker) == 1, "원 주문 행만 남아야 한다"
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_error_response_records_nothing(tmp_path):
+    """브로커 에러 응답은 원장에 남기지 않는다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "AAPL", "NASDAQ", "buy", 7, 149.0,
+                         ctx.job_id, "order-node")
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=_ls_overseas_stock(_response("OrdNo", "67890", error_msg="거래시간 외")),
+        original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=10, new_price=150.0, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert _ledger_count(tracker) == 1
+
+
+# ---------------------------------------------------------------------------
+# 해외선물
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_overseas_futures_modify_inherits_original_side(tmp_path):
+    ctx, tracker = _make_context(tmp_path, "overseas_futures")
+    tracker.record_order("98765", TODAY, "HMHM26", "HKEX", "sell", 1, 20000.0,
+                         ctx.job_id, "order-node")
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=_ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242")),
+        original_order_id="98765",
+        symbol="HMHM26",
+        exchange="HKEX",
+        new_quantity=2,
+        new_price=20100.0,
+        side="buy",                    # 호출부 기본값 — 사실이 아니다
+        config={"expiry_month": "202606", "exchange_code": "HKEX"},
+        context=ctx,
+        node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is True
+    row = _ledger_row(tracker, "F-4242")
+    assert row is not None
+    assert row[4] == "sell"
+    assert (row[2], row[3]) == ("HMHM26", "HKEX")
+    assert (row[5], row[6]) == (2, 20100.0)
+    ctx._workflow_risk_tracker.register_symbol.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_overseas_futures_modify_without_original_is_refused(tmp_path):
+    """원 주문을 못 찾으면 방향을 추측하지 않고 **요청 자체를 거른다**.
+
+    CIDBT00900 은 BnsTpCode 를 필수로 받는다(blocks.py:88-93). 호출부가 넘기는
+    side 는 존재하지 않는 config 키에서 온 값이라(노드 스키마에 side 없음)
+    쓸 수 없다 — 그래서 브로커에 아무것도 보내지 않는다.
+    """
+    ctx, tracker = _make_context(tmp_path, "overseas_futures")
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls,
+        original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="sell",
+        config={"expiry_month": "202606", "exchange_code": "HKEX"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert "direction" in result["modify_result"]["error"]
+    assert result["modified_order_id"] == ""
+    ls.overseas_futureoption().order().CIDBT00900.assert_not_called()
+    assert _ledger_count(tracker) == 0
+
+
+@pytest.mark.asyncio
+async def test_overseas_futures_empty_order_no_records_nothing(tmp_path):
+    ctx, tracker = _make_context(tmp_path, "overseas_futures")
+    tracker.record_order("98765", TODAY, "HMHM26", "HKEX", "sell", 1, 20000.0,
+                         ctx.job_id, "order-node")
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=_ls_overseas_futures(_response("OvrsFutsOrdNo", "")),
+        original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="sell",
+        config={"expiry_month": "202606", "exchange_code": "HKEX"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert _ledger_count(tracker) == 1
+
+
+# ---------------------------------------------------------------------------
+# 국내주식
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_korea_stock_modify_inherits_original_side(tmp_path):
+    """국내 경로는 config.get("side", "buy") 를 쓰고 있었다 — 그 값을 쓰면 안 된다."""
+    ctx, tracker = _make_context(tmp_path, "korea_stock")
+    tracker.record_order("55555", TODAY, "005930", "KRX", "sell", 5, 70000.0,
+                         ctx.job_id, "order-node")
+
+    result = await ModifyOrderNodeExecutor()._modify_korea_stock(
+        ls=_ls_korea_stock(_response("OrdNo", "77777")),
+        original_order_id="55555",
+        symbol="005930",
+        new_quantity=3,
+        new_price=71000.0,
+        config={},                     # side 키 자체가 없다 → 종전엔 "buy"
+        context=ctx,
+        node_id="modify-kr",
+    )
+
+    assert result["modify_result"]["success"] is True
+    row = _ledger_row(tracker, "77777")
+    assert row is not None
+    assert row[4] == "sell"
+    assert (row[2], row[3]) == ("005930", "KRX")
+    assert (row[5], row[6]) == (3, 71000.0)
+    ctx._workflow_risk_tracker.register_symbol.assert_not_called()
+    ctx._workflow_risk_tracker.unregister_symbol.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_korea_stock_modify_without_original_records_nothing(tmp_path):
+    ctx, tracker = _make_context(tmp_path, "korea_stock")
+
+    result = await ModifyOrderNodeExecutor()._modify_korea_stock(
+        ls=_ls_korea_stock(_response("OrdNo", "77777")),
+        original_order_id="55555", symbol="005930",
+        new_quantity=3, new_price=71000.0, config={},
+        context=ctx, node_id="modify-kr",
+    )
+
+    assert result["modify_result"]["success"] is True
+    assert _ledger_count(tracker) == 0
+
+
+@pytest.mark.asyncio
+async def test_korea_stock_empty_order_no_records_nothing(tmp_path):
+    ctx, tracker = _make_context(tmp_path, "korea_stock")
+    tracker.record_order("55555", TODAY, "005930", "KRX", "buy", 5, 70000.0,
+                         ctx.job_id, "order-node")
+
+    result = await ModifyOrderNodeExecutor()._modify_korea_stock(
+        ls=_ls_korea_stock(_response("OrdNo", "")),
+        original_order_id="55555", symbol="005930",
+        new_quantity=3, new_price=71000.0, config={},
+        context=ctx, node_id="modify-kr",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert _ledger_count(tracker) == 1
+
+
+# ---------------------------------------------------------------------------
+# 원 주문 조회 헬퍼 (context.find_workflow_order)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_find_workflow_order_matches_zero_padded_order_no(tmp_path):
+    """ACK 의 '0000123' 과 정정 요청의 '123' 은 같은 주문이다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("0000123", TODAY, "AAPL", "NASDAQ", "sell", 7, 149.0,
+                         ctx.job_id, "order-node")
+
+    found = ctx.find_workflow_order("123", TODAY)
+    assert found is not None and found["side"] == "sell"
+
+
+@pytest.mark.asyncio
+async def test_find_workflow_order_rejects_ambiguous_date_mismatch(tmp_path):
+    """날짜가 다른 동일 주문번호가 둘 이상이면 모호하므로 None 이다.
+
+    브로커 주문번호는 **날짜 안에서만** 유일하다 — 아무거나 집으면 어제 다른
+    주문의 방향을 승계하게 된다.
+    """
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("777", "20260901", "AAPL", "NASDAQ", "buy", 1, 100.0,
+                         ctx.job_id, "order-node")
+    tracker.record_order("777", "20260902", "TSLA", "NASDAQ", "sell", 2, 200.0,
+                         ctx.job_id, "order-node")
+
+    assert ctx.find_workflow_order("777", TODAY) is None
+
+
+@pytest.mark.asyncio
+async def test_find_workflow_order_without_tracker_returns_none(tmp_path):
+    ctx = ExecutionContext(job_id="no-tracker", workflow_id="offline")
+    assert ctx.find_workflow_order("123", TODAY) is None
+
+
+# ---------------------------------------------------------------------------
+# 자정 관통 정정 — D±1 창 + 종목으로 가른다
+#
+# 종전에는 날짜가 어긋나면 **전 기간**을 훑어 후보가 정확히 1건일 때만
+# 수용했다. 그런데 브로커 주문번호는 **영업일마다 리셋**되고(근거:
+# database/workflow_position_tracker.py 모듈 독스트링 — 창 가드 수용조건 ④)
+# 워크플로우 DB 는 며칠~몇 주 누적되므로, 과거 날짜에 같은 번호가 하나만 더
+# 있으면 후보 2건 → None → side 미해결 → 브로커 호출 0회 거부가 됐다.
+# 이제 트래커와 같은 D±1 창만 보고, 후보가 여러 건이면 종목으로 가른다.
+# ---------------------------------------------------------------------------
+
+YESTERDAY = (datetime.now() - timedelta(days=1)).strftime("%Y%m%d")
+TOMORROW = (datetime.now() + timedelta(days=1)).strftime("%Y%m%d")
+
+
+@pytest.mark.asyncio
+async def test_find_workflow_order_prefers_todays_row_over_an_older_same_number(tmp_path):
+    """(1)(3) 오늘 행이 있으면 과거 동명 번호가 있어도 그대로 찾는다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("42", "20260101", "TSLA", "NASDAQ", "sell", 9, 300.0,
+                         ctx.job_id, "order-node")
+    tracker.record_order("42", TODAY, "AAPL", "NASDAQ", "buy", 3, 150.0,
+                         ctx.job_id, "order-node")
+
+    found = ctx.find_workflow_order("42", TODAY, symbol="AAPL")
+    assert found is not None
+    assert (found["order_date"], found["symbol"], found["side"]) == (TODAY, "AAPL", "buy")
+
+
+@pytest.mark.parametrize("recorded_date", ["yesterday", "tomorrow"])
+@pytest.mark.asyncio
+async def test_find_workflow_order_accepts_the_d_plus_minus_one_window(tmp_path, recorded_date):
+    """(2) 어제/내일 행 + 같은 종목이면 찾는다(자정 관통)."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    date = YESTERDAY if recorded_date == "yesterday" else TOMORROW
+    tracker.record_order("42", date, "AAPL", "NASDAQ", "sell", 7, 149.0,
+                         ctx.job_id, "order-node")
+
+    found = ctx.find_workflow_order("42", TODAY, symbol="AAPL")
+    assert found is not None
+    assert (found["order_date"], found["side"]) == (date, "sell")
+
+
+@pytest.mark.asyncio
+async def test_find_workflow_order_window_ignores_rows_outside_d_plus_minus_one(tmp_path):
+    """(3) 과거에 같은 주문번호가 있어도 창 후보를 정확히 고른다.
+
+    종전 전 기간 폴백이었다면 후보 2건 → None 이다.
+    """
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("42", "20260101", "AAPL", "NASDAQ", "buy", 1, 10.0,
+                         ctx.job_id, "order-node")
+    tracker.record_order("42", YESTERDAY, "AAPL", "NASDAQ", "sell", 7, 149.0,
+                         ctx.job_id, "order-node")
+
+    found = ctx.find_workflow_order("42", TODAY, symbol="AAPL")
+    assert found is not None
+    assert (found["order_date"], found["side"]) == (YESTERDAY, "sell")
+
+
+@pytest.mark.asyncio
+async def test_find_workflow_order_window_rejects_a_symbol_mismatch(tmp_path):
+    """(3) 창 후보의 종목이 다르면 남의 주문번호 재발급이다 — 쓰지 않는다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("42", YESTERDAY, "TSLA", "NASDAQ", "sell", 7, 300.0,
+                         ctx.job_id, "order-node")
+
+    assert ctx.find_workflow_order("42", TODAY, symbol="AAPL") is None
+
+
+@pytest.mark.asyncio
+async def test_find_workflow_order_rejects_two_window_rows_with_the_same_symbol(tmp_path):
+    """(4) 종목까지 같은 창 후보가 둘 이상이면 모호하므로 None."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("42", YESTERDAY, "AAPL", "NASDAQ", "buy", 1, 100.0,
+                         ctx.job_id, "order-node")
+    tracker.record_order("42", TOMORROW, "AAPL", "NASDAQ", "sell", 2, 200.0,
+                         ctx.job_id, "order-node")
+
+    assert ctx.find_workflow_order("42", TODAY, symbol="AAPL") is None
+
+
+@pytest.mark.asyncio
+async def test_futures_modify_across_midnight_reaches_the_broker(tmp_path):
+    """(2) 자정 관통 정정이 이제 브로커까지 간다 — 방향은 원장 승계."""
+    ctx, tracker = _make_context(tmp_path, "overseas_futures")
+    tracker.record_order("98765", YESTERDAY, "HMHM26", "HKEX", "sell", 1, 20000.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="buy",   # 호출부 기본값 — 사실이 아니다
+        config={"expiry_month": "202606", "exchange_code": "HKEX"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is True
+    assert _futures_wire(ls).BnsTpCode == "1", "매도 주문 정정은 매도로 나가야 한다"
+    assert _ledger_row(tracker, "F-4242")[4] == "sell"
+
+
+@pytest.mark.asyncio
+async def test_futures_modify_refuses_when_the_window_is_ambiguous(tmp_path):
+    """(5) 방향을 못 찾으면 종전대로 브로커에 아무것도 보내지 않는다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_futures")
+    tracker.record_order("98765", YESTERDAY, "HMHM26", "HKEX", "sell", 1, 20000.0,
+                         ctx.job_id, "order-node")
+    tracker.record_order("98765", TOMORROW, "HMHM26", "HKEX", "buy", 1, 20500.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="buy",
+        config={"expiry_month": "202606", "exchange_code": "HKEX"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is False
+    ls.overseas_futureoption().order().CIDBT00900.assert_not_called()
+    assert _ledger_count(tracker) == 2, "원 주문 두 행만 남아야 한다"
+
+
+# ---------------------------------------------------------------------------
+# 브로커 요청(와이어) — 원장과 갈리지 않는다
+# ---------------------------------------------------------------------------
+
+def _stock_wire(ls):
+    """cosat00311 에 실제로 넘어간 COSAT00311InBlock1."""
+    return ls.overseas_stock().주문().cosat00311.call_args.args[0]
+
+
+def _futures_wire(ls):
+    """CIDBT00900 에 실제로 넘어간 CIDBT00900InBlock1."""
+    return ls.overseas_futureoption().order().CIDBT00900.call_args.args[0]
+
+
+def _korea_wire(ls):
+    """cspat00701 에 실제로 넘어간 CSPAT00701InBlock1."""
+    return ls.korea_stock().order().cspat00701.call_args.kwargs["body"]
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_quantity_only_modify_sends_original_price_on_the_wire(tmp_path):
+    """수량만 정정하면 **브로커에도** 원 가격이 나간다(0.0 아님).
+
+    COSAT00311 의 OvrsOrdPrc 는 "Revised order price"(blocks.py:85-92)이고
+    SDK 예제도 실제 값을 싣는다(example/overseas_stock/run_COSAT00311.py:36-37).
+    어디에도 '0 = 변경 없음' 규약이 없다. 종전 `new_price or 0.0` 은 브로커에
+    가격 0 을 보내면서 원장에는 149.0 을 적는 **불일치**였다.
+    """
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "AAPL", "NASDAQ", "buy", 7, 149.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_stock(_response("OrdNo", "67890"))
+
+    await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=ls, original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=3, new_price=None, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    wire = _stock_wire(ls)
+    assert (wire.OrdQty, wire.OvrsOrdPrc) == (3, 149.0)
+    row = _ledger_row(tracker, "67890")
+    assert (row[5], row[6]) == (wire.OrdQty, wire.OvrsOrdPrc), "원장과 와이어가 같아야 한다"
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_price_only_modify_sends_original_quantity_on_the_wire(tmp_path):
+    """가격만 정정하면 브로커에도 원 수량이 나간다(0 아님)."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "AAPL", "NASDAQ", "buy", 7, 149.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_stock(_response("OrdNo", "67890"))
+
+    await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=ls, original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=None, new_price=151.5, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    wire = _stock_wire(ls)
+    assert (wire.OrdQty, wire.OvrsOrdPrc) == (7, 151.5)
+    row = _ledger_row(tracker, "67890")
+    assert (row[5], row[6]) == (wire.OrdQty, wire.OvrsOrdPrc)
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_modify_without_original_and_partial_fields_is_refused(tmp_path):
+    """승계할 원 주문도 없고 안 바꾼 필드도 있으면 **보내지 않는다**.
+
+    0 은 어느 정정 TR 에서도 '변경 없음' 이 아니다 — 보내면 가격 0 짜리
+    지정가 정정이 된다.
+    """
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    ls = _ls_overseas_stock(_response("OrdNo", "67890"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=ls, original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=3, new_price=None, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    assert result["modify_result"]["success"] is False
+    ls.overseas_stock().주문().cosat00311.assert_not_called()
+    assert _ledger_count(tracker) == 0
+
+
+@pytest.mark.asyncio
+async def test_overseas_futures_wire_uses_ledger_side_not_config(tmp_path):
+    """BnsTpCode 는 원 주문 원장 행의 방향이다 — config 의 "buy" 가 아니다.
+
+    CIDBT00900 blocks.py:88-93 — "'1' = sell (매도), '2' = buy (매수)".
+    매도 선물 주문을 정정하는데 종전 코드는 언제나 '2'(매수)를 보냈다
+    (호출부의 `config.get("side", "buy")` 가 노드 스키마에 없는 키라서).
+    ⚠️ LS 가 불일치 BnsTpCode 를 어떻게 처리하는지는 미관측이다.
+    """
+    ctx, tracker = _make_context(tmp_path, "overseas_futures")
+    tracker.record_order("98765", TODAY, "HMHM26", "HKEX", "sell", 1, 20000.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=None, new_price=20100.0,
+        side="buy",                    # 호출부 기본값 — 사실이 아니다
+        config={"expiry_month": "202606", "exchange_code": "HKEX"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    wire = _futures_wire(ls)
+    assert wire.BnsTpCode == "1", "매도 주문 정정은 매도로 나가야 한다"
+    assert (wire.OrdQty, wire.OvrsDrvtOrdPrc) == (1, 20100.0), "안 바꾼 수량은 승계"
+    row = _ledger_row(tracker, "F-4242")
+    assert (row[4], row[5], row[6]) == ("sell", wire.OrdQty, wire.OvrsDrvtOrdPrc)
+
+
+@pytest.mark.asyncio
+async def test_overseas_futures_buy_order_still_sends_buy(tmp_path):
+    """반대 방향도 승계한다(가드가 '항상 매도' 로 뒤집히지 않았다)."""
+    ctx, tracker = _make_context(tmp_path, "overseas_futures")
+    tracker.record_order("98765", TODAY, "HMHM26", "HKEX", "buy", 1, 20000.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="sell", config={},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert _futures_wire(ls).BnsTpCode == "2"
+
+
+@pytest.mark.asyncio
+async def test_korea_stock_quantity_only_modify_sends_original_price_on_the_wire(tmp_path):
+    """국내도 마찬가지 — 특히 OrdPrc 0 은 '변경 없음' 이 아니라 **시장가용 값**이다.
+
+    CSPAT00701 blocks.py:100-107 — "Use 0 for market orders ('03') and other
+    non-limit price types". 지정가('00')로 0 을 보내면 가격 0 이다.
+    """
+    ctx, tracker = _make_context(tmp_path, "korea_stock")
+    tracker.record_order("55555", TODAY, "005930", "KRX", "sell", 5, 70000.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_korea_stock(_response("OrdNo", "77777"))
+
+    await ModifyOrderNodeExecutor()._modify_korea_stock(
+        ls=ls, original_order_id="55555", symbol="005930",
+        new_quantity=3, new_price=None, config={},
+        context=ctx, node_id="modify-kr",
+    )
+
+    wire = _korea_wire(ls)
+    assert (wire.OrdQty, wire.OrdPrc) == (3, 70000.0)
+    assert wire.OrdprcPtnCode == "00", "지정가로 보내면서 가격 0 을 실으면 안 된다"
+    row = _ledger_row(tracker, "77777")
+    assert (row[5], row[6]) == (wire.OrdQty, wire.OrdPrc)
+
+
+@pytest.mark.asyncio
+async def test_korea_stock_modify_without_original_and_partial_fields_is_refused(tmp_path):
+    ctx, tracker = _make_context(tmp_path, "korea_stock")
+    ls = _ls_korea_stock(_response("OrdNo", "77777"))
+
+    result = await ModifyOrderNodeExecutor()._modify_korea_stock(
+        ls=ls, original_order_id="55555", symbol="005930",
+        new_quantity=None, new_price=71000.0, config={},
+        context=ctx, node_id="modify-kr",
+    )
+
+    assert result["modify_result"]["success"] is False
+    ls.korea_stock().order().cspat00701.assert_not_called()
+    assert _ledger_count(tracker) == 0
+
+
+@pytest.mark.asyncio
+async def test_find_workflow_order_returns_none_for_a_tracker_without_scope(tmp_path):
+    """독스트링의 계약 — 조회 실패는 **None** 이지 예외가 아니다.
+
+    scope 계산(`tracker.product/provider/trading_mode`)과 `tracker.db_path` 독출이
+    try 바깥에 있으면, 그 속성이 없는 트래커를 물었을 때 AttributeError 가
+    호출자(정정 경로)로 올라가 정정 자체를 죽인다.
+    """
+    ctx = ExecutionContext(job_id="bad-tracker", workflow_id="offline")
+
+    class TrackerWithoutScope:
+        pass
+
+    ctx._workflow_position_tracker = TrackerWithoutScope()
+    assert ctx.find_workflow_order("123", TODAY) is None
+
+
+# ---------------------------------------------------------------------------
+# Y1 — '원장에 행이 없다' 와 '원장 자체가 없다' 는 다른 실패다
+#
+# 트래커는 워크플로우에 PnL 리스너가 하나라도 있을 때만 만들어진다
+# (context.init_workflow_position_tracker 의
+#  `any(hasattr(l, 'on_workflow_pnl_update') ...)` 게이트, 또는 init 예외 시 None).
+# 리스너 0개로 엔진을 라이브러리처럼 직접 구동하면 record_workflow_order 가 no-op 이라
+# 원장에 행이 생길 수 없고 find_workflow_order 는 영원히 None 이다 — 방향을 원장에서만
+# 찾으면 해외선물 정정이 그 구성에서 **전면 불능**이 된다(매수든 매도든).
+# 그래서 (1) 사유를 갈라 말하고, (2) 호출자가 side 를 실제로 준 경우엔 그 값을 쓴다.
+# 추측('항상 buy')으로 되돌리지는 않는다 — 매도 주문에 매수 구분을 보내는 건 실계좌
+# 위험이고(불일치 BnsTpCode 처리는 **미관측**), 실패를 명확히 알리는 편이 낫다.
+# ---------------------------------------------------------------------------
+
+def _context_without_ledger():
+    """PnL 리스너 0개 구성 — 트래커가 아예 없다."""
+    ctx = ExecutionContext(job_id="no-ledger", workflow_id="offline")
+    ctx._workflow_risk_tracker = MagicMock()
+    assert ctx.has_workflow_order_ledger() is False
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_futures_modify_without_a_ledger_reports_ledger_unavailable(tmp_path):
+    """(a) 트래커 None + side 미제공 → ledger_unavailable 사유, 브로커 호출 0회."""
+    ctx = _context_without_ledger()
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="buy",   # 호출부 기본값 — 사실이 아니다
+        config={"expiry_month": "202606", "exchange_code": "HKEX"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is False
+    error = result["modify_result"]["error"]
+    assert error.startswith("ledger_unavailable:"), error
+    assert "original_order_not_found" not in error, "원장 미조회와 원장 부재를 갈라야 한다"
+    assert "no workflow order ledger" in error
+    ls.overseas_futureoption().order().CIDBT00900.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_futures_modify_with_a_ledger_but_no_row_reports_order_not_found(tmp_path):
+    """대조군 — 원장은 있는데 그 주문 행이 없으면 사유가 다르다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_futures")
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="buy",
+        config={"expiry_month": "202606", "exchange_code": "HKEX"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert result["modify_result"]["error"].startswith("original_order_not_found:")
+    ls.overseas_futureoption().order().CIDBT00900.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_futures_modify_without_a_ledger_uses_an_explicit_config_side(tmp_path):
+    """(b) 트래커 None + side='sell' 명시 → BnsTpCode='1' 로 브로커에 도달한다.
+
+    이건 추측이 아니라 **호출자가 알려준 값**이다(노드 스키마엔 side 가 없지만
+    라이브러리 직접 호출자는 config 에 넣을 수 있다).
+    """
+    ctx = _context_without_ledger()
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="buy",
+        config={"expiry_month": "202606", "exchange_code": "HKEX", "side": "sell"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is True
+    wire = _futures_wire(ls)
+    assert wire.BnsTpCode == "1", "호출자가 sell 이라고 했으면 매도로 나가야 한다"
+    assert (wire.OrdQty, wire.OvrsDrvtOrdPrc) == (2, 20100.0)
+
+
+@pytest.mark.asyncio
+async def test_futures_modify_without_a_ledger_logs_the_caller_supplied_side(tmp_path, caplog):
+    """명시 side 를 쓴 사실은 로그에 남는다(운영자가 근거를 볼 수 있어야 한다)."""
+    ctx = _context_without_ledger()
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    with caplog.at_level(logging.WARNING, logger="programgarden.executor"):
+        await ModifyOrderNodeExecutor()._modify_overseas_futures(
+            ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+            new_quantity=2, new_price=20100.0, side="buy",
+            config={"exchange_code": "HKEX", "side": "sell"},
+            context=ctx, node_id="modify-fut",
+        )
+
+    messages = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("caller-supplied side" in m and "'sell'" in m for m in messages), messages
+
+
+@pytest.mark.asyncio
+async def test_futures_modify_still_refuses_an_unusable_explicit_side(tmp_path):
+    """side 값이 buy/sell 이 아니면 '안 준 것' 과 같다 — 거부한다."""
+    ctx = _context_without_ledger()
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="buy",
+        config={"exchange_code": "HKEX", "side": "long"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert result["modify_result"]["error"].startswith("ledger_unavailable:")
+    ls.overseas_futureoption().order().CIDBT00900.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_futures_modify_without_a_ledger_still_needs_the_unchanged_fields(tmp_path):
+    """명시 side 가 있어도 승계할 수량/가격이 없으면 보내지 않는다(0 은 '변경 없음' 이 아니다)."""
+    ctx = _context_without_ledger()
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=None, new_price=20100.0, side="buy",
+        config={"exchange_code": "HKEX", "side": "sell"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert result["modify_result"]["error"].startswith("unchanged_field_unresolved:")
+    assert "no order ledger at all" in result["modify_result"]["error"]
+    ls.overseas_futureoption().order().CIDBT00900.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_futures_modify_with_a_ledger_row_ignores_a_conflicting_config_side(tmp_path):
+    """(c) 트래커 있음 + 원장에 행 있음 → 4차 동작 그대로(원장이 이긴다)."""
+    ctx, tracker = _make_context(tmp_path, "overseas_futures")
+    tracker.record_order("98765", TODAY, "HMHM26", "HKEX", "sell", 1, 20000.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_futures(_response("OvrsFutsOrdNo", "F-4242"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_futures(
+        ls=ls, original_order_id="98765", symbol="HMHM26", exchange="HKEX",
+        new_quantity=2, new_price=20100.0, side="buy",
+        # 호출자가 buy 라고 우겨도 원장 행(sell)이 이긴다 — 원장은 우리가 실제로
+        # 브로커에 보낸 값의 기록이다.
+        config={"exchange_code": "HKEX", "side": "buy"},
+        context=ctx, node_id="modify-fut",
+    )
+
+    assert result["modify_result"]["success"] is True
+    assert _futures_wire(ls).BnsTpCode == "1"
+    assert _ledger_row(tracker, "F-4242")[4] == "sell"
+
+
+@pytest.mark.asyncio
+async def test_overseas_stock_modify_without_a_ledger_records_the_explicit_side(tmp_path):
+    """방향이 필요 없는 경로(COSAT00311)도 명시 side 가 있으면 그걸 쓴다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    ls = _ls_overseas_stock(_response("OrdNo", "67890"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=ls, original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=10, new_price=150.0, side="buy",
+        config={"side": "sell"},
+        context=ctx, node_id="modify-node",
+    )
+
+    assert result["modify_result"]["success"] is True
+    row = _ledger_row(tracker, "67890")
+    assert row is not None and row[4] == "sell"
+
+
+# ---------------------------------------------------------------------------
+# Y3 — 소수 수량은 자르지 않고 **거부**한다
+#
+# 세 정정 TR 의 수량 필드는 모두 정수다(COSAT00311 blocks.py:79 / CIDBT00900
+# blocks.py:130 / CSPAT00701 blocks.py:74 — 전부 `OrdQty: int`). 그런데 LS 해외주식은
+# 소수점 거래가 실재한다(prod 2026-08-24 IBM 0.847972주 실측). `int(quantity)` 로
+# 싣던 종전 코드는 브로커엔 OrdQty=0 을 보내고 원장엔 0.847972 를 남겨, 이 구조가
+# 지키려던 '와이어=원장' 불변식을 스스로 깼다.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_modify_refuses_a_fractional_inherited_quantity(tmp_path):
+    """가격만 정정 + 원 주문이 소수 수량 → 보내지 않는다(OrdQty=0 방지)."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "IBM", "NYSE", "buy", 0.847972, 149.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_stock(_response("OrdNo", "67890"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=ls, original_order_id="12345", symbol="IBM", exchange="NYSE",
+        new_quantity=None, new_price=151.5, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    assert result["modify_result"]["success"] is False
+    error = result["modify_result"]["error"]
+    assert error.startswith("non_integer_quantity:"), error
+    assert "0.847972" in error
+    ls.overseas_stock().주문().cosat00311.assert_not_called()
+    assert _ledger_count(tracker) == 1, "원 주문 행만 남는다"
+
+
+@pytest.mark.asyncio
+async def test_modify_refuses_a_fractional_new_quantity(tmp_path):
+    """호출자가 소수 수량을 직접 줘도 마찬가지다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "IBM", "NYSE", "buy", 3, 149.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_stock(_response("OrdNo", "67890"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=ls, original_order_id="12345", symbol="IBM", exchange="NYSE",
+        new_quantity=0.5, new_price=151.5, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert result["modify_result"]["error"].startswith("non_integer_quantity:")
+    ls.overseas_stock().주문().cosat00311.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_modify_refuses_a_zero_quantity(tmp_path):
+    """정수 0 도 막는다 — 절단 버그와 결과(OrdQty=0)가 같다."""
+    ctx, tracker = _make_context(tmp_path, "korea_stock")
+    tracker.record_order("55555", TODAY, "005930", "KRX", "buy", 5, 70000.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_korea_stock(_response("OrdNo", "77777"))
+
+    result = await ModifyOrderNodeExecutor()._modify_korea_stock(
+        ls=ls, original_order_id="55555", symbol="005930",
+        new_quantity=0, new_price=71000.0, config={},
+        context=ctx, node_id="modify-kr",
+    )
+
+    assert result["modify_result"]["success"] is False
+    assert result["modify_result"]["error"].startswith("non_positive_quantity:")
+    ls.korea_stock().order().cspat00701.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_modify_accepts_an_integral_float_quantity(tmp_path):
+    """정수값 float(7.0)은 정상 — 와이어에는 int 7 이 실린다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "AAPL", "NASDAQ", "buy", 7.0, 149.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_stock(_response("OrdNo", "67890"))
+
+    await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=ls, original_order_id="12345", symbol="AAPL", exchange="NASDAQ",
+        new_quantity=None, new_price=151.5, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    wire = _stock_wire(ls)
+    assert wire.OrdQty == 7 and isinstance(wire.OrdQty, int)
+    row = _ledger_row(tracker, "67890")
+    assert (row[5], row[6]) == (wire.OrdQty, wire.OvrsOrdPrc), "원장과 와이어가 같아야 한다"
+
+
+# ---------------------------------------------------------------------------
+# 승계 가격 게이트 — 시장가로 낸 주문의 원장 price 0.0 을 정정에 다시 싣지 않는다
+#
+# 원장 price 는 '브로커에 실제로 보낸 값' 이다. 국내주식 시장가 신규주문은
+# `ord_prc = 0.0 if ordprc_ptn_code == "03"` 을 그대로 기록하고(해외주식 매도
+# 시장가도 `price = 0.0`), 체결 전(= 정정 가능한 상태)에는
+# update_workflow_order_fill_price 가 아직 실체결가를 채우지 않았다. 그 0.0 을
+# 수량만 정정할 때 승계해 지정가('00')로 보내면 '변경 없음' 이 아니라 **가격 0
+# 주문**이다(CSPAT00701 blocks.py:100-107 — 0 은 시장가용 값). non_positive_quantity
+# 게이트와 같은 모양의 구멍이 가격 축에 있었다.
+#
+# 게이트는 **승계값에만** 건다 — 호출자가 new_price=0 을 명시하면 막지 않는다
+# (그 조합의 유효성은 우리가 판정하지 않는다).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "ledger_price",
+    [
+        0.0,   # 시장가 신규주문이 원장에 남기는 값(실제 관측되는 형태)
+        -1.0,  # 게이트 조건(<= 0)의 경계 확인용 — 원장에서 관측된 값은 아니다
+    ],
+)
+async def test_modify_refuses_to_inherit_a_non_positive_price(tmp_path, ledger_price):
+    """(a) 원장 price 0.0(시장가) + new_quantity 만 → 거부 + 브로커 호출 0회."""
+    ctx, tracker = _make_context(tmp_path, "korea_stock")
+    tracker.record_order("55555", TODAY, "005930", "KRX", "buy", 5, ledger_price,
+                         ctx.job_id, "order-node")
+    ls = _ls_korea_stock(_response("OrdNo", "77777"))
+
+    result = await ModifyOrderNodeExecutor()._modify_korea_stock(
+        ls=ls, original_order_id="55555", symbol="005930",
+        new_quantity=3, new_price=None, config={},
+        context=ctx, node_id="modify-kr",
+    )
+
+    assert result["modify_result"]["success"] is False
+    error = result["modify_result"]["error"]
+    assert error.startswith("non_positive_inherited_price:"), error
+    assert "시장가로 낸 주문은 가격을 승계할 수 없다" in error
+    assert "new_price 를 명시하라" in error
+    ls.korea_stock().order().cspat00701.assert_not_called()
+    assert _ledger_count(tracker) == 1, "원 주문 행만 남는다(정정 행 없음)"
+
+
+@pytest.mark.asyncio
+async def test_modify_of_a_market_order_passes_with_an_explicit_price(tmp_path):
+    """(b) 같은 상황 + new_price 명시 → 통과. 와이어와 원장이 그 값을 같이 싣는다."""
+    ctx, tracker = _make_context(tmp_path, "korea_stock")
+    tracker.record_order("55555", TODAY, "005930", "KRX", "buy", 5, 0.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_korea_stock(_response("OrdNo", "77777"))
+
+    result = await ModifyOrderNodeExecutor()._modify_korea_stock(
+        ls=ls, original_order_id="55555", symbol="005930",
+        new_quantity=3, new_price=71000.0, config={},
+        context=ctx, node_id="modify-kr",
+    )
+
+    assert result["modify_result"]["success"] is True, result
+    wire = _korea_wire(ls)
+    assert (wire.OrdQty, wire.OrdPrc, wire.OrdprcPtnCode) == (3, 71000.0, "00")
+    row = _ledger_row(tracker, "77777")
+    assert (row[5], row[6]) == (wire.OrdQty, wire.OrdPrc), "원장과 와이어가 같아야 한다"
+
+
+@pytest.mark.asyncio
+async def test_modify_does_not_block_an_explicitly_stated_zero_price(tmp_path):
+    """(c) new_price=0 **명시** → 게이트가 막지 않고 브로커까지 도달한다.
+
+    그건 호출자의 진술이다. CSPAT00701 에서는 시장가 유형('03')과 함께 유효할 수
+    있다(blocks.py:100-107 "Use 0 for market orders ('03')"). 그 조합의 유효성은
+    엔진이 판정하지 않는다 — 호출자가 준 값을 그대로 싣는다.
+    """
+    ctx, tracker = _make_context(tmp_path, "korea_stock")
+    tracker.record_order("55555", TODAY, "005930", "KRX", "buy", 5, 70000.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_korea_stock(_response("OrdNo", "77777"))
+
+    result = await ModifyOrderNodeExecutor()._modify_korea_stock(
+        ls=ls, original_order_id="55555", symbol="005930",
+        new_quantity=3, new_price=0, config={"price_type_code": "03"},
+        context=ctx, node_id="modify-kr",
+    )
+
+    assert result["modify_result"]["success"] is True, result
+    ls.korea_stock().order().cspat00701.assert_called_once()
+    wire = _korea_wire(ls)
+    assert (wire.OrdQty, wire.OrdPrc, wire.OrdprcPtnCode) == (3, 0.0, "03")
+    row = _ledger_row(tracker, "77777")
+    assert (row[5], row[6]) == (wire.OrdQty, wire.OrdPrc), "원장과 와이어가 같아야 한다"
+
+
+@pytest.mark.asyncio
+async def test_modify_inherits_a_positive_ledger_price(tmp_path):
+    """(d) 원장 price 149.0 승계 → 통과. 게이트는 양수 승계값을 건드리지 않는다."""
+    ctx, tracker = _make_context(tmp_path, "overseas_stock")
+    tracker.record_order("12345", TODAY, "IBM", "NYSE", "buy", 5, 149.0,
+                         ctx.job_id, "order-node")
+    ls = _ls_overseas_stock(_response("OrdNo", "67890"))
+
+    result = await ModifyOrderNodeExecutor()._modify_overseas_stock(
+        ls=ls, original_order_id="12345", symbol="IBM", exchange="NYSE",
+        new_quantity=3, new_price=None, side="buy", config={},
+        context=ctx, node_id="modify-node",
+    )
+
+    assert result["modify_result"]["success"] is True, result
+    ls.overseas_stock().주문().cosat00311.assert_called_once()
+    wire = _stock_wire(ls)
+    assert (wire.OrdQty, wire.OvrsOrdPrc) == (3, 149.0)
+    row = _ledger_row(tracker, "67890")
+    assert (row[5], row[6]) == (wire.OrdQty, wire.OvrsOrdPrc), "원장과 와이어가 같아야 한다"

--- a/src/programgarden/tests/test_overseas_stock_open_orders_fields.py
+++ b/src/programgarden/tests/test_overseas_stock_open_orders_fields.py
@@ -1,0 +1,89 @@
+"""해외주식 미체결 주문 dict 의 필드 출처 — 없는 값을 사실처럼 내보내지 않는다.
+
+``exchange`` 가 비는 원인은 **브로커가 아니라 SDK 매핑**이다. 브로커 응답
+COSAQ00102OutBlock3 에는 주문시장코드가 있다(SDK overseas_stock/accno/
+COSAQ00102/blocks.py:534 ``OrdMktCode`` — "'81' = NYSE, '82' = NASDAQ").
+그 행을 ``StockOpenOrder`` 로 옮기는 매핑(overseas_stock/extension/
+tracker.py:385-398)이 그 필드를 읽지 않고, 모델에도 자리가 없다
+(extension/models.py:189-226). 그래서 사유는 "브로커가 안 줌" 이 아니라
+"중간 매핑에서 유실" 이어야 한다. 키는 포트 스키마(ORDER_LIST_FIELDS 에
+exchange 선언)와 형제 경로(선물/국내) 모양을 위해 남기되, 사유를 같은 dict 에
+실어 소비자가 오해하지 않게 한다. 근본 수정(SDK 모델에 market_code 추가)은
+finance 패키지 몫이라 여기 범위 밖이다.
+
+수량 필드는 int 로 자르지 않는다 — LS 해외주식은 소수점 거래를 지원하고
+(출처: 오너 진술 2026-09-12; prod 2026-08-24 IBM 0.847972주 실측),
+``int()`` 로 자르면 1주 미만 미체결이 통째로 0 이 돼 조용히 사라진다.
+체결수량 필드명도 ``filled_qty`` 가 아니라 ``executed_qty`` 다(models.py:210).
+"""
+
+from types import SimpleNamespace
+
+from programgarden.executor import RealAccountNodeExecutor
+
+
+class _Tracker:
+    def __init__(self, orders):
+        self._orders = orders
+
+    def get_open_orders(self):
+        return self._orders
+
+    def get_positions(self):
+        return {}
+
+    def get_balances(self):
+        return {}
+
+
+def _open_orders(order):
+    data = RealAccountNodeExecutor()._get_overseas_stock_tracker_data(_Tracker({"A1": order}))
+    return data["open_orders"]["A1"]
+
+
+def test_exchange_is_marked_unavailable_not_silently_empty():
+    """사유 문자열은 실제 원인(= SDK 매핑 유실)을 말해야 한다.
+
+    종전 값 "not_provided_by_broker_open_order" 는 사실이 아니었다 — 브로커는
+    OrdMktCode 를 준다(COSAQ00102/blocks.py:534).
+    """
+    row = _open_orders(SimpleNamespace(
+        symbol="IBM", order_type="02", order_price=250.0,
+        order_qty=1, executed_qty=0, remaining_qty=1,
+    ))
+
+    assert row["exchange"] == ""
+    assert row["exchange_unavailable_reason"] == "dropped_by_sdk_open_order_mapping"
+
+
+def test_fractional_quantities_survive_and_executed_qty_is_read():
+    row = _open_orders(SimpleNamespace(
+        symbol="IBM", order_type="02", order_price=250.0,
+        order_qty=0.847972, executed_qty=0.5, remaining_qty=0.347972,
+    ))
+
+    assert row["order_qty"] == 0.847972
+    assert row["filled_qty"] == 0.5       # executed_qty 를 읽어야 한다 (filled_qty 아님)
+    assert row["remaining_qty"] == 0.347972
+
+
+def test_integer_quantities_stay_integers():
+    row = _open_orders(SimpleNamespace(
+        symbol="IBM", order_type="02", order_price=250.0,
+        order_qty=3, executed_qty=1, remaining_qty=2,
+    ))
+
+    assert (row["order_qty"], row["filled_qty"], row["remaining_qty"]) == (3, 1, 2)
+    assert all(isinstance(row[k], int) for k in ("order_qty", "filled_qty", "remaining_qty"))
+
+
+def test_exchange_reason_is_absent_when_the_broker_does_report_one():
+    """SDK 모델이 거래소를 싣게 되면 사유 없이 실제 값이 나가야 한다."""
+    row = _open_orders(SimpleNamespace(
+        symbol="IBM", order_type="02", order_price=250.0,
+        order_qty=1, executed_qty=0, remaining_qty=1,
+        exchange_code="NASDAQ",
+    ))
+
+    assert row["exchange"] == "NASDAQ"
+    assert "exchange_unavailable_reason" not in row

--- a/src/programgarden/tests/test_record_fill_identity_fallback.py
+++ b/src/programgarden/tests/test_record_fill_identity_fallback.py
@@ -1,0 +1,263 @@
+"""체결번호(execution_id) 축이 깨져도 체결은 원장에 남는다 — context.record_workflow_fill.
+
+배경(회귀 방지):
+    원장의 중복방지 키는 (product, provider, trading_mode, order_date, order_no,
+    execution_id) 이고, 그 키를 만드는 WorkflowPositionTracker._execution_key 는
+    **체결번호 자체**를 먼저 _normalize_identifier 에 통과시킨다. 정수가 아닌 수치
+    문자열("0.0" / "-0" / "12.5")이면 거기서
+    ValueError("Numeric execution/order identity must be a positive integer") 가
+    나고, 종전에는 그 예외를 context.record_workflow_fill 의 광역 except 가 삼켜
+    "error" 만 반환했다 — trade_history 에도 workflow_position_lots 에도 **아무것도
+    남지 않았다**(체결 통째 유실).
+
+    executor._usable_execution_identity 는 (주문번호, 주문일자) 축만 미리 거르므로
+    이 축은 열려 있었다. 그래서 축마다 가드를 덧대는 대신, record_workflow_fill 에서
+    **identity 관련 ValueError 만** 잡아 체결번호 없이 한 번 더 기록한다
+    (중복방지만 포기하고 체결은 보존).
+
+    단 ExecutionIdentityConflictError(ValueError 서브클래스)는 "같은 체결번호가 이미
+    기록돼 있는데 사실이 다르다" 는 신호라, 재시도하면 같은 브로커 체결이 두 번
+    기록된다 — 재시도 대상에서 제외한다.
+
+라이브 키 없이 실제 SQLite 원장으로 검증한다.
+"""
+
+import logging
+import sqlite3
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.database.workflow_position_tracker import WorkflowPositionTracker
+
+
+TODAY = datetime.now().strftime("%Y%m%d")
+
+
+def _make_context(tmp_path):
+    ctx = ExecutionContext(job_id="fill-identity", workflow_id="offline")
+    tracker = WorkflowPositionTracker(
+        str(tmp_path / "stock.sqlite"), ctx.job_id, "broker", product="overseas_stock"
+    )
+    ctx._workflow_position_tracker = tracker
+    ctx._workflow_risk_tracker = MagicMock()
+    # 우리 주문으로 기록해 둬야 체결이 버퍼링('pending') 없이 즉시 분류된다.
+    tracker.record_order("123", TODAY, "AAPL", "NASDAQ", "buy", 5, 100.0,
+                         ctx.job_id, "order-node")
+    return ctx, tracker
+
+
+def _history(tracker):
+    with sqlite3.connect(tracker.db_path) as conn:
+        return conn.execute(
+            "SELECT order_no, order_date, symbol, side, quantity, price, "
+            "classification, execution_id FROM trade_history ORDER BY id"
+        ).fetchall()
+
+
+def _lots(tracker):
+    with sqlite3.connect(tracker.db_path) as conn:
+        return conn.execute(
+            "SELECT symbol, original_qty, classification FROM workflow_position_lots ORDER BY id"
+        ).fetchall()
+
+
+async def _fill(ctx, *, execution_id, quantity=5, price=100.0):
+    return await ctx.record_workflow_fill(
+        order_no="123", order_date=TODAY, symbol="AAPL", exchange="NASDAQ",
+        side="buy", quantity=quantity, price=price, fill_time="120000000",
+        commda_code="40", execution_id=execution_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 깨진 체결번호 축 — 체결은 보존되고 경고가 남는다
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("execution_id", ["0.0", "-0", "12.5", "1e3", 4.0])
+@pytest.mark.asyncio
+async def test_unusable_execution_id_still_records_the_fill(tmp_path, caplog, execution_id):
+    """비정수 수치 체결번호여도 trade_history 행이 남고 warning 이 찍힌다."""
+    ctx, tracker = _make_context(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="programgarden.context"):
+        result = await _fill(ctx, execution_id=execution_id)
+
+    assert result == "workflow"
+    rows = _history(tracker)
+    assert len(rows) == 1
+    assert rows[0][:7] == ("123", TODAY, "AAPL", "buy", 5, 100.0, "workflow")
+    # 중복방지만 포기한다 — 체결번호는 원장에 남기지 않는다(거짓 키를 만들지 않는다).
+    assert rows[0][7] is None
+    assert _lots(tracker) == [("AAPL", 5, "workflow")]
+
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("Execution identity unusable" in m and repr(execution_id) in m
+               for m in warnings), warnings
+
+
+# ---------------------------------------------------------------------------
+# 정상 체결번호 — 종전대로 identity 를 쓴다
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_usable_execution_id_keeps_identity_and_replay_protection(tmp_path, caplog):
+    ctx, tracker = _make_context(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="programgarden.context"):
+        first = await _fill(ctx, execution_id="0077")
+        replay = await _fill(ctx, execution_id="77")   # 0-패딩 차이 = 같은 체결
+
+    assert (first, replay) == ("workflow", "workflow")
+    rows = _history(tracker)
+    assert len(rows) == 1                      # 재전달은 이중 기록되지 않는다
+    assert rows[0][7] == "77"                  # 정규화된 체결번호가 원장에 남는다
+    assert _lots(tracker) == [("AAPL", 5, "workflow")]
+    assert not [r for r in caplog.records
+                if "Execution identity unusable" in r.getMessage()]
+
+
+# ---------------------------------------------------------------------------
+# 사실 충돌 — 재시도하지 않는다(이중 기록 금지)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_identity_conflict_is_not_retried_without_identity(tmp_path):
+    """같은 체결번호 + 다른 사실이면 'error' 로 두고 두 번째 행을 만들지 않는다."""
+    ctx, tracker = _make_context(tmp_path)
+
+    assert await _fill(ctx, execution_id="77", quantity=5) == "workflow"
+    conflicted = await _fill(ctx, execution_id="77", quantity=4)
+
+    assert conflicted == "error"
+    assert len(_history(tracker)) == 1
+    assert _lots(tracker) == [("AAPL", 5, "workflow")]
+
+
+# ---------------------------------------------------------------------------
+# Y2 — 폴백이 잡는 범위는 **identity 예외 하나**다
+#
+# 종전 폴백은 `except ValueError` 라, execution_id 가 실려 있기만 하면 identity 와
+# 무관한 tracker 예외까지 삼켜 체결번호 없이 재기록했다. 실제로 닿는 경로가 있다 —
+# _execution_facts 의 유한성 가드(수량/가격이 inf·nan 이면
+# ValueError("Explicit execution quantity and price must be finite")). 그건 체결번호를
+# 뗀다고 나아지지 않는 **체결 사실 자체의 문제**이므로, 비유한 값을 원장에 남기는 대신
+# "error" 로 끝나야 한다. 그래서 tracker 에 ExecutionIdentityError 를 두고
+# _normalize_identifier / _execution_key 계열만 그걸 올린다.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad_price", [float("inf"), float("nan")])
+@pytest.mark.asyncio
+async def test_non_identity_value_error_is_not_swallowed_by_the_fallback(
+    tmp_path, caplog, bad_price
+):
+    """비유한 체결가는 체결번호를 떼고 재기록되지 않는다 — 'error' 로 끝난다."""
+    ctx, tracker = _make_context(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="programgarden.context"):
+        result = await _fill(ctx, execution_id="77", price=bad_price)
+
+    assert result == "error"
+    assert _history(tracker) == [], "비유한 값이 원장에 남으면 안 된다"
+    assert _lots(tracker) == []
+    assert not [r for r in caplog.records
+                if "Execution identity unusable" in r.getMessage()], \
+        "identity 폴백이 identity 와 무관한 예외를 잡으면 안 된다"
+
+
+@pytest.mark.asyncio
+async def test_identity_errors_are_a_dedicated_exception_type():
+    """계약 고정 — 정규화 실패만 ExecutionIdentityError 다(충돌은 별도 타입)."""
+    from programgarden.database.workflow_position_tracker import (
+        ExecutionIdentityConflictError,
+        ExecutionIdentityError,
+        WorkflowPositionTracker,
+    )
+
+    assert issubclass(ExecutionIdentityError, ValueError)
+    with pytest.raises(ExecutionIdentityError):
+        WorkflowPositionTracker._normalize_identifier("12.5")
+    with pytest.raises(ExecutionIdentityError):
+        WorkflowPositionTracker._normalize_identifier(4.0)
+    # 충돌은 재시도 대상이 아니므로 일부러 이 타입의 서브클래스가 아니다.
+    assert not issubclass(ExecutionIdentityConflictError, ExecutionIdentityError)
+
+
+# ---------------------------------------------------------------------------
+# Y5 — X1 의 대가를 명시적으로 고정한다
+#
+# 체결번호를 떼고 재기록하면 그 행에는 중복방지 키가 없다. 그래서 **깨진 체결번호를
+# 실은 같은 프레임이 재전달되면 2행이 된다** — 의도된 트레이드오프다(체결 한 건이
+# 통째로 사라지는 것보다 낫다). 정상 체결번호는 종전대로 1행이다
+# (test_usable_execution_id_keeps_identity_and_replay_protection).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_replayed_frame_with_a_broken_execution_id_records_twice(tmp_path, caplog):
+    """깨진 체결번호로 같은 프레임이 두 번 오면 2행 + 경고 2회."""
+    ctx, tracker = _make_context(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="programgarden.context"):
+        first = await _fill(ctx, execution_id="0.0")
+        replay = await _fill(ctx, execution_id="0.0")
+
+    assert (first, replay) == ("workflow", "workflow")
+    rows = _history(tracker)
+    assert len(rows) == 2, "중복방지를 포기했으므로 재전달이 2행이 된다(의도된 대가)"
+    assert [r[7] for r in rows] == [None, None], "거짓 중복방지 키를 만들지 않는다"
+    assert _lots(tracker) == [("AAPL", 5, "workflow"), ("AAPL", 5, "workflow")]
+
+    warnings = [r.getMessage() for r in caplog.records
+                if "Execution identity unusable" in r.getMessage()]
+    assert len(warnings) == 2, warnings
+
+
+# ---------------------------------------------------------------------------
+# Y4 — record_order 가 띄우는 fire-and-forget 태스크의 침묵 실패
+#
+# record_order 는 버퍼 처리(_process_buffered_fill)를 `loop.create_task` 로 띄우고
+# 아무도 await 하지 않는다. 그 안의 _normalize_identifier 가 ExecutionIdentityError 를
+# 올리면 체결은 버퍼에 남아 타임아웃 경로로 unknown_api 가 되는데, **원인 기록이
+# 하나도 없었다**. done 콜백으로 드러낸다.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_buffered_fill_task_failure_is_logged(tmp_path, caplog):
+    import asyncio
+
+    from programgarden.database.workflow_position_tracker import PendingFill
+
+    ctx, tracker = _make_context(tmp_path)
+    tracker._pending_fills[1] = PendingFill(
+        order_no="999", order_date=TODAY, symbol="AAPL", exchange="NASDAQ",
+        side="buy", quantity=1, price=100.0, fill_time="120000000",
+        commda_code="40", received_at=datetime.now(), execution_id="12.5",
+    )
+
+    logger_name = "programgarden.database.workflow_position_tracker"
+    with caplog.at_level(logging.ERROR, logger=logger_name):
+        tracker.record_order("999", TODAY, "AAPL", "NASDAQ", "buy", 1, 100.0,
+                             ctx.job_id, "order-node")
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+    errors = [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR]
+    assert any("Buffered-fill processing task failed" in m for m in errors), errors
+
+
+@pytest.mark.asyncio
+async def test_successful_buffered_fill_task_logs_nothing(tmp_path, caplog):
+    """정상 경로는 조용하다(콜백이 성공 태스크에 잡음을 만들지 않는다)."""
+    import asyncio
+
+    logger_name = "programgarden.database.workflow_position_tracker"
+    with caplog.at_level(logging.ERROR, logger=logger_name):
+        ctx, tracker = _make_context(tmp_path)
+        tracker.record_order("456", TODAY, "AAPL", "NASDAQ", "buy", 1, 100.0,
+                             ctx.job_id, "order-node")
+        for _ in range(5):
+            await asyncio.sleep(0)
+
+    assert [r.getMessage() for r in caplog.records if r.levelno >= logging.ERROR] == []

--- a/src/programgarden/tests/test_stock_as1_execution_identity.py
+++ b/src/programgarden/tests/test_stock_as1_execution_identity.py
@@ -113,3 +113,215 @@ async def test_context_call_without_execution_identity_retains_legacy_arguments(
     assert calls == [{"order_no": "123", "order_date": "20260909", "symbol": "SYNTH",
                       "exchange": "NASDAQ", "side": "buy", "quantity": 0.5, "price": 100,
                       "fill_time": "120000001", "commda_code": "10"}]
+
+
+async def _capture_as1_fill_kwargs(monkeypatch, **field_overrides):
+    """AS1 콜백을 실제로 태워 context.record_workflow_fill 의 kwargs 를 잡아온다."""
+    values = {name: field.examples[0] for name, field in AS1RealResponseBody.model_fields.items()}
+    values.update(sOrdNo=123, sExecNO="0001", sExecQty=0.5, sExecPrc=100,
+                  sShtnIsuNo="SYNTH", sOrdMktCode="82", sOrdPtnCode="02", sBnsTp="2")
+    values.update(field_overrides)
+    body = AS1RealResponseBody.model_validate(values)
+
+    writes = []
+
+    async def record(**kwargs):
+        writes.append(kwargs)
+        return "workflow"
+
+    context = SimpleNamespace(
+        job_id="as1-fill-time", is_shutdown=False, log=lambda *a, **k: None,
+        record_workflow_fill=record,
+    )
+
+    callbacks = {}
+    real = SimpleNamespace(
+        connect=AsyncMock(),
+        AS0=lambda: SimpleNamespace(on_as0_message=lambda cb: callbacks.update(as0=cb)),
+        AS1=lambda: SimpleNamespace(on_as1_message=lambda cb: callbacks.update(as1=cb)),
+    )
+    ls = SimpleNamespace(overseas_stock=lambda: SimpleNamespace(real=lambda: real))
+
+    submitted = []
+    schedule = asyncio.run_coroutine_threadsafe
+
+    def capture(coroutine, loop):
+        future = schedule(coroutine, loop)
+        submitted.append(future)
+        return future
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", capture)
+    await BrokerNodeExecutor()._subscribe_overseas_stock_fill_events(ls, "broker", context)
+    callbacks["as1"](SimpleNamespace(body=body))
+    assert submitted, "AS1 callback did not schedule the fill recording"
+    await asyncio.wrap_future(submitted.pop())
+    assert len(writes) == 1
+    return writes[0]
+
+
+@pytest.mark.asyncio
+async def test_as1_fill_time_prefers_execution_time(monkeypatch):
+    """sExecTime(체결시각)이 있으면 그 값을 쓴다."""
+    kwargs = await _capture_as1_fill_kwargs(
+        monkeypatch, sExecTime="093015", sRcptExecTime="093020", proctm="120000001")
+    assert kwargs["fill_time"] == "093015"
+
+
+@pytest.mark.asyncio
+async def test_as1_fill_time_falls_back_to_exchange_received_time(monkeypatch):
+    """sExecTime 이 공백이면 sRcptExecTime(거래소수신체결시각)으로 내려간다."""
+    kwargs = await _capture_as1_fill_kwargs(
+        monkeypatch, sExecTime="   ", sRcptExecTime="093020", proctm="120000001")
+    assert kwargs["fill_time"] == "093020"
+
+
+@pytest.mark.asyncio
+async def test_as1_fill_time_is_empty_when_frame_reports_none(monkeypatch):
+    """둘 다 비면 **빈 문자열**이다 — proctm 도, 로컬 시계도 쓰지 않는다.
+
+    proctm 은 AP처리시간(증권사 서버 처리시각)이지 거래소 체결시각이 아니다
+    (출처: 오너 진술 2026-09-12; SDK AS1/blocks.py:91 이 proctm 을 AS0~AS4 공유
+    WS 프레임 헤더 구간으로, :317 이 sExecTime 을 AS1 체결 전용 구간으로 둔다).
+    그리고 `datetime.now().strftime('%H%M%S000')` 합성값은 파드 로컬(UTC) 벽시계를
+    브로커 체결시각과 같은 9자리 모양으로 내보내, 소비자(pg-worker
+    app/order_fill_updates.py)가 그걸 America/New_York 로 읽어 executed_at 을
+    '계산된 체결시각' 으로 확정하게 만든다(executed_at_source 태그 없이).
+    빈 문자열이어야 그쪽 `and fill_time` 가드가 걸려 received_at 폴백이 된다.
+    """
+    kwargs = await _capture_as1_fill_kwargs(
+        monkeypatch, sExecTime="", sRcptExecTime="", proctm="120000001")
+    assert kwargs["fill_time"] == ""
+
+
+@pytest.mark.asyncio
+async def test_absent_fill_time_stays_empty_on_the_wire_but_safe_in_the_ledger(tmp_path):
+    """체결시각이 없을 때: 서버로는 빈 문자열, 원장에는 날짜필터 안전한 표식.
+
+    서버 쪽 — pg-worker(app/order_fill_updates.py)는 `order_date + fill_time` 을
+    시장 세션 타임존으로 읽어 executed_at 을 확정한다. 빈 문자열이어야
+    `and fill_time` 가드가 걸려 received_at 폴백이 된다.
+
+    원장 쪽 — fill_datetime 은 f"{order_date}_{fill_time}" 이고 날짜 필터는
+    `fill_datetime >= f"{start_date}_000000000"` 라는 **문자열 비교**다. 빈
+    체결시각을 그대로 넣으면 "20260912_" < "20260912_000000000" 이라 그 로트가
+    대회 구간 PnL(get_workflow_positions/calculate_pnl)에서 통째로 사라진다.
+    그래서 원장에만 비숫자 표식(UNKNOWN_FILL_TIME)을 쓴다.
+    """
+    from programgarden.context import UNKNOWN_FILL_TIME
+
+    today = datetime.now().strftime("%Y%m%d")
+    context = ExecutionContext(job_id="fill-time-absent", workflow_id="offline")
+    path = str(tmp_path / "absent.sqlite")
+    tracker = WorkflowPositionTracker(path, context.job_id, "broker", product="korea_stock")
+    context._workflow_position_tracker = tracker
+    tracker.set_fill_classified_callback(context._on_tracker_fill_classified)
+    tracker.record_order("4242", today, "005930", "KRX", "buy", 1, 55000,
+                         context.job_id, "order-node")
+
+    events = []
+
+    class Capture:
+        async def on_order_fill(self, event):
+            events.append(event)
+
+        def __getattr__(self, name):
+            async def noop(*args, **kwargs):
+                return None
+            return noop
+
+    context.add_listener(Capture())
+
+    result = await context.record_workflow_fill(
+        order_no="4242", order_date=today, symbol="005930", exchange="KRX",
+        side="buy", quantity=1, price=55000, fill_time="", commda_code="40",
+    )
+    assert result == "workflow"
+
+    assert events and events[0].fill_time == "", "서버로 나가는 fill_time 은 비어 있어야 한다"
+
+    with sqlite3.connect(path) as conn:
+        stored = conn.execute(
+            "SELECT fill_datetime FROM workflow_position_lots"
+        ).fetchone()[0]
+    assert stored == f"{today}_{UNKNOWN_FILL_TIME}"
+    # 날짜 필터(문자열 비교)를 통과해야 대회 구간 PnL 에서 사라지지 않는다.
+    assert stored >= f"{today}_000000000"
+    assert "005930" in tracker.get_workflow_positions(start_date=today)
+
+
+@pytest.mark.asyncio
+async def test_record_workflow_fill_default_media_code_is_not_a_fabricated_value():
+    """commda_code 를 안 넘기면 원장에는 ""(= 프레임이 말하지 않음)가 간다.
+
+    종전 기본값은 "40"(OPEN API)이었다 — 관측되지 않은 값을 원장에 증거처럼
+    남기는 조작값이고, tracker.detect_anomalies 가 `WHERE commda_code='40'` 을
+    unknown_api 비율의 분모로 써서 trust_score 에 실제로 영향이 간다.
+    """
+    context = ExecutionContext(job_id="media-default", workflow_id="offline")
+    calls = []
+
+    class LegacyTracker:
+        async def record_fill(self, **kwargs):
+            calls.append(kwargs)
+            return "manual"
+
+    context._workflow_position_tracker = LegacyTracker()
+    await context.record_workflow_fill(
+        "123", "20260909", "SYNTH", "NASDAQ", "buy", 1, 100, "120000001")
+
+    assert calls[0]["commda_code"] == ""
+
+
+@pytest.mark.asyncio
+async def test_as1_zero_order_number_keeps_the_fill_and_drops_execution_id(tmp_path, monkeypatch):
+    """sOrdNo=0 프레임도 **체결을 잃지 않는다**(E3 가드 회귀).
+
+    AS1 의 sOrdNo 는 int 다(SDK overseas_stock/real/AS1/blocks.py:374). 0 이 오면
+    `str(...)` 이 '0' 이 되고, tracker._normalize_identifier 가 0-패딩을 벗겨
+    None 으로 접는다. 그 상태에서 체결번호(sExecNO)를 실으면 _execution_key 가
+    ValueError("Explicit execution identity requires an order number and date")
+    를 올리고, 그 예외를 context.record_workflow_fill 의 try 가 삼켜 **체결이
+    통째로 사라진다**(trade_history rows=0). SC1·TC3 에는 이 가드가 있었는데
+    AS1 에만 빠져 있었다.
+
+    기대 동작: 중복방지(execution_id)만 포기하고 체결 자체는 원장에 남는다.
+    """
+    context = ExecutionContext(job_id="stock-zero-ordno", workflow_id="offline")
+    path = str(tmp_path / "zero.sqlite")
+    tracker = WorkflowPositionTracker(path, context.job_id, "broker", product="overseas_stock")
+    context._workflow_position_tracker = tracker
+    today = datetime.now().strftime("%Y%m%d")
+    tracker.record_order("0", today, "SYNTH", "NASDAQ", "buy", 1, 100,
+                         context.job_id, "order-node")
+
+    callbacks = {}
+    real = SimpleNamespace(
+        connect=AsyncMock(),
+        AS0=lambda: SimpleNamespace(on_as0_message=lambda cb: callbacks.update(as0=cb)),
+        AS1=lambda: SimpleNamespace(on_as1_message=lambda cb: callbacks.update(as1=cb)),
+    )
+    ls = SimpleNamespace(overseas_stock=lambda: SimpleNamespace(real=lambda: real))
+
+    submitted = []
+    schedule = asyncio.run_coroutine_threadsafe
+
+    def capture(coroutine, loop):
+        future = schedule(coroutine, loop)
+        submitted.append(future)
+        return future
+
+    monkeypatch.setattr(asyncio, "run_coroutine_threadsafe", capture)
+    await BrokerNodeExecutor()._subscribe_overseas_stock_fill_events(ls, "broker", context)
+
+    values = {name: field.examples[0] for name, field in AS1RealResponseBody.model_fields.items()}
+    values.update(sOrdNo=0, sExecNO="0001", sExecQty=0.5, sExecPrc=100,
+                  sShtnIsuNo="SYNTH", sOrdMktCode="82", sOrdPtnCode="02", sBnsTp="2",
+                  sExecTime="093015")
+    callbacks["as1"](SimpleNamespace(body=AS1RealResponseBody.model_validate(values)))
+    assert submitted, "AS1 callback did not schedule the fill recording"
+    await asyncio.wrap_future(submitted.pop())
+
+    rows = ledger_rows(path)
+    assert len(rows) == 1, "주문번호가 0 이라고 체결을 통째로 버리면 안 된다"
+    assert rows[0][0] is None, "중복방지 키를 만들 수 없으면 체결번호는 싣지 않는다"
+    assert rows[0][1] == 0.5

--- a/src/programgarden/tests/test_workflow_position_tracker.py
+++ b/src/programgarden/tests/test_workflow_position_tracker.py
@@ -2,6 +2,7 @@
 import asyncio
 import sqlite3
 import tempfile
+from datetime import datetime, timedelta
 from decimal import Decimal
 import pytest
 from programgarden.database import (
@@ -11,6 +12,7 @@ from programgarden.database import (
     AnomalyResult,
     PendingFill,
 )
+from programgarden.database.workflow_position_tracker import media_channel
 
 
 class TestWorkflowPositionTracker:
@@ -703,3 +705,694 @@ class TestWorkflowLotOwnershipAndEstimate:
                     "SELECT remaining_qty FROM workflow_position_lots WHERE classification='workflow'"
                 ).fetchone()[0]
             assert wf_remaining == 3  # 수동 매도가 workflow 로트 2주를 소진
+
+
+class TestOrderDateWindowMatching:
+    """T2 후속 — 주문일자 D±1 창의 수용 조건 (2026-09-12 적대적 검토 B1·B2·B5 + 재검증).
+
+    창은 '같은 주문인데 주문일자가 한 칸 어긋난 경우' 를 구제하려고 존재하고, 그 어긋남은
+    **양방향 모두 이 저장소에 근거가 있다**:
+      · D-1 = AS1/SC1 프레임에 주문일자 필드가 없어 수신 시각의 로컬 날짜를 쓰기 때문
+        (설계상). 자정 직전 접수 → 자정 직후 체결.
+      · D+1 = LS 가 야간 세션을 전 영업일로 파일링하기 때문(2026-09-10 실측: 00:39:25 KST
+        접수(로컬 20260910) → OrdDt 20260909 — tests/test_broker_business_date_window.py
+        헤더). record_order 는 로컬 날짜, TC3 체결은 프레임 ordr_dt 라 주문이 하루 뒤다.
+    넓힌 경로는 추론이므로 수용 조건이 여섯이다 — 후보 1건 · 종목 일치 · (비교 가능하면)
+    매매구분 일치 · **매체코드가 사람 채널이 아닐 것** · **체결 수량 ≤ 주문 수량** ·
+    **주문 기록 시각과 체결 수신 시각이 12시간 이내(휴리스틱·보조)**. 종목 대조가 없으면
+    우리 원장에 없는 제3자 주문번호가 늘 '후보 1건' 이라 무조건 통과하고, 뒤의 세 가드가
+    없으면 **영업일마다 리셋되는 브로커 주문번호가 재발급된 남의 주문**이 종목·side 까지
+    같아 그대로 흡수된다. 시각 가드만으로는 못 가른다 — 미국주식은 KST 주간(09:00~)에도
+    거래되므로(저장소 메모리 관측 확정) 다음 날 낮 재발급이 우리 주문 몇 시간 뒤일 수 있다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_previous_day_order_matches_and_resolves_node_id(self):
+        """(1) 주문 D-1 / 체결 D, 같은 종목 → workflow 이고 node_id 도 채워진다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('86382', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            result = await t.record_fill('86382', '20260912', 'AAPL', 'NASDAQ',
+                                         'buy', 1, 100.0, '000030000', '40')
+            assert result == 'workflow'
+            # B2: 분류와 **같은 매처**를 쓰므로 창으로 매칭된 체결도 node_id 가 붙는다.
+            # (안 그러면 classification='workflow' + node_id=None 조합이 생겨 하류
+            #  멱등 키 job_id:node_id:order_id:seq 의 node 축이 빈 문자열로 접힌다.)
+            assert t.lookup_order_identity('86382', '20260912') == ('j', 'node-w')
+            # 호출부가 체결 사실을 직접 넘겨도 같은 결과
+            assert t.lookup_order_identity('86382', '20260912',
+                                           symbol='AAPL', side='buy') == ('j', 'node-w')
+
+    @pytest.mark.asyncio
+    async def test_previous_day_order_with_other_symbol_is_not_workflow(self):
+        """(2) 주문 D-1 / 체결 D 인데 종목이 다르면 workflow 가 아니다 (B1 회귀 가드)."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            t.record_order('86382', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            result = await t.record_fill('86382', '20260912', 'TSLA', 'NASDAQ',
+                                         'sell', 5, 300.0, '000030000', '40')
+            assert result == 'pending'          # API 코드 → 버퍼
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                rows = conn.execute(
+                    "SELECT classification, symbol FROM trade_history").fetchall()
+            assert rows == [('unknown_api', 'TSLA')]
+            assert t.lookup_order_identity('86382', '20260912') is None
+
+    @pytest.mark.asyncio
+    async def test_side_mismatch_in_window_is_rejected(self):
+        """창 후보의 매매구분이 체결과 다르면 거부한다(원장에 side 가 있어 비교 가능)."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            t.record_order('86382', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            assert await t.record_fill('86382', '20260912', 'AAPL', 'NASDAQ',
+                                       'sell', 1, 100.0, '000030000', '40') == 'pending'
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                kinds = [r[0] for r in conn.execute(
+                    "SELECT classification FROM trade_history")]
+            assert kinds == ['unknown_api']
+
+    @pytest.mark.asyncio
+    async def test_next_day_order_matches_the_overnight_business_date_fill(self):
+        """(M1) 주문 기록 D+1 / 체결 D → workflow 이고 node_id 도 붙는다.
+
+        LS 야간 세션 파일링의 실제 형태다(2026-09-10 실측, 헤더는
+        tests/test_broker_business_date_window.py): 00:39 KST 로컬 20260910 접수 주문을
+        record_order 가 '20260910' 으로 기록하는데, TC3 체결 프레임의 ordr_dt 는 전
+        영업일 '20260909' 로 온다. D-1 팔만 있으면 이 체결은 매칭에 실패해 unknown_api 로
+        굳는다 — 이 저장소가 **실측으로 기록한 유일한 방향**이 그쪽이다.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('86382', '20260910', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            result = await t.record_fill('86382', '20260909', 'AAPL', 'NASDAQ',
+                                         'buy', 1, 100.0, '003925000', '40')
+            assert result == 'workflow'
+            assert t.lookup_order_identity('86382', '20260909') == ('j', 'node-w')
+
+    @pytest.mark.asyncio
+    async def test_window_rejects_two_candidates_for_the_same_order_no(self):
+        """(4) 창 안에 같은 주문번호 후보가 2건이면 모호해서 거부한다.
+
+        UNIQUE(order_no, order_date) 때문에 **한 날짜**에 같은 주문번호는 1건뿐이라,
+        D-1 한 칸짜리 창에서 후보가 2건이 되는 실제 형태는 0 패딩만 다른 재사용
+        ('123' 과 '0123')이다. 이 경로(명시 체결번호)는 주문번호를 정규화해 맞추므로
+        둘 다 후보가 되고, 후보 수 가드가 둘 다 거부한다.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            t.record_order('123', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'n1')
+            t.record_order('0123', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'n2')
+            assert await t.record_fill('123', '20260912', 'AAPL', 'NASDAQ', 'buy', 1, 100.0,
+                                       '000030000', '40', execution_id='E1') == 'pending'
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                kinds = [r[0] for r in conn.execute(
+                    "SELECT classification FROM trade_history")]
+            assert kinds == ['unknown_api']
+
+    @pytest.mark.asyncio
+    async def test_same_order_no_on_both_days_takes_the_exact_date_path(self):
+        """같은 주문번호가 D-1·D 양쪽 원장에 있으면 **창까지 가지 않는다**.
+
+        같은 날짜(D) 정확일치가 먼저 성립하므로 그 주문의 node 가 답이다 — 창의 후보
+        수 가드가 개입할 여지 자체가 없다(위 테스트가 그 가드를 따로 고정한다).
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('86382', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-prev')
+            t.record_order('86382', '20260912', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-today')
+            assert await t.record_fill('86382', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 100.0, '000030000', '40') == 'workflow'
+            assert t.lookup_order_identity('86382', '20260912') == ('j', 'node-today')
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('order_date', ['20260910', '20260914'])
+    async def test_two_days_apart_is_unknown_api(self, order_date):
+        """(5) D±2 는 창 밖이다 → unknown_api."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            t.record_order('86382', order_date, 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            assert await t.record_fill('86382', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 100.0, '000030000', '40') == 'pending'
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                kinds = [r[0] for r in conn.execute(
+                    "SELECT classification FROM trade_history")]
+            assert kinds == ['unknown_api']
+
+    @pytest.mark.asyncio
+    async def test_hts_fill_sharing_a_previous_day_order_no_is_not_absorbed(self):
+        """(7) B1 실측 시나리오 재현 — HTS(85) 체결이 우리 D-1 주문번호와 겹쳐도 흡수 안 됨.
+
+        검토자 실측: 우리 D-1 AAPL buy #86382 기록 뒤 다음 날 TSLA sell 5@300 commda=85
+        체결을 넣자 classification='workflow' 로 기록되고 FIFO 가 'Sell without enough
+        position' 까지 냈다. 이제 종목이 달라 창 매칭이 거부되고, 매체코드 표대로 manual.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('86382', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            await t.record_fill('86382', '20260911', 'AAPL', 'NASDAQ',
+                                'buy', 1, 100.0, '235900000', '40')
+            result = await t.record_fill('86382', '20260912', 'TSLA', 'NASDAQ',
+                                         'sell', 5, 300.0, '000030000', '85')
+            assert result == 'manual'
+            with sqlite3.connect(t.db_path) as conn:
+                tsla = conn.execute(
+                    "SELECT classification FROM trade_history WHERE symbol='TSLA'").fetchall()
+                aapl_lot = conn.execute(
+                    "SELECT remaining_qty, classification FROM workflow_position_lots "
+                    "WHERE symbol='AAPL'").fetchone()
+            assert tsla == [('manual',)]
+            assert aapl_lot == (1, 'workflow')      # 우리 로트는 그대로
+
+    @pytest.mark.asyncio
+    async def test_buffered_fill_matches_previous_day_order_recorded_late(self):
+        """체결이 먼저 오고 주문 ACK 가 늦게 기록돼도 ±1일 창(여기선 D-1 방향)으로 이어붙인다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 5.0        # 타임아웃 전에 주문이 기록되는 상황
+            assert await t.record_fill('86382', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 100.0, '000030000', '40') == 'pending'
+            t.record_order('86382', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            await asyncio.sleep(0.05)
+            with sqlite3.connect(t.db_path) as conn:
+                kinds = [r[0] for r in conn.execute(
+                    "SELECT classification FROM trade_history")]
+            assert kinds == ['workflow']
+
+    @pytest.mark.asyncio
+    async def test_buffered_fill_with_other_symbol_is_not_claimed_by_late_order(self):
+        """버퍼에 있던 남의 체결은 늦게 기록된 우리 D-1 주문이 데려가지 못한다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.2
+            assert await t.record_fill('86382', '20260912', 'TSLA', 'NASDAQ',
+                                       'buy', 1, 100.0, '000030000', '40') == 'pending'
+            t.record_order('86382', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            await asyncio.sleep(0.35)
+            with sqlite3.connect(t.db_path) as conn:
+                kinds = [r[0] for r in conn.execute(
+                    "SELECT classification FROM trade_history")]
+            assert kinds == ['unknown_api']
+
+    def test_order_date_window_is_one_day_each_way_and_never_raises(self):
+        """(M1·B5) 창은 D-1·D+1 두 칸이고, 문자열이 아닌 order_date 로 죽지 않는다."""
+        window = WorkflowPositionTracker._order_date_window
+        assert window('20260301') == ['20260228', '20260302']   # 2026 은 평년
+        assert window('20270101') == ['20261231', '20270102']
+        assert window('20261231') == ['20261230', '20270101']
+        assert window(20260912) == ['20260911', '20260913']     # 숫자여도 죽지 않는다
+        assert window(None) == []
+        assert window('') == []
+        assert window('2026-09-12') == []              # 형식 이상 → 넓히지 않는다
+        assert window(object()) == []                  # AttributeError 로 죽지 않는다
+
+    @pytest.mark.asyncio
+    async def test_non_string_order_date_does_not_kill_record_fill(self):
+        """(B5) 종전에는 (order_date or '').strip() 이 AttributeError 를 던져 체결 기록 전체가 죽었다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            result = await t.record_fill('O1', 20260912, 'AAPL', 'NASDAQ',
+                                         'buy', 1, 100.0, '000030000', '85')
+            assert result == 'manual'
+
+
+def _shift_order_created_at(tracker, order_no, order_date, *, hours):
+    """원장에 이미 적힌 주문 기록 시각을 과거로 옮긴다(창 시각 가드 실증용).
+
+    record_order 는 created_at 에 ``datetime.now()`` 를 쓰므로, 테스트에서는 주문과 체결이
+    같은 순간에 일어난다. 실제로 갈리는 건 '어제 밤 기록 → 오늘 낮 체결' 이므로 그 간격을
+    원장 값으로 직접 만든다(다른 필드는 건드리지 않는다).
+    """
+    with sqlite3.connect(tracker.db_path) as conn:
+        row = conn.execute(
+            "SELECT created_at FROM workflow_orders WHERE order_no = ? AND order_date = ?",
+            (order_no, order_date)).fetchone()
+        moved = (datetime.fromisoformat(row[0]) - timedelta(hours=hours)).isoformat()
+        conn.execute(
+            "UPDATE workflow_orders SET created_at = ? WHERE order_no = ? AND order_date = ?",
+            (moved, order_no, order_date))
+        conn.commit()
+
+
+class TestWidenedWindowReuseGuards:
+    """(M2) 브로커 주문번호는 **영업일마다 리셋**된다 — 창 경로에만 가드 둘을 더 건다.
+
+    어제 우리 주문번호가 오늘 사용자 주문에 재발급되고 종목·매매구분까지 같으면 종전
+    세 가드(후보 1건·종목·side)를 전부 통과한다. 검토자 실측: 우리 D-1 AAPL buy #3 →
+    다음 날 14:00 사용자 HTS 매수 7@250(order_no '3', commda_code '85')이
+    classification='workflow' 로 기록되고 workflow_position_lots 에 남의 로트가 생겼다.
+
+    (가) 프레임이 "사람이 낸 주문"이라고 명시한 매체코드면 창 수용을 거부한다.
+    (나) 주문 기록 시각과 체결 수신 시각의 간격이 임계(12시간)를 넘으면 거부한다 —
+         **휴리스틱(보조)** 이다. 미국주식은 KST 주간(09:00~, Blue Ocean)에도 거래되므로
+         (저장소 메모리 관측 확정 2026-09-11) 다음 날 낮 재발급이 우리 주문 몇 시간 뒤일
+         수 있어 시각만으로는 못 가른다.
+    (다) 체결 수량이 주문 수량(workflow_orders.quantity)을 넘으면 거부한다 — 우리 주문의
+         체결(부분·전량)은 주문 수량을 넘을 수 없으므로 우리 체결을 놓치지 않고, 세션
+         시각에 의존하지 않는다. 검토자 실측 형태(우리 1주 → 남의 7주)를 (가)(나)가 모두
+         통과하는 조건에서도 잡는다.
+    셋 다 **창 경로 전용**이다 — 정확일치 경로의 의미는 그대로 둔다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_hts_reissued_order_no_with_same_symbol_and_side_is_manual(self):
+        """(가) 검토자 실측 시나리오가 이제 manual 로 떨어진다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            result = await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                         'buy', 7, 250.0, '140000000', '85')
+            assert result == 'manual'
+            with sqlite3.connect(t.db_path) as conn:
+                lots = conn.execute(
+                    "SELECT classification, original_qty FROM workflow_position_lots").fetchall()
+                hist = conn.execute("SELECT classification FROM trade_history").fetchall()
+            assert lots == [('manual', 7)]      # workflow 로트가 아니다
+            assert hist == [('manual',)]
+            # 분류와 조회가 같은 판정을 한다(한쪽만 workflow 가 되지 않는다).
+            assert t.lookup_order_identity('3', '20260912') is None
+
+    @pytest.mark.asyncio
+    async def test_without_the_media_guard_the_hts_reissue_is_absorbed(self, monkeypatch):
+        """(가 실증) 매체코드 가드를 빼면 HTS 재발급이 흡수된다.
+
+        나머지 가드(후보 1건·종목·side·수량·시각)를 전부 통과하는 형태로 맞춘다 — 남의
+        HTS 주문이 우리 주문과 **같은 수량(1주)** 이고 같은 시간대다. 수량 가드(다)가 들어온
+        뒤에도 이 형태는 (가) 만이 막으므로, 그래서 이 가드가 load-bearing 이다.
+        (검토자 실측 원형인 7주 체결은 이제 (다)도 막는다 — 그 실증은 아래 (다) 테스트.)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            monkeypatch.setattr(WorkflowPositionTracker, '_may_widen_for_media',
+                                staticmethod(lambda commda_code: True))
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            result = await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                         'buy', 1, 250.0, '140000000', '85')
+            assert result == 'workflow'         # 가드 없이는 남의 체결을 흡수한다
+            with sqlite3.connect(t.db_path) as conn:
+                lots = conn.execute(
+                    "SELECT classification, original_qty FROM workflow_position_lots").fetchall()
+            assert lots == [('workflow', 1)]
+
+    @pytest.mark.asyncio
+    async def test_media_guard_does_not_touch_the_exact_date_path(self):
+        """(가) 정확일치 경로의 의미는 그대로 — 사람 매체코드라도 우리 주문이면 workflow.
+
+        우리 OPEN API 주문이 항상 '40' 을 달고 오는 게 아니므로(2026-09-12 AS1 실측에서
+        40 이었지만 표에는 41/43 도 있다), 정확일치 경로에서 매체코드로 우리 체결을
+        걷어내면 안 된다. 거기선 (주문번호, 주문일자) 동시 일치가 더 강한 증거다.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('7', '20260912', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            assert await t.record_fill('7', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 100.0, '140000000', '85') == 'workflow'
+            assert t.lookup_order_identity('7', '20260912') == ('j', 'node-w')
+
+    @pytest.mark.asyncio
+    async def test_api_reissue_far_from_the_order_is_refused_by_the_time_guard(self):
+        """(나) 매체코드가 사람이 아니어도 시각이 멀면 창 수용을 거부한다.
+
+        (가)(다)가 못 막는 형태 — 재발급된 번호로 들어온 타 API 체결이 우리 주문과 같은
+        수량(1주)이다. 주문 기록은 어제 밤, 체결은 오늘 낮(15시간)이라 임계 12시간 밖이다.
+        (수량을 1주로 맞춘 건 시각 가드만 고립시키기 위해서다 — 7주면 (다)가 먼저 잡는다.)
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            _shift_order_created_at(t, '3', '20260911', hours=15)
+            assert await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 250.0, '140000000', '40') == 'pending'
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                kinds = [r[0] for r in conn.execute(
+                    "SELECT classification FROM trade_history")]
+            assert kinds == ['unknown_api']
+            assert t.lookup_order_identity('3', '20260912') is None
+
+    @pytest.mark.asyncio
+    async def test_time_guard_still_accepts_a_full_session_gap(self):
+        """(나 실증) 같은 시나리오라도 간격이 임계 안이면 종전대로 workflow 다.
+
+        미국 정규장 한 세션(KST 22:30~05:00, 6.5시간)만큼 떨어져 있어도 수용한다 —
+        가드가 구제 대상(자정/영업일 경계 한 칸)을 죽이지 않는다는 뜻이다.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 7, 250.0, 'j', 'node-w')
+            _shift_order_created_at(t, '3', '20260911', hours=6.5)
+            assert await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 7, 250.0, '043000000', '40') == 'workflow'
+            assert t.lookup_order_identity('3', '20260912') == ('j', 'node-w')
+
+    @pytest.mark.asyncio
+    async def test_order_row_without_created_at_is_excluded_from_the_window(self):
+        """(나) created_at 이 비어 있는 옛 행은 추론 없이 창 수용에서 제외한다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 7, 250.0, 'j', 'node-w')
+            with sqlite3.connect(t.db_path) as conn:
+                conn.execute("UPDATE workflow_orders SET created_at = NULL "
+                             "WHERE order_no = ? AND order_date = ?", ('3', '20260911'))
+                conn.commit()
+            assert await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 7, 250.0, '000030000', '40') == 'pending'
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                kinds = [r[0] for r in conn.execute(
+                    "SELECT classification FROM trade_history")]
+            assert kinds == ['unknown_api']
+
+    @pytest.mark.asyncio
+    async def test_exact_date_path_does_not_need_created_at(self):
+        """정확일치 경로는 시각 가드를 타지 않는다 — created_at 이 없어도 workflow."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('7', '20260912', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            with sqlite3.connect(t.db_path) as conn:
+                conn.execute("UPDATE workflow_orders SET created_at = NULL")
+                conn.commit()
+            assert await t.record_fill('7', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 100.0, '000030000', '40') == 'workflow'
+
+
+class TestWidenedWindowQuantityGuard:
+    """(다) 창 경로의 수량 상한 — 체결 수량 ≤ 주문 수량(workflow_orders.quantity).
+
+    오너 지적(2026-09-12): 미국주식은 **KST 주간(09:00~, Blue Ocean)에도 거래된다**(저장소
+    메모리 관측 확정 — MARA 거래량 26→938). 그러면 자정 직전 우리 주문 → 다음 날 10:00
+    남의 재발급 주문은 10시간이라 시각 가드(12시간) 안이고, 매체코드가 API(40)면 (가)도
+    통과한다. 그 형태를 시각과 무관하게 잡는 게 수량 상한이다 — 우리 주문의 체결(부분·
+    전량)은 주문 수량을 넘을 수 없으므로 false-miss 가 없다.
+
+    아래 시나리오는 **매체 가드·시각 가드를 모두 통과하는 조건**(commda '40', 간격 3시간)
+    으로 고정한다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_api_reissue_with_more_quantity_than_our_order_is_not_workflow(self):
+        """우리 D-1 AAPL buy #3 **1주** → 다음 날 API(40) 같은 번호·종목·방향 **7주**, 3시간
+        → workflow 가 아니다(버퍼 → unknown_api). 분류와 조회가 같은 판정을 한다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            _shift_order_created_at(t, '3', '20260911', hours=3)
+            assert await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 7, 250.0, '100000000', '40') == 'pending'
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                hist = conn.execute(
+                    "SELECT classification, quantity FROM trade_history").fetchall()
+                lots = conn.execute(
+                    "SELECT classification, original_qty FROM workflow_position_lots").fetchall()
+            assert hist == [('unknown_api', 7)]
+            assert lots == [('unknown_api', 7)]          # workflow 로트가 생기지 않는다
+            assert t.lookup_order_identity('3', '20260912') is None
+            # 호출부가 체결 사실을 직접 넘겨도 같은 판정
+            assert t.lookup_order_identity(
+                '3', '20260912', symbol='AAPL', side='buy', commda_code='40',
+                received_at=datetime.now(), quantity=7) is None
+
+    @pytest.mark.asyncio
+    async def test_same_quantity_in_the_same_conditions_is_workflow(self):
+        """대조 — 같은 조건에서 **1주** 체결이면 workflow 이고 node_id 도 붙는다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            _shift_order_created_at(t, '3', '20260911', hours=3)
+            assert await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 250.0, '100000000', '40') == 'workflow'
+            assert t.lookup_order_identity('3', '20260912') == ('j', 'node-w')
+            assert t.lookup_order_identity(
+                '3', '20260912', symbol='AAPL', side='buy', commda_code='40',
+                received_at=datetime.now(), quantity=1) == ('j', 'node-w')
+
+    @pytest.mark.asyncio
+    async def test_partial_fill_in_the_window_is_workflow(self):
+        """부분체결 — 주문 3주, 체결 1주 → workflow (수량 상한은 부분체결을 죽이지 않는다)."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 3, 100.0, 'j', 'node-w')
+            _shift_order_created_at(t, '3', '20260911', hours=3)
+            assert await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 250.0, '100000000', '40') == 'workflow'
+            assert t.lookup_order_identity('3', '20260912') == ('j', 'node-w')
+
+    @pytest.mark.asyncio
+    async def test_fractional_fill_in_the_window_is_workflow(self):
+        """소수점 주식 — 주문 1, 체결 0.847972 → 통과(float 비교)."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            _shift_order_created_at(t, '3', '20260911', hours=3)
+            assert await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 0.847972, 250.0, '100000000', '40') == 'workflow'
+            assert t.lookup_order_identity('3', '20260912') == ('j', 'node-w')
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize('ledger_quantity', [None, 0])
+    async def test_order_row_without_quantity_is_excluded_from_the_window(self, ledger_quantity):
+        """원장 수량이 비었거나 0 이면 대조 불가 → 추론 없이 창 수용 거부(unknown_api)."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            _shift_order_created_at(t, '3', '20260911', hours=3)
+            with sqlite3.connect(t.db_path) as conn:
+                conn.execute("UPDATE workflow_orders SET quantity = ? "
+                             "WHERE order_no = ? AND order_date = ?",
+                             (ledger_quantity, '3', '20260911'))
+                conn.commit()
+            assert await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 250.0, '100000000', '40') == 'pending'
+            await asyncio.sleep(0.15)
+            with sqlite3.connect(t.db_path) as conn:
+                kinds = [r[0] for r in conn.execute(
+                    "SELECT classification FROM trade_history")]
+            assert kinds == ['unknown_api']
+            assert t.lookup_order_identity('3', '20260912') is None
+
+    @pytest.mark.asyncio
+    async def test_without_the_quantity_guard_the_api_reissue_is_absorbed(self, monkeypatch):
+        """(다 실증) 수량 가드를 빼면 7주 재발급이 그대로 흡수된다 — load-bearing.
+
+        매체 가드(40 → 통과)·시각 가드(3시간 → 통과)·후보 1건·종목·side 는 이 시나리오를
+        못 막는다.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            monkeypatch.setattr(WorkflowPositionTracker, '_fill_quantity_within_order',
+                                staticmethod(lambda fill_quantity, order_quantity: True))
+            t.record_order('3', '20260911', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            _shift_order_created_at(t, '3', '20260911', hours=3)
+            assert await t.record_fill('3', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 7, 250.0, '100000000', '40') == 'workflow'
+            with sqlite3.connect(t.db_path) as conn:
+                lots = conn.execute(
+                    "SELECT classification, original_qty FROM workflow_position_lots").fetchall()
+            assert lots == [('workflow', 7)]            # 남의 7주가 우리 로트가 된다
+
+    @pytest.mark.asyncio
+    async def test_quantity_guard_does_not_touch_the_exact_date_path(self):
+        """정확일치 경로는 수량 가드를 타지 않는다 — (주문번호, 주문일자) 동시 일치가 답이다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('7', '20260912', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'node-w')
+            assert await t.record_fill('7', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 7, 100.0, '100000000', '40') == 'workflow'
+            assert t.lookup_order_identity('7', '20260912') == ('j', 'node-w')
+
+    @pytest.mark.parametrize('fill_qty, order_qty, expected', [
+        (1, 1, True),              # 전량
+        (1, 3, True),              # 부분
+        (0.847972, 1, True),       # 소수점 주식
+        (7, 1, False),             # 주문보다 큰 체결 = 우리 체결일 수 없다
+        (Decimal('2'), 2, True),   # Decimal 도 float 로 비교
+        (1, None, False),          # 원장 수량 없음 → 추론 없이 거부
+        (1, 0, False),             # 원장 수량 0
+        (1, -1, False),            # 원장 수량 음수
+        (1, 'abc', False),         # 숫자가 아님
+        (None, 1, False),          # 체결 수량 없음
+        (float('nan'), 1, False),  # 유한하지 않음
+        (1, float('inf'), False),
+    ])
+    def test_fill_quantity_within_order_unit(self, fill_qty, order_qty, expected):
+        assert WorkflowPositionTracker._fill_quantity_within_order(fill_qty, order_qty) is expected
+
+
+class TestMatcherModesAndHotPath:
+    """(m1·m3) 주문번호 대조 mode 별 strict 의미와 정확일치 핫패스의 조회 형태."""
+
+    @staticmethod
+    def _insert_raw_order(tracker, order_no, order_date, node_id):
+        """record_order 를 거치지 않고 원장에 행을 넣는다(깨진 주문번호 재현용)."""
+        with sqlite3.connect(tracker.db_path) as conn:
+            conn.execute(
+                """
+                INSERT INTO workflow_orders
+                (product, provider, order_no, order_date, symbol, exchange, side,
+                 quantity, price, job_id, node_id, trading_mode, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (tracker.product, tracker.provider, order_no, order_date, 'AAPL', 'NASDAQ',
+                 'buy', 1, 100.0, 'j', node_id, tracker.trading_mode,
+                 datetime.now().isoformat()))
+            conn.commit()
+
+    def test_unnormalizable_row_does_not_kill_the_whole_lookup(self):
+        """(m1) 같은 날짜의 정규화 불가 행 하나가 lookup 전체를 죽이지 않는다.
+
+        통합 전 이 경로는 그 행만 ``except ValueError: continue`` 로 건너뛰었다. strict=True
+        로 통합하면 ValueError 가 lookup_order_identity 의 except 로 올라가 **멀쩡한 주문의
+        node_id 까지 None** 이 된다.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            self._insert_raw_order(t, '000000.5', '20260912', 'node-broken')
+            self._insert_raw_order(t, '0000123', '20260912', 'node-x')
+            assert t.lookup_order_identity('123', '20260912') == ('j', 'node-x')
+
+    def test_normalized_mode_keeps_its_strict_meaning(self):
+        """(m1) 명시 체결번호 경로(mode='normalized')의 strict 의미는 종전 그대로다.
+
+        그 날짜의 우리 주문 기록이 깨졌다는 신호이므로 삼키지 않는다.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            self._insert_raw_order(t, '000000.5', '20260912', 'node-broken')
+            self._insert_raw_order(t, '0000123', '20260912', 'node-x')
+            with pytest.raises(ValueError):
+                t._match_workflow_order('123', '20260912', mode='normalized')
+
+    def test_exact_date_match_is_an_indexed_equality_query(self, monkeypatch):
+        """(m3) 체결 핫패스는 order_no 등가조건 한 방이다 — 날짜 전체 스캔 + 파이썬 루프 금지.
+
+        통합 과정에서 이 단계가 'order_date 로만 좁혀 전부 읽고 파이썬에서 비교' 로 바뀌었다.
+        EXPLAIN QUERY PLAN 실측(2026-09-12): order_no 를 포함한 등가조건은
+        UNIQUE(order_no, order_date) 인덱스를 등가 탐색하고, order_date 만 거는 형태는
+        idx_orders_lookup_v2 를 trading_mode=? 로만 타 그 모드의 행을 전부 훑는다.
+        """
+        import programgarden.database.workflow_position_tracker as wpt
+
+        statements = []
+        real_connect = wpt.sqlite3.connect
+
+        class _SpyConnection:
+            def __init__(self, conn):
+                self._conn = conn
+
+            def execute(self, sql, *args, **kwargs):
+                statements.append(" ".join(str(sql).split()))
+                return self._conn.execute(sql, *args, **kwargs)
+
+            def __getattr__(self, name):
+                return getattr(self._conn, name)
+
+            def __enter__(self):
+                self._conn.__enter__()
+                return self
+
+            def __exit__(self, *args):
+                return self._conn.__exit__(*args)
+
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.record_order('86382', '20260912', 'AAPL', 'NASDAQ', 'buy', 1, 100.0, 'j', 'n')
+            monkeypatch.setattr(wpt.sqlite3, 'connect',
+                                lambda *a, **k: _SpyConnection(real_connect(*a, **k)))
+
+            statements.clear()
+            assert t._check_workflow_order('86382', '20260912') is True
+            assert len(statements) == 1                      # 창 조회조차 하지 않는다
+            assert 'AND order_no = ?' in statements[0]        # 인덱스 등가조회
+            assert 'order_date IN' not in statements[0]
+
+            statements.clear()
+            assert t._check_workflow_order('99999', '20260912') is False
+            # 실패했을 때만 창 후보를 끌어온다(정확일치 단계는 여전히 등가조회 한 방).
+            assert len(statements) == 2
+            assert 'AND order_no = ?' in statements[0]
+            assert 'order_date IN' in statements[1]
+
+
+class TestMediaChannelSingleTable:
+    """(6)(B3) 매체코드 표는 상품 분기 없는 **단일 합집합**이다.
+
+    tracker 는 워크플로우당 1개이고 가장 먼저 초기화된 브로커의 product 로 고정되므로,
+    표를 상품으로 가르면 해외+국내 혼합 워크플로우에서 반대쪽 시장 체결이 통째로
+    오분류된다(85 HTS → other, 43 api → other 라 버퍼도 건너뛴다).
+    """
+
+    @pytest.mark.parametrize('code', ['85', '60', '22', '23', '50', '00', '51', '03'])
+    def test_human_codes(self, code):
+        # 85=HTS(해외 TR 문서/AS1 실측) · 60=HTS · 50=MTS(국내, 오너 진술 2026-09-12,
+        # 라이브 미관측) · 22/23=앱(표) · 00=지점 · 51=투혼앱 · 03=투혼웹(실측)
+        assert media_channel(code) == 'human'
+
+    @pytest.mark.parametrize('code', ['40', '41', '43'])
+    def test_api_codes(self, code):
+        assert media_channel(code) == 'api'
+
+    @pytest.mark.parametrize('value', ['', '   ', None])
+    def test_blank_is_unknown(self, value):
+        assert media_channel(value) == 'unknown'
+
+    @pytest.mark.parametrize('code', ['77', '96', 'LP', 'SK', 'SO'])
+    def test_unlisted_or_broker_side_is_other(self, code):
+        assert media_channel(code) == 'other'
+
+    def test_takes_no_product_argument(self):
+        # 상품 분기를 되돌렸다는 사실 자체를 고정한다(시그니처가 다시 갈리면 실패).
+        with pytest.raises(TypeError):
+            media_channel('60', 'korea_stock')
+
+    @pytest.mark.asyncio
+    async def test_overseas_hts_fill_stays_manual_on_a_korea_scoped_tracker(self):
+        """혼합 워크플로우 회귀 가드 — 국내 product 로 고정된 tracker 라도 85 는 사람이다."""
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b', product='korea_stock')
+            assert await t.record_fill('H1', '20260912', 'AAPL', 'NASDAQ',
+                                       'buy', 1, 100.0, '000030000', '85') == 'manual'
+
+
+class TestUnknownApiRatioDenominator:
+    """(B6) unknown_api 비율의 분모는 리터럴 '40' 이 아니라 media_channel() 기준이다."""
+
+    @pytest.mark.asyncio
+    async def test_denominator_follows_the_media_table(self):
+        with tempfile.TemporaryDirectory() as d:
+            t = WorkflowPositionTracker(f'{d}/t.db', 'j', 'b')
+            t.FILL_BUFFER_TIMEOUT = 0.05
+            # 우리 체결 — 빈 매체코드(TC3 선물 프레임처럼). 종전 '40' 고정 분모에서는
+            # 이런 행이 통째로 빠져 선물은 이 이상탐지가 영구히 0행이었다.
+            t.record_order('W1', '20260912', 'ES', 'CME', 'buy', 1, 100.0, 'j', 'n')
+            assert await t.record_fill('W1', '20260912', 'ES', 'CME', 'buy', 1, 100.0,
+                                       '000030000', '') == 'workflow'
+            # 타 API 체결 2건: 빈 코드 1 + 43(Robo API) 1 → 둘 다 분모에 든다
+            assert await t.record_fill('X1', '20260912', 'ES', 'CME', 'buy', 1, 100.0,
+                                       '000031000', '') == 'pending'
+            assert await t.record_fill('X2', '20260912', 'ES', 'CME', 'buy', 1, 100.0,
+                                       '000032000', '43') == 'pending'
+            # 사람(85)·브로커측(96) 코드는 분모 밖이다
+            assert await t.record_fill('H1', '20260912', 'ES', 'CME', 'buy', 1, 100.0,
+                                       '000033000', '85') == 'manual'
+            assert await t.record_fill('B1', '20260912', 'ES', 'CME', 'buy', 1, 100.0,
+                                       '000034000', '96') == 'other'
+            await asyncio.sleep(0.15)
+
+            ratios = [a for a in t.detect_anomalies() if a.pattern == 'unknown_api_ratio']
+            assert len(ratios) == 1
+            # 분모 3 = 빈 코드 2 + '43' 1, 분자 2 = unknown_api. 85/96 은 제외.
+            assert '2/3' in ratios[0].description
+            assert ratios[0].severity == 20          # 감점 폭은 종전 그대로(최대 20)
+            assert t.calculate_trust_score() == 80

--- a/src/programgarden/tests/test_workflow_risk_tracker.py
+++ b/src/programgarden/tests/test_workflow_risk_tracker.py
@@ -6,6 +6,7 @@ Feature-gated 위험관리 추적기의 모든 기능을 검증합니다.
 
 import asyncio
 import os
+import shutil
 import sqlite3
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -20,6 +21,7 @@ from programgarden.database.workflow_risk_tracker import (
     HWMUpdateResult,
     HWMValidationResult,
     VALID_FEATURES,
+    _to_qty_decimal,
 )
 
 
@@ -28,9 +30,20 @@ from programgarden.database.workflow_risk_tracker import (
 # ============================================================
 
 @pytest.fixture
-def tmp_db_path(tmp_path):
-    """임시 DB 경로"""
-    return str(tmp_path / "test_workflow.db")
+def tmp_db_path():
+    """이 테스트 전용 임시 DB 경로.
+
+    pytest 의 ``tmp_path`` 를 쓰지 않는다 — ``tmp_path`` 는 사용자 단위 공용 base
+    (``pytest-of-<user>/pytest-N``)에 만들어지고 pytest 가 오래된 numbered dir 를
+    정리(기본 보관 3개)하므로, 같은 머신에서 다른 pytest 프로세스가 동시에 돌면
+    실행 중인 디렉토리가 정리 대상에 걸릴 수 있다. 여기서는 테스트마다
+    독립 디렉토리를 만들고 끝나면 우리가 지운다(WAL/SHM 부산물 포함).
+    """
+    d = tempfile.mkdtemp(prefix="pg-risk-tracker-")
+    try:
+        yield os.path.join(d, "test_workflow.db")
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
 
 
 def make_tracker(db_path, features, trading_mode="live"):
@@ -764,3 +777,262 @@ class TestUpdatePriceWindowIntegration:
         assert len(tracker._price_window) == 50
         vol = tracker.get_volatility("AAPL")
         assert vol is not None
+
+
+# ============================================================
+# 13. 소수점(fractional) 수량 — HWM 보존
+# ============================================================
+
+class TestFractionalQuantity:
+    """소수 수량 포지션에서도 재시작 검증이 HWM(트레일링 고점)을 지켜야 한다.
+
+    LS 는 해외주식 소수점 주식을 지원한다(출처: 오너 진술 2026-09-12).
+    사용자의 HTS/앱 소수 매도가 분류 무관 로트를 FIFO 로 소진하면 workflow 잔량이
+    소수가 되는데, 예전처럼 position_qty 를 int 로 자르면 9.5 → 9 로 저장돼
+    다음 재시작 비교에서 Decimal('9.5') != 9 가 항상 참이 되고, HWM 이 매번
+    평단으로 리셋(drawdown 0 초기화)됐다.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fractional_qty_survives_db_roundtrip(self, tmp_db_path):
+        """0.532주가 flush → 재복원 후에도 0.532 로 남는다 (int 절단 시 0)"""
+        t1 = make_tracker(tmp_db_path, {"hwm"})
+        t1.register_symbol("AAPL", "NASDAQ", 150.0, Decimal("0.532"))
+        assert t1.get_hwm("AAPL").position_qty == Decimal("0.532")
+        await t1.flush_to_db()
+
+        t2 = make_tracker(tmp_db_path, {"hwm"})
+        assert t2.get_hwm("AAPL").position_qty == Decimal("0.532")
+
+    @pytest.mark.asyncio
+    async def test_fractional_position_keeps_hwm_on_restart(self, tmp_db_path):
+        """수량 9.5 그대로면 'kept' — HWM 200 이 평단 150 으로 리셋되지 않는다"""
+        t1 = make_tracker(tmp_db_path, {"hwm"})
+        t1.register_symbol("AAPL", "NASDAQ", 150.0, Decimal("9.5"))
+        t1.update_price("AAPL", "NASDAQ", 200.0)  # HWM = 200
+        await t1.flush_to_db()
+
+        t2 = make_tracker(tmp_db_path, {"hwm"})
+
+        class MockPT:
+            def get_workflow_positions(self):
+                return {"AAPL": type("P", (), {
+                    "symbol": "AAPL",
+                    "quantity": Decimal("9.5"),   # PositionInfo.quantity 는 Decimal
+                    "avg_price": Decimal("150.0"),
+                    "exchange": "NASDAQ",
+                })()}
+
+        results = t2.validate_hwm_on_restart(MockPT())
+        assert [r.action for r in results] == ["kept"]
+        assert t2.get_hwm("AAPL").hwm_price == Decimal("200")
+
+    @pytest.mark.asyncio
+    async def test_fractional_qty_decrease_still_resets(self, tmp_db_path):
+        """9.5 → 9.0 처럼 실제로 줄면 여전히 reset (오차 허용으로 놓치지 않는다)"""
+        t1 = make_tracker(tmp_db_path, {"hwm"})
+        t1.register_symbol("AAPL", "NASDAQ", 150.0, Decimal("9.5"))
+        t1.update_price("AAPL", "NASDAQ", 200.0)
+        await t1.flush_to_db()
+
+        t2 = make_tracker(tmp_db_path, {"hwm"})
+
+        class MockPT:
+            def get_workflow_positions(self):
+                return {"AAPL": type("P", (), {
+                    "symbol": "AAPL",
+                    "quantity": Decimal("9.0"),
+                    "avg_price": Decimal("150.0"),
+                    "exchange": "NASDAQ",
+                })()}
+
+        results = t2.validate_hwm_on_restart(MockPT())
+        assert [r.action for r in results] == ["reset"]
+        assert t2.get_hwm("AAPL").position_qty == Decimal("9.0")
+
+    def test_new_fractional_position_registers(self, tmp_db_path):
+        """포지션 0.532 만 있어도 등록되고 **수량 0.532 가 그대로 저장**된다.
+
+        신규 등록 게이트(`if pos_qty > 0`)는 절단 전 원본 Decimal('0.532') 로
+        판정하므로 구 코드에서도 등록 자체는 됐다 — 깨졌던 건 저장 수량이다.
+        int 절단 시 position_qty 가 0 으로 남아 트레일링 청산의 수량 폴백이
+        0 이 됐다.
+        """
+        tracker = make_tracker(tmp_db_path, {"hwm"})
+
+        class MockPT:
+            def get_workflow_positions(self):
+                return {"TSLA": type("P", (), {
+                    "symbol": "TSLA",
+                    "quantity": Decimal("0.532"),
+                    "avg_price": Decimal("200.0"),
+                    "exchange": "NASDAQ",
+                })()}
+
+        results = tracker.validate_hwm_on_restart(MockPT())
+        assert [r.action for r in results] == ["new"]
+        assert tracker.get_hwm("TSLA").position_qty == Decimal("0.532")
+
+    def test_additional_fractional_buy_updates_avg(self, tmp_db_path):
+        """소수 추가 매수: Decimal * Decimal 산술이 TypeError 없이 평단을 갱신"""
+        tracker = make_tracker(tmp_db_path, {"hwm"})
+        tracker.register_symbol("AAPL", "NASDAQ", 100.0, Decimal("0.5"))
+        tracker.register_symbol("AAPL", "NASDAQ", 120.0, Decimal("0.5"))
+
+        hwm = tracker.get_hwm("AAPL")
+        assert hwm.position_qty == Decimal("1.0")
+        assert hwm.position_avg_price == Decimal("110")
+
+    @pytest.mark.asyncio
+    async def test_float_unrepresentable_decimal_keeps_hwm(self, tmp_db_path):
+        """float 로 정확히 표현 못 하는 Decimal 수량도 재시작 시 'kept'.
+
+        _qty_changed 를 고정하는 테스트다. position_qty 는 저장 직전 float 로
+        바인딩되므로 Decimal('0.1234567890123456789') 는 복원 시
+        Decimal('0.12345678901234568') 이 된다. 비교를 순수 `!=` 로 되돌리면
+        브로커가 **같은 수량**을 보고해도 항상 '변동'으로 판정돼 HWM 이 매
+        재시작 평단으로 리셋된다. float 정밀도 비교라야 'kept' 가 나온다.
+        """
+        qty = Decimal("0.1234567890123456789")
+        # 전제 확인: 순수 Decimal 비교면 왕복 후 값이 달라진다
+        # (전제가 깨지면 이 테스트가 조용히 무의미해지므로 여기서 잡는다)
+        assert Decimal(str(float(qty))) != qty
+        assert float(Decimal(str(float(qty)))) == float(qty)
+
+        t1 = make_tracker(tmp_db_path, {"hwm"})
+        t1.register_symbol("AAPL", "NASDAQ", 150.0, qty)
+        t1.update_price("AAPL", "NASDAQ", 200.0)  # HWM = 200
+
+        # flush 완료를 명시적으로 확인한다. flush_to_db 는 executor 스레드에서
+        # 쓰고 dirty 플래그로 무엇을 쓸지 정하므로, 여기서 "몇 건 썼는지 + 실제로
+        # 행이 남았는지"를 직접 보지 않으면 flush 가 조용히 0건이어도 아래 단언이
+        # AttributeError('NoneType' has no attribute ...) 로만 터져 원인이 안 남는다.
+        written = await t1.flush_to_db()
+        assert written == 1, f"flush 가 HWM 을 쓰지 않았다 (written={written})"
+        assert not t1.get_hwm("AAPL").dirty, "flush 후에도 dirty 플래그가 남아 있다"
+        with sqlite3.connect(tmp_db_path) as conn:
+            rows = conn.execute(
+                "SELECT symbol, position_qty FROM risk_high_water_mark"
+            ).fetchall()
+        assert len(rows) == 1 and rows[0][0] == "AAPL", f"DB 에 HWM 행이 없다: {rows}"
+
+        t2 = make_tracker(tmp_db_path, {"hwm"})
+        restored = t2.get_hwm("AAPL")
+        assert restored is not None, "DB → 메모리 복원이 HWM 을 가져오지 못했다"
+        assert restored.position_qty != qty  # float 왕복으로 값이 바뀜
+
+        class MockPT:
+            def get_workflow_positions(self):
+                return {"AAPL": type("P", (), {
+                    "symbol": "AAPL",
+                    "quantity": qty,          # 브로커는 원래 Decimal 을 그대로 보고
+                    "avg_price": Decimal("150.0"),
+                    "exchange": "NASDAQ",
+                })()}
+
+        results = t2.validate_hwm_on_restart(MockPT())
+        assert [r.action for r in results] == ["kept"]
+        assert t2.get_hwm("AAPL").hwm_price == Decimal("200")
+
+    def test_nan_quantity_becomes_zero(self, tmp_db_path, caplog):
+        """NaN 수량은 0 으로 잘라내고 경고를 남긴다.
+
+        Decimal(str(float('nan'))) 은 InvalidOperation 을 던지지 않아 예전
+        except 가드를 그대로 통과했다. 그 값이 position_qty 에 들어가면
+        nan != nan 이 항상 참이라 HWM 이 매 재시작 리셋되고, sqlite 바인딩은
+        NULL 이 돼 원인조차 남지 않는다.
+        """
+        import logging
+
+        assert _to_qty_decimal(float("nan")) == Decimal("0")
+        assert _to_qty_decimal(Decimal("NaN")) == Decimal("0")
+        assert _to_qty_decimal(float("inf")) == Decimal("0")
+
+        with caplog.at_level(logging.WARNING):
+            tracker = make_tracker(tmp_db_path, {"hwm"})
+            tracker.register_symbol("AAPL", "NASDAQ", 150.0, float("nan"))
+        assert any("유한수가 아님" in r.message for r in caplog.records)
+
+        state = tracker.get_hwm("AAPL")
+        assert state.position_qty == Decimal("0")
+        assert state.position_qty == state.position_qty  # nan 이면 False 가 된다
+
+    def test_nan_quantity_does_not_reset_hwm_on_restart(self, tmp_db_path):
+        """브로커가 NaN 수량을 보고해도 0 으로 정규화돼 판정이 결정적이다."""
+        tracker = make_tracker(tmp_db_path, {"hwm"})
+        tracker.register_symbol("AAPL", "NASDAQ", 150.0, Decimal("0"))
+        tracker.update_price("AAPL", "NASDAQ", 200.0)
+
+        class MockPT:
+            def get_workflow_positions(self):
+                return {"AAPL": type("P", (), {
+                    "symbol": "AAPL",
+                    "quantity": float("nan"),
+                    "avg_price": Decimal("150.0"),
+                    "exchange": "NASDAQ",
+                })()}
+
+        results = tracker.validate_hwm_on_restart(MockPT())
+        # NaN → 0 이므로 기억값 0 과 같다 → 수량 변동 없음(kept).
+        # 정규화가 없으면 nan != 0 으로 매번 reset 된다.
+        assert [r.action for r in results] == ["kept"]
+        assert tracker.get_hwm("AAPL").hwm_price == Decimal("200")
+
+
+# ============================================================
+# 14. 수량 0 추가매수 — 평단 0/0 나눗셈 방지
+# ============================================================
+
+class TestZeroQuantityAveraging:
+    """수량이 0 으로 정규화된 매수가 겹쳐도 평단 계산이 터지지 않아야 한다.
+
+    _to_qty_decimal 이 NaN/읽기 실패를 0 으로 접기 때문에, 같은 종목에 그런 매수가
+    두 번 오면 total_qty = 0 이 되어 `total_cost / total_qty` 가
+    decimal.InvalidOperation [DivisionUndefined] 로 터졌다(검토자 라이브 재현).
+    """
+
+    def test_repeated_zero_qty_buy_does_not_raise(self, tmp_db_path, caplog):
+        import logging
+
+        tracker = make_tracker(tmp_db_path, {"hwm"})
+        tracker.register_symbol("AAPL", "NASDAQ", 150.0, Decimal("0"))
+
+        with caplog.at_level(logging.WARNING):
+            tracker.register_symbol("AAPL", "NASDAQ", 170.0, Decimal("0"))
+
+        state = tracker.get_hwm("AAPL")
+        assert state.position_qty == Decimal("0")
+        # 평단은 계산할 근거가 없으므로 직전 값을 유지한다(170 으로 덮어쓰지 않는다).
+        assert state.position_avg_price == Decimal("150.0")
+        assert any("평단 갱신 불가" in r.message for r in caplog.records)
+
+    def test_repeated_nan_qty_buy_does_not_raise(self, tmp_db_path):
+        """NaN 수량 두 번(→ 0 + 0)도 예외 없이 넘어간다."""
+        tracker = make_tracker(tmp_db_path, {"hwm"})
+        tracker.register_symbol("AAPL", "NASDAQ", 150.0, float("nan"))
+        tracker.register_symbol("AAPL", "NASDAQ", 160.0, float("nan"))
+
+        state = tracker.get_hwm("AAPL")
+        assert state.position_qty == Decimal("0")
+        assert state.position_avg_price == Decimal("150.0")
+        assert state.hwm_price == Decimal("150.0")  # HWM 은 추가매수로 건드리지 않는다
+
+    def test_normal_additional_buy_still_averages(self, tmp_db_path):
+        """가드가 정상 추가매수 경로를 막지 않는다(회귀 방지)."""
+        tracker = make_tracker(tmp_db_path, {"hwm"})
+        tracker.register_symbol("AAPL", "NASDAQ", 100.0, Decimal("0.5"))
+        tracker.register_symbol("AAPL", "NASDAQ", 120.0, Decimal("0.5"))
+
+        state = tracker.get_hwm("AAPL")
+        assert state.position_qty == Decimal("1.0")
+        assert state.position_avg_price == Decimal("110")
+
+    def test_zero_qty_buy_onto_existing_position_keeps_avg(self, tmp_db_path):
+        """기존 수량이 있으면 0 수량 추가매수는 평단을 희석하지 않는다."""
+        tracker = make_tracker(tmp_db_path, {"hwm"})
+        tracker.register_symbol("AAPL", "NASDAQ", 100.0, Decimal("2"))
+        tracker.register_symbol("AAPL", "NASDAQ", 500.0, Decimal("0"))
+
+        state = tracker.get_hwm("AAPL")
+        assert state.position_qty == Decimal("2")
+        assert state.position_avg_price == Decimal("100")


### PR DESCRIPTION
## Summary
LS 브로커 필드 의미를 오너가 확인해준 사실(체결번호·AP처리시각·소수점 주식·TC3 조건부 필드·국내 매체코드)로 코드를 전수 대조해 확정된 결함을 고친 릴리스 — **엔진 1.37.0 · finance 1.9.6 · community 1.15.2** (core 1.28.0 변경 없음, lockstep 검사 통과).

체결 **분류**가 깨지던 경로:
- 국내주식 신규주문이 원장에 기록되지 않아 국내 체결이 한 건도 `workflow` 로 분류될 수 없었음
- 정정 후 새 주문번호 미기록 → 오분류. 해외선물 정정 `BnsTpCode` 가 존재할 수 없는 config 키에서 항상 '매수'
- 주문 기록(접수 로컬 날짜)↔AS1 체결(수신 로컬 날짜)이 KST 자정을 넘기면 갈려 `unknown_api` 로 / LS 야간장 영업일 파일링(TC3)으로 반대 방향
- SC1 `execno`·TC3 `ccls_no` 미독출 → 원장 중복방지 비활성
- AS1 이 `proctm`(AP처리시각)을 체결시각 자리에 사용, 합성 `now()` 폴백
- TC3 매체코드 `'40'` 하드코딩(프레임에 없는 값), 국내 매체코드 60/50 미등재
- 소수점 주식 `int()` 절삭(RealAccountNode·HWM·플러그인), `executed_qty` 필드명 오타

수정 상세는 `src/programgarden/CHANGELOG.md` 1.37.0 항목. 주문일자 D±1 창은 **가드 6종**(후보 1건·종목·방향·사람 매체코드 거부·시각 12h 휴리스틱·체결수량≤주문수량)을 모두 요구하며, 각 가드는 떼어내면 오매칭이 재현되는 것을 테스트로 고정했습니다.

## Validation
- engine **1690 passed** · community **1733 passed**(31 failed 는 HEAD 기준선과 동일한 선택 의존성 미설치) · finance **3026 passed**
- 리플레이 하네스 12/12(오프라인) · dev dsl-api 왕복 포함 **18/18**
- 6라운드 구현 → 적대적 검토 → 재현 확인 워크플로우

## 미관측 / 후속
- `sExecTime` 형식·타임존은 라이브 미관측(월 2026-09-14 주간장 1주 체결로 확정 예정). 국내 매체코드 60/50 은 오너 진술 출처.
- SC2/SC3 미구독, `_ls_korea_stock_order_event` 파서, `_parse_tc3_data` `fill_price` 키, 트레이앱 `on_order_fill`, `partial_take_profit` 상태 경로 — 별건.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jgvXMHMiFPHPEsadb6ydr
