### PR TITLE
fix: 1.37.1 — 주문이벤트 노드 스트림별 등록·TC3 체결가·로그인 실패 승격·상태 플러그인 정렬 (finance 1.9.7 / community 1.15.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "programgarden"
-version = "1.37.0"
+version = "1.37.1"
 description = "LS증권 API을 메인으로 제작된 노코딩 시스템 트레이딩 DSL 오픈소스"
 authors = [
     {name = "장용준",email = "coding@programgarden.com"}

--- a/src/community/CHANGELOG.md
+++ b/src/community/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [1.15.3] - 2026-09-12
+### Fixed
+- **상태 기반 플러그인 5종의 트래커 메서드명 정렬 (time_based_exit / pair_trading / beta_hedge / correlation_guard /
+  roll_management) + partial_take_profit** — 실제 `WorkflowRiskTracker` 에 없는 `get_state`/`set_state`(및 `record_event`)
+  를 부르던 결함. `time_based_exit` 는 실제 트래커 + 포지션 1건에서 `AttributeError` 로 즉사(엔진 1.37.1 이 positions
+  분기에 context 를 넘기게 되면서 드러남), 나머지는 `except: pass` 가 삼켜 상태·이벤트가 한 번도 기록되지 않았다.
+  실제 이름 `load_state`/`save_state`/`delete_state`/`record_risk_event(details=)` 를 **동기** 호출하고, hasattr 3종으로
+  has_state 를 판정해 다른 트래커 변종은 크래시 대신 무상태 강등, 실패는 삼키지 않고 warning 로그.
+- **var_cvar_monitor 위험 이벤트가 한 건도 기록되지 않던 결함** — 실제 트래커에 없는 `record_event(data=)` 를 부르고
+  `except: pass` 가 삼켰다. `record_risk_event(event_type="var_breach", severity, symbol, details=)` 로 정렬, 실패는
+  warning. 이로써 커뮤니티 플러그인에 남은 잘못된 트래커 메서드명은 0건(grep 실측).
+- **partial_take_profit 분할 익절이 매 사이클 재발동하던 결함** — 상태 경로가 죽어 `level_index=0` 으로 되돌아가
+  3사이클 연속 50% 매도가 재현됐다. 실제 트래커로 단계·최초수량이 왕복한다(엔진 1.37.1 필요).
+- **time_based_exit 보유일수가 실제로 자란다** — 종전엔 상태가 죽어 매 사이클 entry_date=오늘 → hold_days=0 으로
+  영영 청산하지 않았다. 이제 처음 관측한 날이 진입일로 고정된다(브로커 체결일 아님 — 워크플로우 시작 전 보유분은
+  첫 실행일). docstring 이 약속했던 '사라진 종목 상태 자동 정리' 스윕 구현(없으면 재매수 직후 거짓 exit 위험).
+  `analysis.stale_state_cleared` 추가.
+- **correlation_guard 히스테리시스가 실제로 동작** — 경계 구간의 '이전 regime 유지' 가 종전엔 항상 normal 이었다.
+  `beta_hedge`/`correlation_guard` 위험 이벤트(`beta_deviation`/`high_correlation`)가 이제 risk_events 에 기록된다.
+- 테스트: 6개 파일의 목 트래커를 실제 시그니처 fake 로 교체하고, 실제 `WorkflowRiskTracker`(sqlite) 왕복 테스트를
+  추가. 공허했던 `test_hysteresis`(픽스처 avg=1.0 → threshold 0.99 로는 경계 구간 아님) 실효화.
+
 ## [1.15.2] - 2026-09-12
 ### Fixed
 - **포지션 값 강제(coercion) 전수 정리** — 12개 플러그인(beta_hedge / correlation_guard / drawdown_protection /

--- a/src/community/programgarden_community/plugins/beta_hedge/__init__.py
+++ b/src/community/programgarden_community/plugins/beta_hedge/__init__.py
@@ -10,13 +10,32 @@ BetaHedge (베타 헷지) 플러그인
 - positions (선택): 보유 포지션 (list[dict]) — 포트폴리오 베타 계산용
   예: [{"symbol": "AAPL", "current_price": 150.0, "qty": 100, ...}, ...]
 - fields: {lookback, market_symbol, target_beta, beta_tolerance, hedge_method, ...}
+
+상태(strategy_state)·이벤트 경로 — 2026-09-12 수정
+--------------------------------------------------------------------------------
+계산된 포트폴리오 베타를 ``portfolio_beta`` 키에 저장하고(값 float → 트래커 'float'
+타입으로 그대로 왕복), 헷지가 필요하면 ``beta_deviation`` 위험 이벤트를 남긴다. 상태는
+**write-only** 다 — 이 플러그인은 되읽지 않는다. 키는 노드별로 나뉘지 않는다(같은
+워크플로우에 BetaHedge 노드를 둘 이상 두면 마지막 값이 남는다).
+
+2026-09-12 이전에는 실제 트래커 ``programgarden.database.workflow_risk_tracker.
+WorkflowRiskTracker`` 에 없는 ``set_state``/``record_event`` 를 불렀고 ``except: pass``
+가 그 AttributeError 를 삼켜 상태도 이벤트도 **한 번도 기록되지 않았다**(data 기반
+분기는 예전부터 context 를 넘겼으므로 라이브에서도 같은 경로였다 — 코드 대조 기준).
+이제 실제 이름 ``save_state`` / ``record_risk_event(event_type, severity, symbol, exchange,
+details, node_id)`` 를 동기 호출하고, 실패는 삼키지 않고 logger.warning 으로 남긴다.
+``load_state``/``save_state``/``delete_state`` 셋이 전부 없는 트래커 변종이면 크래시
+대신 **무상태로 강등**한다(저장·이벤트 생략). dry_run 에서는 트래커가 뜨지 않는다.
 """
 
+import logging
 from typing import List, Dict, Any, Optional, Set
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
 from .._position_qty import coerce_qty
+
+logger = logging.getLogger(__name__)
 
 
 # risk_features 선언
@@ -343,34 +362,50 @@ async def beta_hedge_condition(
                 "reduce_by_pct": min(max_hedge_pct, round(abs(beta_deviation) * 20, 2)),
             }
 
-    # state 저장
-    has_risk_tracker = context and hasattr(context, "risk_tracker") and context.risk_tracker
-    if has_risk_tracker and portfolio_beta is not None:
+    # state / risk_event — 메서드 이름·호출 규약은 **실제 트래커**(WorkflowRiskTracker)에
+    # 맞춘다: save_state / load_state / delete_state, record_risk_event(event_type, severity,
+    # symbol, exchange, details, node_id) — 전부 동기. 종전의 set_state / record_event 는 실제
+    # 클래스에 없는 이름이라 except 가 AttributeError 를 삼켜 상태도 이벤트도 **한 번도
+    # 기록되지 않았다**. 필요한 메서드가 없는 트래커 변종이면 크래시 대신 그 경로만 끈다.
+    _tracker = getattr(context, "risk_tracker", None) if context else None
+    has_state = _tracker is not None and all(
+        hasattr(_tracker, name) for name in ("load_state", "save_state", "delete_state")
+    )
+    has_events = _tracker is not None and hasattr(_tracker, "record_risk_event")
+
+    if has_state and portfolio_beta is not None:
         # 계산되지 않은 베타를 상태에 저장하면 다음 회차가 그 거짓값을 읽는다.
+        # 값은 float → 트래커 'float' 타입으로 그대로 왕복한다.
         try:
-            context.risk_tracker.set_state("portfolio_beta", portfolio_beta)
-        except Exception:
-            pass
+            if not _tracker.save_state("portfolio_beta", portfolio_beta):
+                logger.warning(
+                    "BetaHedge: 상태 저장 실패 (portfolio_beta) — 트래커가 False 를 돌려줌 "
+                    "('state' feature 없음 또는 DB 쓰기 실패)"
+                )
+        except Exception as e:
+            logger.warning(f"BetaHedge: 상태 저장 실패 (portfolio_beta): {e}")
 
     # risk_event 기록
-    if hedge_needed and has_risk_tracker:
+    if hedge_needed and has_events:
         try:
-            # 🔴 record_event 는 실제 트래커에 없는 메서드다 (관측 2026-09-12):
-            #    WorkflowRiskTracker 의 실제 이름은 record_risk_event 다. 아래 except 가
-            #    AttributeError 를 삼키므로 이 위험 이벤트는 **한 건도 기록되지 않는다**.
-            #    메서드명 정렬은 이 플러그인 밖(엔진) 수정이라 여기서 고치지 않는다 — 미검증.
-            context.risk_tracker.record_event(
+            event_id = _tracker.record_risk_event(
                 event_type="beta_deviation",
+                severity="warning",
                 symbol="PORTFOLIO",
-                data={
+                details={
                     "portfolio_beta": portfolio_beta,
                     "target_beta": target_beta,
                     "deviation": round(beta_deviation, 4),
                     "hedge_method": hedge_method,
                 },
             )
-        except Exception:
-            pass
+            if event_id is None:
+                logger.warning(
+                    "BetaHedge: 위험 이벤트 기록 실패 (beta_deviation) — 트래커가 None 을 돌려줌 "
+                    "('events' feature 없음 또는 INSERT 실패)"
+                )
+        except Exception as e:
+            logger.warning(f"BetaHedge: 위험 이벤트 기록 실패 (beta_deviation): {e}")
 
     # 결과 정리
     for bd in beta_data:

--- a/src/community/programgarden_community/plugins/correlation_guard/__init__.py
+++ b/src/community/programgarden_community/plugins/correlation_guard/__init__.py
@@ -7,11 +7,33 @@ regime 전환(히스테리시스) 및 포지션 축소를 추천합니다.
 입력 형식:
 - data: 플랫 배열 (2개 이상 종목 데이터 포함)
 - fields: {lookback, correlation_threshold, recovery_threshold, action, reduce_by_pct, method}
+
+상태(strategy_state)·이벤트 경로 — 2026-09-12 수정
+--------------------------------------------------------------------------------
+히스테리시스의 '이전 regime' 은 ``correlation_guard_regime`` 키에서 되읽고(값 str →
+트래커 'string' 타입으로 그대로 왕복), 매 사이클 현재 regime 을 다시 저장한다. 트리거
+시 ``high_correlation`` 위험 이벤트를 남긴다. 키는 노드별로 나뉘지 않는다 — 같은
+워크플로우에 CorrelationGuard 노드를 둘 이상 두면 regime 을 공유한다.
+
+2026-09-12 이전에는 실제 트래커 ``programgarden.database.workflow_risk_tracker.
+WorkflowRiskTracker`` 에 없는 ``get_state``/``set_state``/``record_event`` 를 불렀고
+``except: pass`` 가 그 AttributeError 를 삼켰다 → prev_regime 은 언제나 "normal"
+(경계 구간 recovery_threshold < avg < correlation_threshold 의 '이전 상태 유지' 가
+사실상 '항상 normal'), 이벤트는 한 건도 남지 않았다(data 기반 분기는 예전부터 context
+를 넘겼으므로 라이브에서도 같은 경로였다 — 코드 대조 기준). 이제 실제 이름
+``load_state``/``save_state``/``record_risk_event(event_type, severity, symbol, exchange,
+details, node_id)`` 를 동기 호출하고, 실패는 삼키지 않고 logger.warning 으로 남긴다.
+``load_state``/``save_state``/``delete_state`` 셋이 전부 없는 트래커 변종이면 크래시
+대신 **무상태로 강등**한다(prev_regime="normal", 저장·이벤트 생략). dry_run 에서는
+트래커가 뜨지 않는다.
 """
 
+import logging
 from typing import List, Dict, Any, Optional, Set
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
+
+logger = logging.getLogger(__name__)
 
 
 # risk_features 선언
@@ -262,25 +284,33 @@ async def correlation_guard_condition(
     else:
         avg_correlation = 0.0
 
-    # regime 결정 (히스테리시스)
-    prev_regime = "normal"
-    has_risk_tracker = context and hasattr(context, "risk_tracker") and context.risk_tracker
+    # regime 결정 (히스테리시스) — 이전 regime 은 strategy_state 에서 되읽는다.
+    # 메서드 이름·호출 규약은 **실제 트래커**(WorkflowRiskTracker)에 맞춘다: load_state /
+    # save_state / delete_state, record_risk_event(event_type, severity, symbol, exchange,
+    # details, node_id) — 전부 동기. 종전의 get_state/set_state/record_event 는 실제 클래스에
+    # 없는 이름이라 except 가 AttributeError 를 삼켜 prev_regime 이 언제나 "normal" 이었고
+    # 이벤트도 한 건도 남지 않았다. 필요한 메서드가 없는 트래커 변종이면 크래시 대신 그
+    # 경로만 끈다(무상태 강등). 모듈 docstring 참조.
+    _tracker = getattr(context, "risk_tracker", None) if context else None
+    has_state = _tracker is not None and all(
+        hasattr(_tracker, name) for name in ("load_state", "save_state", "delete_state")
+    )
+    has_events = _tracker is not None and hasattr(_tracker, "record_risk_event")
 
-    if has_risk_tracker:
-        # 🔴 이 히스테리시스 상태 읽기/쓰기는 실제로 동작하지 않는다 (관측 2026-09-12):
-        #    실제 트래커 programgarden.database.workflow_risk_tracker.WorkflowRiskTracker
-        #    에는 get_state/set_state 가 없다(save_state/load_state/delete_state 뿐).
-        #    아래 except 가 그 AttributeError 를 삼키므로 prev_regime 은 언제나
-        #    "normal" 이고, 경계 구간(recovery_threshold < corr < corr_threshold)의
-        #    '이전 상태 유지' 는 사실상 '항상 normal' 로 동작한다.
-        #    메서드명 정렬은 이 플러그인 밖(엔진) 수정이라 여기서 고치지 않는다 —
-        #    미검증 분기로 남긴다.
+    prev_regime = "normal"
+    if has_state:
         try:
-            state = context.risk_tracker.get_state("correlation_guard_regime")
-            if state:
-                prev_regime = state
-        except Exception:
-            pass
+            saved_regime = _tracker.load_state("correlation_guard_regime")
+        except Exception as e:
+            saved_regime = None
+            logger.warning(f"CorrelationGuard: 상태 조회 실패 (correlation_guard_regime): {e}")
+        if saved_regime in ("normal", "high_correlation"):
+            prev_regime = saved_regime
+        elif saved_regime:
+            logger.warning(
+                f"CorrelationGuard: 저장된 regime 을 읽을 수 없어 'normal' 로 간주 "
+                f"(value={saved_regime!r})"
+            )
 
     if avg_correlation >= corr_threshold:
         regime = "high_correlation"
@@ -291,27 +321,33 @@ async def correlation_guard_condition(
 
     triggered = regime == "high_correlation"
 
-    # state 저장
-    if has_risk_tracker:
+    # state 저장 — 값은 str → 트래커 'string' 타입으로 그대로 왕복한다
+    if has_state:
         try:
-            context.risk_tracker.set_state("correlation_guard_regime", regime)
-        except Exception:
-            pass
+            if not _tracker.save_state("correlation_guard_regime", regime):
+                logger.warning(
+                    "CorrelationGuard: 상태 저장 실패 (correlation_guard_regime) — 트래커가 False 를 "
+                    "돌려줌 ('state' feature 없음 또는 DB 쓰기 실패)"
+                )
+        except Exception as e:
+            logger.warning(f"CorrelationGuard: 상태 저장 실패 (correlation_guard_regime): {e}")
 
     # risk_event 기록
-    if triggered and has_risk_tracker:
+    if triggered and has_events:
         try:
-            # 🔴 record_event 는 실제 트래커에 없는 메서드다 (관측 2026-09-12):
-            #    WorkflowRiskTracker 의 실제 이름은 record_risk_event 다. 아래 except 가
-            #    AttributeError 를 삼키므로 이 위험 이벤트는 **한 건도 기록되지 않는다**.
-            #    메서드명 정렬은 이 플러그인 밖(엔진) 수정이라 여기서 고치지 않는다 — 미검증.
-            context.risk_tracker.record_event(
+            event_id = _tracker.record_risk_event(
                 event_type="high_correlation",
+                severity="warning",
                 symbol="PORTFOLIO",
-                data={"avg_correlation": avg_correlation, "threshold": corr_threshold, "action": action},
+                details={"avg_correlation": avg_correlation, "threshold": corr_threshold, "action": action},
             )
-        except Exception:
-            pass
+            if event_id is None:
+                logger.warning(
+                    "CorrelationGuard: 위험 이벤트 기록 실패 (high_correlation) — 트래커가 None 을 "
+                    "돌려줌 ('events' feature 없음 또는 INSERT 실패)"
+                )
+        except Exception as e:
+            logger.warning(f"CorrelationGuard: 위험 이벤트 기록 실패 (high_correlation): {e}")
 
     # 결과 집계
     passed, failed, symbol_results, values = [], [], [], []

--- a/src/community/programgarden_community/plugins/pair_trading/__init__.py
+++ b/src/community/programgarden_community/plugins/pair_trading/__init__.py
@@ -9,12 +9,29 @@ CorrelationAnalysis와 차별: 상관계수 측정이 아닌 진입/청산 신�
 - fields: {symbol_a, symbol_b, lookback, entry_z, exit_z, spread_method, correlation_min}
 
 ※ 다중 종목 플러그인 - ConditionNode auto-iterate 제약 → NodeRunner 테스트 권장
+
+상태(strategy_state) 경로 — 2026-09-12 수정
+--------------------------------------------------------------------------------
+마지막 신호를 ``pair_{symbol_a}_{symbol_b}`` 키에 저장한다(값 str → 트래커 'string'
+타입으로 그대로 왕복). **write-only 이력**이다 — 이 플러그인은 되읽지 않는다.
+
+2026-09-12 이전에는 실제 트래커 ``programgarden.database.workflow_risk_tracker.
+WorkflowRiskTracker`` 에 없는 ``set_state`` 를 불렀고 ``except: pass`` 가 그
+AttributeError 를 삼켜 **한 번도 저장되지 않았다**(data 기반 분기는 예전부터 context 를
+넘겼으므로 라이브에서도 같은 경로였다 — 코드 대조 기준). 이제 실제 이름
+``save_state`` 를 동기 호출하고, 실패는 삼키지 않고 logger.warning 으로 남긴다.
+``load_state``/``save_state``/``delete_state`` 셋이 전부 없는 트래커 변종이면 크래시
+대신 **무상태로 강등**한다(저장 생략). ``state`` feature 없이 만들어진 실제 트래커는
+save_state 가 False 를 돌려주며 warning 만 남는다. dry_run 에서는 트래커가 뜨지 않는다.
 """
 
+import logging
 import math
 from typing import List, Dict, Any, Optional, Set
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
+
+logger = logging.getLogger(__name__)
 
 
 # risk_features 선언 (페어 상태 추적)
@@ -300,13 +317,25 @@ async def pair_trading_condition(
     elif abs(z_score) < exit_z:
         signal = "exit"
 
-    # state 저장
-    has_risk_tracker = context and hasattr(context, "risk_tracker") and context.risk_tracker
-    if has_risk_tracker and signal:
+    # state 저장 — 마지막 신호 이력(write-only: 이 플러그인은 되읽지 않는다).
+    # 메서드 이름·호출 규약은 **실제 트래커**(WorkflowRiskTracker)에 맞춘다 —
+    # load_state / save_state / delete_state, 전부 동기. 종전의 set_state 는 실제 클래스에
+    # 없는 이름이라 except 가 AttributeError 를 삼켜 **한 번도 저장되지 않았다**.
+    # 셋이 전부 있을 때만 켜고, 다른 트래커 변종이면 무상태로 강등한다(모듈 docstring 참조).
+    _tracker = getattr(context, "risk_tracker", None) if context else None
+    has_state = _tracker is not None and all(
+        hasattr(_tracker, name) for name in ("load_state", "save_state", "delete_state")
+    )
+    if has_state and signal:
+        state_key = f"pair_{symbol_a}_{symbol_b}"
         try:
-            context.risk_tracker.set_state(f"pair_{symbol_a}_{symbol_b}", signal)
-        except Exception:
-            pass
+            if not _tracker.save_state(state_key, signal):
+                logger.warning(
+                    f"PairTrading: 상태 저장 실패 ({state_key}) — 트래커가 False 를 돌려줌 "
+                    "('state' feature 없음 또는 DB 쓰기 실패)"
+                )
+        except Exception as e:
+            logger.warning(f"PairTrading: 상태 저장 실패 ({state_key}): {e}")
 
     # 결과 구성
     exchange_a = symbol_exchange_map.get(symbol_a, "UNKNOWN")

--- a/src/community/programgarden_community/plugins/partial_take_profit/__init__.py
+++ b/src/community/programgarden_community/plugins/partial_take_profit/__init__.py
@@ -3,9 +3,8 @@ PartialTakeProfit (분할 익절) 플러그인
 
 여러 단계에서 분할 매도하여 리스크를 줄이면서 수익 확보.
 - levels: [{pnl_pct: 5, sell_pct: 50}, {pnl_pct: 10, sell_pct: 30}, {pnl_pct: 20, sell_pct: 20}]
-- strategy_state로 완료된 단계 추적 (⚠️ 의도일 뿐 — 아래 '상태 경로는 라이브에서
-  동작하지 않는다' 절 참조)
-- 포지션 청산 시 상태 자동 삭제 (같은 이유로 미검증)
+- strategy_state로 완료된 단계 추적
+- 포지션 청산 시 상태 자동 삭제
 
 입력 형식:
 - positions: RealAccountNode의 positions 출력 (list[dict])
@@ -13,31 +12,27 @@ PartialTakeProfit (분할 익절) 플러그인
 - fields: {levels}
 - context: strategy_state 접근용 (선택)
 
-🔴 상태(strategy_state) 경로는 현재 **라이브에서 동작하지 않는다** (관측 2026-09-12)
+상태(strategy_state) 경로 — 2026-09-12 수정 전/후
 --------------------------------------------------------------------------------
-아래 ``get_state``/``set_state``/``delete_state`` 헬퍼는 두 가지 이유로 실행기
-경로에서 실제로 돌지 않는다. 둘 다 이 파일 밖(엔진 쪽)의 문제이며 여기서 고치지
-않는다 — 아래 분기는 **미검증**이다.
+2026-09-12 이전에는 이 경로가 **라이브에서 죽어 있었다**. 두 가지 이유였고 둘 다
+이번에 닫혔다:
 
-1. 메서드 이름이 실제 트래커와 다르다. 실제 클래스
+1. 메서드 이름이 실제 트래커와 달랐다. 실제 클래스
    ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 에는
    ``get_state``/``set_state`` 가 **없다** — 있는 것은 ``save_state`` /
-   ``load_state`` / ``load_states`` / ``delete_state`` / ``delete_states`` 뿐이다
-   (그리고 이것들은 async 가 아니라 동기 메서드다). 실제 트래커를 가진 context 를
-   넘기면 이 경로는 ``AttributeError: 'WorkflowRiskTracker' object has no
-   attribute 'get_state'`` 로 즉사한다(실제 트래커 인스턴스로 재현 확인).
-2. 애초에 context 가 오지 않는다. 이 플러그인은 ``required_data=["positions"]``
-   라 실행기의 **positions 기반 분기**로 도는데, 그 분기
-   (``ConditionNodeExecutor.execute``, programgarden/executor.py — plugin_kwargs 가
-   ``{"positions": positions, "fields": evaluated_fields}`` 로 고정)는 ``context``
-   를 넘기지 않는다. 그래서 라이브에서는 항상 ``has_state`` 가 False 이고 상태는
-   저장·복원되지 않는다(context 없이 연속 호출하면 매번 같은 단계가 재발동하는
-   것으로 재현 확인).
+   ``load_state`` / ``load_states`` / ``delete_state`` / ``delete_states`` 이고
+   전부 **동기** 메서드다. 아래 헬퍼는 이제 그 실제 이름을 동기 호출한다.
+2. 애초에 context 가 오지 않았다. 이 플러그인은 ``required_data=["positions"]``
+   라 실행기의 positions 기반 분기로 도는데, 그 분기
+   (``ConditionNodeExecutor.execute``)가 plugin_kwargs 를
+   ``{"positions", "fields"}`` 로 고정해 ``context`` 를 넘기지 않았다. 이제
+   items/data 기반 분기와 같은 규약으로 **시그니처에 context 가 있으면 넘긴다**.
 
-따라서 위 docstring 의 "strategy_state 로 ... 추적/저장" 은 **의도**이지 현재
-동작이 아니다. 이 경로를 되살리려면 (a) 메서드명을 실제 트래커에 맞추고,
-(b) 실행기의 positions 분기가 context 를 넘기게 하고, (c) 동기/비동기 호출 규약을
-맞춰야 한다 — 전부 이 플러그인 파일 밖의 수정이다.
+남은 조건: 트래커는 ``state`` feature 로 초기화돼 있어야 한다(이 모듈이
+``risk_features = {"state"}`` 를 선언하므로 실행기가 워크플로우에 이 플러그인이
+있으면 그 feature 로 트래커를 만든다). feature 가 없으면 ``load_state`` 는 기본값
+None, ``save_state`` 는 False 를 돌려주고 — 그 경우 동작은 상태가 없던 종전과 같다
+(같은 단계가 매 사이클 재발동). dry_run 에서는 트래커 자체가 뜨지 않는다.
 """
 
 import json
@@ -147,25 +142,27 @@ async def partial_take_profit_condition(
         }
 
     # strategy_state 접근 헬퍼.
-    # 🔴 아래 세 함수는 라이브 실행기 경로에서 돌지 않는다 — 실행기의 positions 분기
-    #    (ConditionNodeExecutor.execute)가 context 를 넘기지 않아 has_state 가 항상
-    #    False 이고, 설령 실제 트래커를 넘겨도 WorkflowRiskTracker 에는
-    #    get_state/set_state 가 없어 AttributeError 로 죽는다. 모듈 docstring 의
-    #    '상태 경로는 라이브에서 동작하지 않는다' 절 참조. 미검증 분기.
-    has_state = context and hasattr(context, "risk_tracker") and context.risk_tracker
+    # 메서드 이름·호출 규약은 **실제 트래커**(WorkflowRiskTracker)에 맞춘다 —
+    # load_state / save_state / delete_state 이고 전부 동기다(await 하지 않는다).
+    # 종전의 get_state/set_state 는 실제 클래스에 없는 이름이라 실제 트래커를
+    # 넘기면 AttributeError 로 죽었다. 모듈 docstring 의 '상태 경로' 절 참조.
+    _tracker = getattr(context, "risk_tracker", None) if context else None
+    has_state = _tracker is not None and all(
+        hasattr(_tracker, name) for name in ("load_state", "save_state", "delete_state")
+    )
 
     async def get_state(key: str) -> Any:
         if has_state:
-            return await context.risk_tracker.get_state(key)
+            return _tracker.load_state(key)
         return None
 
     async def set_state(key: str, value: Any) -> None:
         if has_state:
-            await context.risk_tracker.set_state(key, value)
+            _tracker.save_state(key, value)
 
     async def delete_state(key: str) -> None:
         if has_state:
-            await context.risk_tracker.delete_state(key)
+            _tracker.delete_state(key)
 
     passed, failed, symbol_results = [], [], []
 
@@ -245,10 +242,12 @@ async def partial_take_profit_condition(
         original_qty_raw = await get_state(f"partial_tp.{symbol}.original_qty")
         # Decimal 로 복원되는 저장값도 받아들인다(구 isinstance(int, float) 검사는
         # Decimal 을 놓쳐 매 단계 '현재 수량' 기준으로 되돌아갔다).
-        # ⚠️ 이 분기는 **라이브에서 도달하지 않는다** — get_state 가 항상 None 을
-        #    돌려주므로(모듈 docstring 의 '상태 경로' 절) original_qty 는 늘 아래
-        #    폴백인 현재 qty 가 된다. Decimal 복원 자체는 목(MockRiskTracker)에서만
-        #    검증됐다.
+        # 저장 경로는 이제 라이브에서 실제로 돈다(2026-09-12 상태 경로 복구).
+        # 다만 Decimal 복원은 **이 플러그인이 만드는 값에서는 나오지 않는다** —
+        # 아래 set_state 가 싣는 값은 preserve_qty 의 int/float 이고, 트래커는
+        # 선언 타입대로 되돌려준다(_serialize/_deserialize_state_value: int→int,
+        # float→float, Decimal→Decimal). Decimal 수용은 다른 기록자(HWM 트래커의
+        # Decimal 수량 등)가 같은 키를 쓸 때를 위한 방어다.
         original_qty_state = coerce_qty(original_qty_raw)
         original_qty = (
             original_qty_state

--- a/src/community/programgarden_community/plugins/roll_management/__init__.py
+++ b/src/community/programgarden_community/plugins/roll_management/__init__.py
@@ -8,8 +8,23 @@ RollManagement (롤오버 관리) 플러그인 - 선물 전용
 - positions: 선물 포지션 (list[dict])
   예: [{"symbol": "HSIZ25", "qty": 1, "current_price": 17500.0, "exchange": "HKEX", ...}, ...]
 - fields: {days_before_expiry, roll_strategy}
+
+상태(strategy_state) 경로 — 2026-09-12 수정
+--------------------------------------------------------------------------------
+롤 신호가 난 사이클마다 ``roll.{symbol}.signal_date`` 키에 그 날짜(``YYYY-MM-DD`` str →
+트래커 'string' 타입으로 그대로 왕복)를 저장한다. **write-only 이력**이다 — 이 플러그인은
+되읽지 않으며, 신호가 이어지는 동안 매 사이클 그날 날짜로 덮어쓴다(마지막 신호일).
+
+2026-09-12 이전에는 실제 트래커 ``programgarden.database.workflow_risk_tracker.
+WorkflowRiskTracker`` 에 없는 ``set_state`` 를 ``await`` 했고 ``except: pass`` 가 그
+AttributeError 를 삼켜 크래시는 없었지만 **이력이 한 번도 남지 않았다**. 이제 실제 이름
+``save_state`` 를 동기 호출하고, 실패는 삼키지 않고 logger.warning 으로 남긴다.
+``load_state``/``save_state``/``delete_state`` 셋이 전부 없는 트래커 변종이면 크래시
+대신 **무상태로 강등**한다(저장 생략). ``state`` feature 없이 만들어진 실제 트래커는
+save_state 가 False 를 돌려주며 warning 만 남는다. dry_run 에서는 트래커가 뜨지 않는다.
 """
 
+import logging
 from typing import Any, Dict, List, Optional, Set
 from datetime import datetime, timedelta
 
@@ -17,6 +32,8 @@ from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
 from .._position_qty import coerce_number, preserve_qty
+
+logger = logging.getLogger(__name__)
 
 
 # risk_features 선언
@@ -160,6 +177,14 @@ async def roll_management_condition(
     now = datetime.now()
     passed, failed, symbol_results = [], [], []
 
+    # strategy_state 접근 — 메서드 이름·호출 규약은 **실제 트래커**(WorkflowRiskTracker)에
+    # 맞춘다: load_state / save_state / delete_state, 전부 동기(await 하지 않는다).
+    # 셋이 전부 있을 때만 켜고, 다른 트래커 변종이면 무상태로 강등한다(모듈 docstring 참조).
+    _tracker = getattr(context, "risk_tracker", None) if context else None
+    has_state = _tracker is not None and all(
+        hasattr(_tracker, name) for name in ("load_state", "save_state", "delete_state")
+    )
+
     for pos_data in positions:
         symbol = pos_data.get("symbol")
         if not symbol:
@@ -208,15 +233,17 @@ async def roll_management_condition(
         else:
             result_info["qty"] = qty
 
-        # state 저장 (롤오버 이력)
-        if should_roll and context and hasattr(context, "risk_tracker") and context.risk_tracker:
+        # state 저장 (롤오버 이력 — write-only: 이 플러그인은 되읽지 않는다)
+        if should_roll and has_state:
+            state_key = f"roll.{symbol}.signal_date"
             try:
-                await context.risk_tracker.set_state(
-                    f"roll.{symbol}.signal_date",
-                    now.strftime("%Y-%m-%d"),
-                )
-            except Exception:
-                pass
+                if not _tracker.save_state(state_key, now.strftime("%Y-%m-%d")):
+                    logger.warning(
+                        f"RollManagement: 상태 저장 실패 ({state_key}) — 트래커가 False 를 돌려줌 "
+                        "('state' feature 없음 또는 DB 쓰기 실패)"
+                    )
+            except Exception as e:
+                logger.warning(f"RollManagement: 상태 저장 실패 ({state_key}): {e}")
 
         symbol_results.append(result_info)
 

--- a/src/community/programgarden_community/plugins/time_based_exit/__init__.py
+++ b/src/community/programgarden_community/plugins/time_based_exit/__init__.py
@@ -2,10 +2,9 @@
 TimeBasedExit (시간 기반 청산) 플러그인
 
 보유 기간이 설정된 일수를 초과하면 자동 청산 시그널 발생.
-- strategy_state에 진입일 저장 (⚠️ 의도일 뿐 — 아래 '상태 경로는 라이브에서
-  동작하지 않는다' 절 참조)
-- 포지션 청산 시 상태 자동 삭제 (같은 이유로 미검증)
-- 포지션이 사라진 종목의 상태도 자동 정리
+- strategy_state 에 진입일(이 플러그인이 포지션을 **처음 관측한 날**) 저장
+- 포지션 청산(qty 0) 시 상태 자동 삭제
+- 포지션이 사라진 종목(positions 에 더 이상 없음)의 상태도 자동 정리
 
 입력 형식:
 - positions: RealAccountNode의 positions 출력 (list[dict])
@@ -13,33 +12,51 @@ TimeBasedExit (시간 기반 청산) 플러그인
 - fields: {max_hold_days, warn_days}
 - context: strategy_state 접근용 (선택)
 
-🔴 상태(strategy_state) 경로는 현재 **라이브에서 동작하지 않는다** (관측 2026-09-12)
+상태(strategy_state) 경로 — 2026-09-12 수정 전/후
 --------------------------------------------------------------------------------
-아래 ``get_state``/``set_state``/``delete_state`` 헬퍼는 두 가지 이유로 실행기
-경로에서 실제로 돌지 않는다. 둘 다 이 파일 밖(엔진 쪽)의 문제이며 여기서 고치지
-않는다 — 아래 분기는 **미검증**이다.
+2026-09-12 이전에는 이 경로가 **라이브에서 죽어 있었다**. 두 가지 이유였고 둘 다
+이번에 닫혔다:
 
-1. 메서드 이름이 실제 트래커와 다르다. 실제 클래스
+1. 메서드 이름·호출 규약이 실제 트래커와 달랐다. 실제 클래스
    ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 에는
    ``get_state``/``set_state`` 가 **없다** — 있는 것은 ``save_state`` /
-   ``load_state`` / ``load_states`` / ``delete_state`` / ``delete_states`` 뿐이다
-   (그리고 이것들은 async 가 아니라 동기 메서드다). 실제 트래커를 가진 context 를
-   넘기면 이 경로는 ``AttributeError: 'WorkflowRiskTracker' object has no
-   attribute 'get_state'`` 로 즉사한다(실제 트래커 인스턴스로 재현 확인).
-2. 애초에 context 가 오지 않는다. 이 플러그인은 ``required_data=["positions"]``
-   라 실행기의 **positions 기반 분기**로 도는데, 그 분기
-   (``ConditionNodeExecutor.execute``, programgarden/executor.py — plugin_kwargs 가
-   ``{"positions": positions, "fields": evaluated_fields}`` 로 고정)는 ``context``
-   를 넘기지 않는다. 그래서 라이브에서는 항상 ``has_state`` 가 False 이고 상태는
-   저장·복원되지 않는다(context 없이 연속 호출하면 매번 같은 단계가 재발동하는
-   것으로 재현 확인).
+   ``load_state`` / ``load_states`` / ``delete_state`` / ``delete_states`` 이고
+   전부 **동기** 메서드다. 실제 트래커를 넘기면 첫 포지션에서
+   ``AttributeError: 'WorkflowRiskTracker' object has no attribute 'get_state'`` 로
+   즉사했다(실제 인스턴스로 재현). 아래 헬퍼는 이제 실제 이름을 동기 호출한다.
+2. 애초에 context 가 오지 않았다. 이 플러그인은 ``required_data=["positions"]``
+   라 실행기의 positions 기반 분기로 도는데, 그 분기(``ConditionNodeExecutor.execute``)
+   가 plugin_kwargs 를 ``{"positions", "fields"}`` 로 고정해 ``context`` 를 넘기지
+   않았다. 이제 items/data 기반 분기와 같은 규약으로 **시그니처에 context 가 있으면
+   넘긴다**(executor 쪽 수정).
 
-따라서 위 docstring 의 "strategy_state 로 ... 추적/저장" 은 **의도**이지 현재
-동작이 아니다. 이 경로를 되살리려면 (a) 메서드명을 실제 트래커에 맞추고,
-(b) 실행기의 positions 분기가 context 를 넘기게 하고, (c) 동기/비동기 호출 규약을
-맞춰야 한다 — 전부 이 플러그인 파일 밖의 수정이다.
+켜졌을 때의 의미 (수정 전과 달라지는 동작)
+- 수정 전: 매 사이클 entry_date=오늘 → hold_days=0 → **영영 청산하지 않았다**.
+- 수정 후: entry_date 는 이 플러그인이 그 종목을 **처음 관측한 날**로 고정되고 이후
+  사이클에서 덮어쓰지 않는다 → hold_days 가 실제로 자라 max_hold_days 에 exit 가 난다.
+  ⚠️ '진입일' 은 브로커 체결일이 아니다. 워크플로우가 돌기 전부터 보유하던 포지션은
+  워크플로우 **첫 실행일**이 진입일이 된다(output_fields.entry_date 설명 참조).
+- 저장 형식: ISO 문자열 ``YYYY-MM-DD``. 트래커는 str 을 'string' 타입으로 저장하고
+  그대로 되돌려주므로(``_serialize_state_value``/``_deserialize_state_value``)
+  ``date.fromisoformat`` 로 바로 복원된다. datetime/Decimal 을 싣지 않는다.
+- 저장 범위: 트래커 DB 는 ``{workflow_id}_workflow.db``, 키는 (product, provider,
+  trading_mode) 로 스코프된다 → 같은 워크플로우를 **재시작해도 entry_date 가 복원**된다.
+  다른 워크플로우는 다른 DB 라 서로 보이지 않는다.
+- 정리: qty 0 인 종목은 그 자리에서 삭제하고, positions 에 **없는** 종목(전량 매도 후
+  브로커가 목록에서 뺀 경우)은 사이클 끝에 ``load_states("time_exit.")`` 로 훑어 지운다
+  (positions 가 비어 있으면 전부 지운다 — 계좌가 비었다는 뜻이다). 정리하지 않으면
+  재매수 직후 옛 entry_date 로 hold_days 가 커져 **거짓 exit** 가 나기 때문이다.
+  같은 워크플로우에 TimeBasedExit 노드를 둘 이상 두고 positions 를 종목별로 갈라
+  넣는 구성은 키 네임스페이스(``time_exit.{symbol}.entry_date``)를 공유하므로
+  지원하지 않는다.
+- 강등: 트래커에 ``load_state``/``save_state``/``delete_state`` 셋이 전부 없으면(다른
+  트래커 변종) 상태 경로를 켜지 않고 **무상태로 강등**한다 — 크래시 대신 context 없이
+  부른 것과 같은 종전 동작(hold_days=0)이다. ``state`` feature 없이 만들어진 실제
+  트래커도 같다(load_state→None, save_state→False). dry_run 에서는 트래커 자체가 뜨지
+  않는다.
 """
 
+import logging
 from datetime import date, timedelta
 from typing import Any, Dict, List, Optional, Set
 
@@ -48,9 +65,14 @@ from programgarden_core.registry.plugin_registry import PluginCategory, ProductT
 
 from .._position_qty import preserve_qty
 
+logger = logging.getLogger(__name__)
+
 
 # risk_features: strategy_state 사용
 risk_features: Set[str] = {"state"}
+
+_STATE_PREFIX = "time_exit."
+_STATE_SUFFIX = ".entry_date"
 
 TIME_BASED_EXIT_SCHEMA = PluginSchema(
     id="TimeBasedExit",
@@ -82,8 +104,8 @@ TIME_BASED_EXIT_SCHEMA = PluginSchema(
     optional_fields=[],
     tags=["exit", "time", "holding_period"],
     output_fields={
-        "entry_date": {"type": "str", "description": "Detected entry date (YYYY-MM-DD)"},
-        "hold_days": {"type": "int", "description": "Number of days position has been held"},
+        "entry_date": {"type": "str", "description": "Entry date as first observed by this plugin (YYYY-MM-DD) - the first workflow cycle that saw the position, not the broker fill date"},
+        "hold_days": {"type": "int", "description": "Number of days position has been held (today - entry_date)"},
         "max_hold_days": {"type": "int", "description": "Maximum allowed holding days"},
         "warn": {"type": "bool", "description": "Whether the warning threshold has been crossed"},
         "action": {"type": "str", "description": "Recommended action: 'exit', 'warn', 'hold', 'cleared', or 'skip'"},
@@ -92,12 +114,48 @@ TIME_BASED_EXIT_SCHEMA = PluginSchema(
     locales={
         "ko": {
             "name": "시간 기반 청산",
-            "description": "보유 기간이 설정된 일수를 초과하면 자동으로 청산 시그널을 발생시킵니다. 진입일을 자동으로 추적합니다.",
+            "description": "보유 기간이 설정된 일수를 초과하면 자동으로 청산 시그널을 발생시킵니다. 처음 관측한 날을 진입일로 기록해 추적합니다.",
             "fields.max_hold_days": "최대 보유 일수",
             "fields.warn_days": "경고 시작 일수 (0 = 비활성)",
         },
     },
 )
+
+
+def _entry_date_key(symbol: str) -> str:
+    return f"{_STATE_PREFIX}{symbol}{_STATE_SUFFIX}"
+
+
+def _sweep_stale_entry_dates(tracker: Any, present_symbols: Set[str]) -> List[str]:
+    """positions 에 더 이상 없는 종목의 entry_date 상태를 지운다 (모듈 docstring '정리' 절).
+
+    ``load_states(prefix)`` 가 없는 트래커 변종이면 정리하지 않는다(무상태 강등과 같은
+    규약). 심볼에 점이 들어갈 수 있으므로(BRK.B) 키를 '.' 로 split 하지 않고
+    접두·접미를 잘라 심볼을 얻는다. 지운 심볼 목록을 돌려준다.
+    """
+    if tracker is None:
+        return []
+    load_states = getattr(tracker, "load_states", None)
+    if not callable(load_states):
+        return []
+    removed: List[str] = []
+    try:
+        keys = list(load_states(_STATE_PREFIX).keys())
+    except Exception as e:
+        logger.warning(f"TimeBasedExit: 상태 정리용 조회 실패 (prefix={_STATE_PREFIX}): {e}")
+        return []
+    for key in keys:
+        if not key.endswith(_STATE_SUFFIX):
+            continue
+        symbol = key[len(_STATE_PREFIX):-len(_STATE_SUFFIX)]
+        if not symbol or symbol in present_symbols:
+            continue
+        try:
+            tracker.delete_state(key)
+            removed.append(symbol)
+        except Exception as e:
+            logger.warning(f"TimeBasedExit: 상태 정리 실패 ({key}): {e}")
+    return removed
 
 
 async def time_based_exit_condition(
@@ -121,47 +179,65 @@ async def time_based_exit_condition(
     max_hold_days = fields.get("max_hold_days", 5)
     warn_days = fields.get("warn_days", 0)
 
+    # strategy_state 접근 헬퍼.
+    # 메서드 이름·호출 규약은 **실제 트래커**(WorkflowRiskTracker)에 맞춘다 —
+    # load_state / save_state / delete_state 이고 전부 동기다(await 하지 않는다).
+    # 셋이 전부 있을 때만 상태 경로를 켠다. 다른 트래커 변종이면 크래시 대신 무상태로
+    # 강등한다. 모듈 docstring 의 '상태 경로' 절 참조.
+    _tracker = getattr(context, "risk_tracker", None) if context else None
+    has_state = _tracker is not None and all(
+        hasattr(_tracker, name) for name in ("load_state", "save_state", "delete_state")
+    )
+
+    def get_state(key: str) -> Any:
+        if has_state:
+            return _tracker.load_state(key)
+        return None
+
+    def set_state(key: str, value: Any) -> None:
+        if not has_state:
+            return
+        try:
+            if not _tracker.save_state(key, value):
+                logger.warning(
+                    f"TimeBasedExit: 상태 저장 실패 ({key}) — 트래커가 False 를 돌려줌 "
+                    "('state' feature 없음 또는 DB 쓰기 실패)"
+                )
+        except Exception as e:
+            logger.warning(f"TimeBasedExit: 상태 저장 실패 ({key}): {e}")
+
+    def delete_state(key: str) -> None:
+        if not has_state:
+            return
+        try:
+            _tracker.delete_state(key)
+        except Exception as e:
+            logger.warning(f"TimeBasedExit: 상태 삭제 실패 ({key}): {e}")
+
     positions = positions or []
     if not positions:
+        # 계좌가 비었다 — 남아 있는 entry_date 는 전부 '사라진 종목' 의 것이다.
+        stale = _sweep_stale_entry_dates(_tracker if has_state else None, set())
         return {
             "passed_symbols": [],
             "failed_symbols": [],
             "symbol_results": [],
             "values": [],
             "result": False,
-            "analysis": {"error": "No positions data"},
+            "analysis": {"error": "No positions data", "stale_state_cleared": stale},
         }
-
-    # strategy_state 접근 헬퍼.
-    # 🔴 아래 세 함수는 라이브 실행기 경로에서 돌지 않는다 — 실행기의 positions 분기
-    #    (ConditionNodeExecutor.execute)가 context 를 넘기지 않아 has_state 가 항상
-    #    False 이고, 설령 실제 트래커를 넘겨도 WorkflowRiskTracker 에는
-    #    get_state/set_state 가 없어 AttributeError 로 죽는다. 모듈 docstring 의
-    #    '상태 경로는 라이브에서 동작하지 않는다' 절 참조. 미검증 분기.
-    has_state = context and hasattr(context, "risk_tracker") and context.risk_tracker
-
-    async def get_state(key: str) -> Any:
-        if has_state:
-            return await context.risk_tracker.get_state(key)
-        return None
-
-    async def set_state(key: str, value: Any) -> None:
-        if has_state:
-            await context.risk_tracker.set_state(key, value)
-
-    async def delete_state(key: str) -> None:
-        if has_state:
-            await context.risk_tracker.delete_state(key)
 
     today = date.today()
     today_str = today.isoformat()
 
     passed, failed, symbol_results = [], [], []
+    present_symbols: Set[str] = set()
 
     for pos_data in positions:
         symbol = pos_data.get("symbol")
         if not symbol:
             continue
+        present_symbols.add(symbol)
         raw_qty = pos_data.get("qty", pos_data.get("quantity", 0))
         exchange = pos_data.get("exchange") or pos_data.get("market_code", "UNKNOWN")
         exchange_map = {"81": "NYSE", "82": "NASDAQ", "83": "AMEX"}
@@ -188,7 +264,7 @@ async def time_based_exit_condition(
 
         # 수량 0이면 청산 완료 → 상태 삭제
         if qty <= 0:
-            await delete_state(f"time_exit.{symbol}.entry_date")
+            delete_state(_entry_date_key(symbol))
             failed.append(sym_dict)
             symbol_results.append({
                 "symbol": symbol, "exchange": exchange_name,
@@ -196,17 +272,23 @@ async def time_based_exit_condition(
             })
             continue
 
-        # 진입일 로드 또는 최초 감지
-        entry_date_str = await get_state(f"time_exit.{symbol}.entry_date")
+        # 진입일 로드 또는 최초 감지 — 처음 관측한 날을 고정하고 이후엔 덮어쓰지 않는다
+        entry_date_str = get_state(_entry_date_key(symbol))
         if not entry_date_str:
             entry_date_str = today_str
-            await set_state(f"time_exit.{symbol}.entry_date", entry_date_str)
+            set_state(_entry_date_key(symbol), entry_date_str)
 
         try:
             entry_date = date.fromisoformat(entry_date_str)
         except (ValueError, TypeError):
+            # 읽을 수 없는 저장값(형식 불일치)은 오늘로 다시 고정한다 — 사유를 남긴다.
+            logger.warning(
+                f"TimeBasedExit: 저장된 진입일을 읽을 수 없어 오늘로 재설정 "
+                f"(symbol={symbol}, value={entry_date_str!r})"
+            )
             entry_date = today
-            await set_state(f"time_exit.{symbol}.entry_date", today_str)
+            entry_date_str = today_str
+            set_state(_entry_date_key(symbol), today_str)
 
         hold_days = (today - entry_date).days
         is_warn = warn_days > 0 and hold_days >= (max_hold_days - warn_days) and hold_days < max_hold_days
@@ -226,6 +308,9 @@ async def time_based_exit_condition(
         else:
             failed.append(sym_dict)
 
+    # positions 에서 사라진 종목의 entry_date 정리 (모듈 docstring '정리' 절)
+    stale = _sweep_stale_entry_dates(_tracker if has_state else None, present_symbols)
+
     return {
         "passed_symbols": passed,
         "failed_symbols": failed,
@@ -238,6 +323,7 @@ async def time_based_exit_condition(
             "warn_days": warn_days,
             "total_positions": len(positions),
             "exit_count": len(passed),
+            "stale_state_cleared": stale,
         },
     }
 

--- a/src/community/programgarden_community/plugins/var_cvar_monitor/__init__.py
+++ b/src/community/programgarden_community/plugins/var_cvar_monitor/__init__.py
@@ -26,11 +26,14 @@ Value at Risk(VaR)와 Conditional VaR(CVaR, Expected Shortfall) 계산.
 이 플러그인의 범위 밖이다.)
 """
 
+import logging
 from typing import List, Dict, Any, Optional, Set
 from programgarden_core.registry import PluginSchema
 from programgarden_core.registry.plugin_registry import PluginCategory, ProductType
 
 from .._position_qty import below_broker_lot, coerce_qty, half_position_qty
+
+logger = logging.getLogger(__name__)
 
 
 # risk_features 선언
@@ -329,20 +332,31 @@ async def var_cvar_monitor_condition(
                     )
             passed.append(sym_dict)
 
-            # risk_event 기록
-            if context and hasattr(context, "risk_tracker") and context.risk_tracker:
+            # risk_event 기록 — 메서드 이름·호출 규약은 **실제 트래커**(WorkflowRiskTracker)의
+            # record_risk_event(event_type, severity, symbol, exchange, details, node_id) 에 맞춘다.
+            # 종전의 record_event(data=) 는 실제 클래스에 없는 이름이라 except 가 AttributeError 를
+            # 삼켜 var_breach 이벤트가 **한 건도 기록되지 않았다**(2026-09-12 코드 대조). 메서드가
+            # 없는 트래커 변종이면 크래시 대신 이 경로만 끄고, 실패는 삼키지 않고 warning 으로 남긴다.
+            _tracker = getattr(context, "risk_tracker", None) if context else None
+            if _tracker is not None and hasattr(_tracker, "record_risk_event"):
                 try:
-                    # 🔴 record_event 는 실제 트래커에 없는 메서드다 (관측 2026-09-12):
-                    #    WorkflowRiskTracker 의 실제 이름은 record_risk_event 다. 아래 except 가
-                    #    AttributeError 를 삼키므로 이 위험 이벤트는 **한 건도 기록되지 않는다**.
-                    #    메서드명 정렬은 이 플러그인 밖(엔진) 수정이라 여기서 고치지 않는다 — 미검증.
-                    context.risk_tracker.record_event(
+                    event_id = _tracker.record_risk_event(
                         event_type="var_breach",
+                        severity="warning",
                         symbol=symbol,
-                        data={"var_pct": var_pct, "threshold": alert_threshold, "action": action},
+                        details={"var_pct": var_pct, "threshold": alert_threshold, "action": action},
                     )
-                except Exception:
-                    pass
+                    if event_id is None:
+                        logger.warning(
+                            "var_cvar_monitor: record_risk_event returned None for %s "
+                            "(events feature off or DB write failed) — event not recorded", symbol
+                        )
+                except Exception as exc:  # noqa: BLE001 — 기록 실패가 조건 판정을 막으면 안 된다
+                    logger.warning("var_cvar_monitor: record_risk_event failed for %s: %s", symbol, exc)
+            elif _tracker is not None:
+                logger.warning(
+                    "var_cvar_monitor: risk_tracker has no record_risk_event — var_breach for %s not recorded", symbol
+                )
         else:
             failed.append(sym_dict)
 

--- a/src/community/pyproject.toml
+++ b/src/community/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-community"
-version = "1.15.2"
+version = "1.15.3"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden Community - 전략 플러그인 모음"
 readme = "README.md"

--- a/src/community/tests/test_beta_hedge_plugin.py
+++ b/src/community/tests/test_beta_hedge_plugin.py
@@ -1,24 +1,14 @@
 """
 BetaHedge (베타 헷지) 플러그인 테스트
 
-🔴 이 파일의 ``MockRiskTracker`` 는 **실제 클래스에 없는 메서드를 제공한다** (관측 2026-09-12)
+상태(strategy_state)·이벤트 경로 — 2026-09-12 수정
 ------------------------------------------------------------------------------------------
-실제 트래커 ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 의
-실제 인터페이스와 대조한 결과:
-
-| 목이 제공하는 이름 | 실제 클래스 | 비고 |
-|---|---|---|
-| ``get_state``   | **없음** | 실제 이름은 ``load_state`` (동기) |
-| ``set_state``   | **없음** | 실제 이름은 ``save_state`` (동기) |
-| ``delete_state``| 있음     | 단 **동기** 메서드 — 플러그인은 ``await`` 한다 |
-| ``record_event``| **없음** | 실제 이름은 ``record_risk_event`` |
-
-즉 아래 상태 관련 테스트들은 '플러그인이 라이브에서 실제로 상태를 저장·복원한다'
-를 증명하지 않는다 — **목이 약속한 계약대로 플러그인이 호출한다**는 것만 증명한다.
-라이브에서는 (가) 실제 트래커를 넘기면 ``AttributeError`` 로 죽고, (나) 애초에
-실행기가 positions 기반 플러그인에 ``context`` 를 넘기지 않아 상태 경로가 아예
-돌지 않는다(플러그인 모듈 docstring 의 '상태 경로' 절 참조).
-목을 실제 시그니처로 맞추는 수정은 이번 회차 범위 밖이다 — 후속 필요.
+``FakeRiskTracker`` 는 실제 트래커 ``programgarden.database.workflow_risk_tracker.
+WorkflowRiskTracker`` 의 **실제 시그니처**(``load_state``/``save_state``/``delete_state``/
+``record_risk_event`` — 전부 동기)를 흉내낸다. 종전 목은 실제 클래스에 없는
+``get_state``/``set_state``/``record_event`` 를 제공해, 테스트는 통과하는데 라이브에서는
+except 가 AttributeError 를 삼켜 상태도 이벤트도 한 건도 기록되지 않았다.
+``TestLiveStatePathIsAlive`` 가 **실제 트래커 인스턴스**로 그 사실을 고정한다.
 """
 
 import pytest
@@ -30,31 +20,54 @@ from programgarden_community.plugins.beta_hedge import (
 )
 
 
-class MockRiskTracker:
-    """strategy_state **목 계약** 모킹 — 실제 WorkflowRiskTracker 인터페이스가 아니다.
-
-    ``get_state``/``set_state`` 는 실제 클래스에 없는 이름이고(실제: ``load_state``/
-    ``save_state``, 둘 다 동기), ``delete_state`` 는 이름은 같지만 실제로는 동기
-    메서드다. 파일 상단 주석 참조.
-    """
+class FakeRiskTracker:
+    """실제 WorkflowRiskTracker 의 state/events 인터페이스와 같은 이름·동기 규약의 fake."""
 
     def __init__(self):
         self.state = {}
         self.events = []
 
-    def get_state(self, key):
-        return self.state.get(key)
+    def load_state(self, key, default=None):
+        return self.state.get(key, default)
 
-    def set_state(self, key, value):
+    def save_state(self, key, value):
         self.state[key] = value
+        return True
 
-    def record_event(self, event_type, symbol, data):
-        self.events.append({"event_type": event_type, "symbol": symbol, "data": data})
+    def delete_state(self, key):
+        return self.state.pop(key, None) is not None
+
+    def record_risk_event(self, event_type, severity="warning", symbol=None,
+                          exchange=None, details=None, node_id=None):
+        self.events.append({
+            "event_type": event_type, "severity": severity, "symbol": symbol,
+            "exchange": exchange, "details": details, "node_id": node_id,
+        })
+        return len(self.events)
+
+
+MockRiskTracker = FakeRiskTracker  # 기존 테스트 본문 이름 유지 (실제 시그니처 fake)
 
 
 class MockContext:
     def __init__(self):
-        self.risk_tracker = MockRiskTracker()
+        self.risk_tracker = FakeRiskTracker()
+
+
+def _market_data():
+    """SPY + 고베타(TSLA) + 저베타(JNJ) — 클래스 픽스처 mock_data_with_market 와 같은 데이터"""
+    data = []
+    spy_price, tsla_price, jnj_price = 450.0, 200.0, 160.0
+    for i in range(130):
+        market_move = 0.005 if i % 3 < 2 else -0.003
+        spy_price *= (1 + market_move)
+        tsla_price *= (1 + market_move * 2.0 + 0.001)
+        jnj_price *= (1 + market_move * 0.5 + 0.0005)
+        date = f"2026{(i // 30) + 1:02d}{(i % 30) + 1:02d}"
+        data.append({"symbol": "SPY", "exchange": "NYSE", "date": date, "close": round(spy_price, 2)})
+        data.append({"symbol": "TSLA", "exchange": "NASDAQ", "date": date, "close": round(tsla_price, 2)})
+        data.append({"symbol": "JNJ", "exchange": "NYSE", "date": date, "close": round(jnj_price, 2)})
+    return data
 
 
 class TestBetaHedgePlugin:
@@ -457,3 +470,107 @@ class TestPortfolioBetaIsNotFabricated:
         )
         assert "portfolio_beta" in result["analysis"]
         assert "portfolio_beta_unavailable_reason" not in result["analysis"]
+
+
+class TestLiveStatePathIsAlive:
+    """상태·이벤트 경로가 **실제 트래커로 실제로 돈다**는 것을 고정한다 (2026-09-12 수정).
+
+    수정 전엔 set_state/record_event(없는 이름) → except 삼킴 → 상태 0건·이벤트 0건.
+    """
+
+    _HEDGE_FIELDS = {"lookback": 120, "market_symbol": "SPY", "target_beta": 0.0, "beta_tolerance": 0.1}
+
+    @staticmethod
+    def _real_tracker(tmp_path, features=frozenset({"state", "events"})):
+        mod = pytest.importorskip(
+            "programgarden.database.workflow_risk_tracker",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        return mod.WorkflowRiskTracker(
+            db_path=str(tmp_path / "rt.db"),
+            job_id="pin", product="overseas_stock", provider="ls",
+            trading_mode="real", features=set(features),
+        )
+
+    @staticmethod
+    def _ctx(tracker):
+        class RealCtx:
+            risk_tracker = tracker
+        return RealCtx()
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_persists_portfolio_beta_as_float(self, tmp_path):
+        tracker = self._real_tracker(tmp_path)
+        result = await beta_hedge_condition(
+            data=_market_data(), fields=dict(self._HEDGE_FIELDS), context=self._ctx(tracker),
+        )
+        assert result["analysis"]["hedge_needed"] is True  # 전제 (동일비중 beta ≈ 1.25 > 0.1)
+        saved = tracker.load_state("portfolio_beta")
+        assert isinstance(saved, float)  # 'float' 타입 왕복
+        assert saved == result["analysis"]["portfolio_beta"]
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_records_beta_deviation_event(self, tmp_path):
+        import json
+        tracker = self._real_tracker(tmp_path)
+        result = await beta_hedge_condition(
+            data=_market_data(), fields=dict(self._HEDGE_FIELDS), context=self._ctx(tracker),
+        )
+        events = tracker.get_risk_events(event_type="beta_deviation")
+        assert len(events) == 1
+        assert events[0]["symbol"] == "PORTFOLIO"
+        details = json.loads(events[0]["details"])
+        assert details["portfolio_beta"] == result["analysis"]["portfolio_beta"]
+        assert details["target_beta"] == 0.0
+        assert details["hedge_method"] == "long_inverse_etf"
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_no_event_when_hedge_not_needed(self, tmp_path):
+        tracker = self._real_tracker(tmp_path)
+        result = await beta_hedge_condition(
+            data=_market_data(),
+            fields={"lookback": 120, "market_symbol": "SPY", "target_beta": 1.25, "beta_tolerance": 1.0},
+            context=self._ctx(tracker),
+        )
+        assert result["analysis"]["hedge_needed"] is False
+        assert tracker.get_risk_events(event_type="beta_deviation") == []
+        assert isinstance(tracker.load_state("portfolio_beta"), float)  # 상태는 헷지 여부와 무관하게 저장
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_unavailable_portfolio_beta_is_not_saved(self, tmp_path):
+        """읽을 수 없는 포지션 → portfolio_beta None → 실제 트래커에도 저장하지 않는다."""
+        tracker = self._real_tracker(tmp_path)
+        await beta_hedge_condition(
+            data=_market_data(), fields={"lookback": 120, "market_symbol": "SPY"},
+            positions=[{"symbol": "TSLA", "current_price": 150.0, "qty": "n/a"}],
+            context=self._ctx(tracker),
+        )
+        assert tracker.load_state("portfolio_beta") is None
+
+    @pytest.mark.asyncio
+    async def test_tracker_without_features_warns_instead_of_swallowing(self, tmp_path, caplog):
+        import logging
+        caplog.set_level(logging.WARNING)
+        tracker = self._real_tracker(tmp_path, features=frozenset())
+        result = await beta_hedge_condition(
+            data=_market_data(), fields=dict(self._HEDGE_FIELDS), context=self._ctx(tracker),
+        )
+        assert result["analysis"]["hedge_needed"] is True  # 판정 자체는 그대로
+        messages = [r.message for r in caplog.records]
+        assert any("BetaHedge: 상태 저장 실패" in m for m in messages)
+        assert any("BetaHedge: 위험 이벤트 기록 실패" in m for m in messages)
+
+    @pytest.mark.asyncio
+    async def test_foreign_tracker_variant_degrades_instead_of_crashing(self):
+        class Foreign:
+            def set_state(self, key, value):  # 옛 이름 — 실제 트래커엔 없다
+                raise AssertionError("must not be called")
+
+            def record_event(self, **kw):
+                raise AssertionError("must not be called")
+
+        class Ctx:
+            risk_tracker = Foreign()
+
+        result = await beta_hedge_condition(data=_market_data(), fields=dict(self._HEDGE_FIELDS), context=Ctx())
+        assert result["analysis"]["hedge_needed"] is True

--- a/src/community/tests/test_correlation_guard_plugin.py
+++ b/src/community/tests/test_correlation_guard_plugin.py
@@ -1,5 +1,14 @@
 """
 CorrelationGuard (상관관계 가드) 플러그인 테스트
+
+상태(strategy_state)·이벤트 경로 — 2026-09-12 수정
+------------------------------------------------------------------------------------------
+``FakeRiskTracker`` 는 실제 트래커 ``programgarden.database.workflow_risk_tracker.
+WorkflowRiskTracker`` 의 **실제 시그니처**(``load_state``/``save_state``/``delete_state``/
+``record_risk_event`` — 전부 동기)를 흉내낸다. 종전 목은 실제 클래스에 없는
+``get_state``/``set_state``/``record_event`` 를 제공해, 테스트는 통과하는데 라이브에서는
+except 가 AttributeError 를 삼켜 히스테리시스도 이벤트도 동작하지 않았다.
+``TestLiveStatePathIsAlive`` 가 **실제 트래커 인스턴스**로 그 사실을 고정한다.
 """
 
 import pytest
@@ -11,25 +20,63 @@ from programgarden_community.plugins.correlation_guard import (
 )
 
 
-class MockRiskTracker:
-    """mock risk tracker for state/event"""
+class FakeRiskTracker:
+    """실제 WorkflowRiskTracker 의 state/events 인터페이스와 같은 이름·동기 규약의 fake."""
+
     def __init__(self, initial_state=None):
         self.state = initial_state or {}
         self.events = []
 
-    def get_state(self, key):
-        return self.state.get(key)
+    def load_state(self, key, default=None):
+        return self.state.get(key, default)
 
-    def set_state(self, key, value):
+    def save_state(self, key, value):
         self.state[key] = value
+        return True
 
-    def record_event(self, event_type, symbol, data):
-        self.events.append({"event_type": event_type, "symbol": symbol, "data": data})
+    def delete_state(self, key):
+        return self.state.pop(key, None) is not None
+
+    def record_risk_event(self, event_type, severity="warning", symbol=None,
+                          exchange=None, details=None, node_id=None):
+        self.events.append({
+            "event_type": event_type, "severity": severity, "symbol": symbol,
+            "exchange": exchange, "details": details, "node_id": node_id,
+        })
+        return len(self.events)
+
+
+MockRiskTracker = FakeRiskTracker  # 기존 테스트 본문 이름 유지 (실제 시그니처 fake)
 
 
 class MockContext:
     def __init__(self, initial_state=None):
-        self.risk_tracker = MockRiskTracker(initial_state)
+        self.risk_tracker = FakeRiskTracker(initial_state)
+
+
+async def _boundary_fields(data, lookback=60):
+    """실제 avg_correlation 을 재서 recovery < avg < threshold 인 필드를 만든다."""
+    probe = await correlation_guard_condition(data=data, fields={"lookback": lookback})
+    avg = probe["analysis"]["avg_correlation"]
+    return {
+        "lookback": lookback,
+        "correlation_threshold": avg + 0.05,
+        "recovery_threshold": avg - 0.05,
+    }
+
+
+def _high_correlation_data():
+    """고상관 2종목 (거의 동일한 움직임) — 클래스 픽스처와 같은 데이터"""
+    data = []
+    aapl_price, msft_price = 150.0, 300.0
+    for i in range(70):
+        move = 1.01 if i % 3 < 2 else 0.99
+        aapl_price *= move
+        msft_price *= move * (1 + 0.001)
+        date = f"2026{(i // 30) + 1:02d}{(i % 30) + 1:02d}"
+        data.append({"symbol": "AAPL", "exchange": "NASDAQ", "date": date, "close": round(aapl_price, 2)})
+        data.append({"symbol": "MSFT", "exchange": "NASDAQ", "date": date, "close": round(msft_price, 2)})
+    return data
 
 
 class TestCorrelationGuardPlugin:
@@ -131,20 +178,23 @@ class TestCorrelationGuardPlugin:
 
     @pytest.mark.asyncio
     async def test_hysteresis(self, mock_data_high_correlation):
-        """히스테리시스: 이전 regime 유지"""
-        # 이전 regime이 high_correlation인데, 현재 avg가 threshold~recovery 사이
+        """히스테리시스: 경계 구간(recovery < avg < threshold)에서는 이전 regime 유지.
+
+        픽스처의 avg_correlation 은 1.0 이라(실측) 고정 임계값 0.99 로는 경계 구간이
+        만들어지지 않았다 — 종전 이 테스트는 avg ≥ threshold 로 무조건 high 가 나와
+        히스테리시스를 검증하지 못했다. 실제 avg 를 재고 그 ±0.05 를 임계값으로 쓴다.
+        """
+        fields = await _boundary_fields(mock_data_high_correlation)
         ctx = MockContext(initial_state={"correlation_guard_regime": "high_correlation"})
         result = await correlation_guard_condition(
-            data=mock_data_high_correlation,
-            fields={
-                "lookback": 60,
-                "correlation_threshold": 0.99,  # 이 기준은 안 넘지만
-                "recovery_threshold": 0.1,      # 이것보다는 높으므로
-            },
-            context=ctx,
+            data=mock_data_high_correlation, fields=fields, context=ctx,
         )
-        # 이전 regime 유지 (high_correlation)
-        assert result["analysis"]["regime"] == "high_correlation"
+        assert result["analysis"]["regime"] == "high_correlation"  # 이전 regime 유지
+        # 대조군: 이전 regime 이 없으면 같은 입력에서 normal
+        control = await correlation_guard_condition(
+            data=mock_data_high_correlation, fields=fields, context=MockContext(),
+        )
+        assert control["analysis"]["regime"] == "normal"
 
     @pytest.mark.asyncio
     async def test_regime_recovery(self, mock_data_low_correlation):
@@ -228,3 +278,116 @@ class TestCorrelationGuardPlugin:
             fields={"lookback": 60, "method": "spearman"},
         )
         assert result["analysis"]["method"] == "spearman"
+
+
+class TestLiveStatePathIsAlive:
+    """상태·이벤트 경로가 **실제 트래커로 실제로 돈다**는 것을 고정한다 (2026-09-12 수정).
+
+    켜졌을 때의 의미: 경계 구간(recovery < avg < threshold)에서 '이전 regime 유지' 가
+    실제로 **직전 사이클이 저장한 regime** 을 따른다(수정 전엔 항상 normal).
+    """
+
+    @staticmethod
+    def _real_tracker(tmp_path, features=frozenset({"state", "events"}), name="rt.db"):
+        mod = pytest.importorskip(
+            "programgarden.database.workflow_risk_tracker",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        return mod.WorkflowRiskTracker(
+            db_path=str(tmp_path / name),
+            job_id="pin", product="overseas_stock", provider="ls",
+            trading_mode="real", features=set(features),
+        )
+
+    @staticmethod
+    def _ctx(tracker):
+        class RealCtx:
+            risk_tracker = tracker
+        return RealCtx()
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_hysteresis_round_trip(self, tmp_path):
+        """1회차 고상관 트리거 → 2회차 경계 구간은 **저장된** high_correlation 을 유지한다."""
+        tracker = self._real_tracker(tmp_path)
+        first = await correlation_guard_condition(
+            data=_high_correlation_data(),
+            fields={"lookback": 60, "correlation_threshold": 0.5},
+            context=self._ctx(tracker),
+        )
+        assert first["analysis"]["regime"] == "high_correlation"
+        assert tracker.load_state("correlation_guard_regime") == "high_correlation"
+
+        boundary = await _boundary_fields(_high_correlation_data())
+        second = await correlation_guard_condition(
+            data=_high_correlation_data(), fields=boundary, context=self._ctx(tracker),
+        )
+        assert second["analysis"]["regime"] == "high_correlation", "히스테리시스가 상태를 되읽지 못했다"
+
+        # 이력이 없는 새 DB 의 트래커는 같은 입력에서 normal 이다 — 위 결과가 상태 덕분임을 고정
+        fresh = self._real_tracker(tmp_path, name="fresh.db")
+        third = await correlation_guard_condition(
+            data=_high_correlation_data(), fields=boundary, context=self._ctx(fresh),
+        )
+        assert third["analysis"]["regime"] == "normal"
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_regime_survives_restart(self, tmp_path):
+        await correlation_guard_condition(
+            data=_high_correlation_data(),
+            fields={"lookback": 60, "correlation_threshold": 0.5},
+            context=self._ctx(self._real_tracker(tmp_path)),
+        )
+        restarted = self._real_tracker(tmp_path)  # 같은 rt.db
+        result = await correlation_guard_condition(
+            data=_high_correlation_data(), fields=await _boundary_fields(_high_correlation_data()),
+            context=self._ctx(restarted),
+        )
+        assert result["analysis"]["regime"] == "high_correlation"
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_records_risk_event(self, tmp_path):
+        """수정 전엔 record_event(없는 이름) → except 삼킴 → 이벤트 0건."""
+        import json
+        tracker = self._real_tracker(tmp_path)
+        result = await correlation_guard_condition(
+            data=_high_correlation_data(),
+            fields={"lookback": 60, "correlation_threshold": 0.5, "action": "reduce_pct"},
+            context=self._ctx(tracker),
+        )
+        assert result["analysis"]["triggered"] is True
+        events = tracker.get_risk_events(event_type="high_correlation")
+        assert len(events) == 1
+        assert events[0]["symbol"] == "PORTFOLIO"
+        details = json.loads(events[0]["details"])
+        assert details["avg_correlation"] == result["analysis"]["avg_correlation"]
+        assert details["action"] == "reduce_pct"
+
+    @pytest.mark.asyncio
+    async def test_tracker_without_features_warns_instead_of_swallowing(self, tmp_path, caplog):
+        import logging
+        caplog.set_level(logging.WARNING)
+        tracker = self._real_tracker(tmp_path, features=frozenset())
+        result = await correlation_guard_condition(
+            data=_high_correlation_data(),
+            fields={"lookback": 60, "correlation_threshold": 0.5},
+            context=self._ctx(tracker),
+        )
+        assert result["analysis"]["regime"] == "high_correlation"  # 판정 자체는 그대로
+        messages = [r.message for r in caplog.records]
+        assert any("CorrelationGuard: 상태 저장 실패" in m for m in messages)
+        assert any("CorrelationGuard: 위험 이벤트 기록 실패" in m for m in messages)
+
+    @pytest.mark.asyncio
+    async def test_foreign_tracker_variant_degrades_instead_of_crashing(self):
+        class Foreign:
+            def get_state(self, key):  # 옛 이름 — 실제 트래커엔 없다
+                raise AssertionError("must not be called")
+
+        class Ctx:
+            risk_tracker = Foreign()
+
+        result = await correlation_guard_condition(
+            data=_high_correlation_data(), fields=await _boundary_fields(_high_correlation_data()),
+            context=Ctx(),
+        )
+        assert result["analysis"]["regime"] == "normal"  # prev_regime 기본값

--- a/src/community/tests/test_pair_trading_plugin.py
+++ b/src/community/tests/test_pair_trading_plugin.py
@@ -147,5 +147,92 @@ class TestPairTradingPlugin:
         assert "spread_method" in PAIR_TRADING_SCHEMA.fields_schema
 
 
+class TestLiveStatePathIsAlive:
+    """상태 경로가 **실제 트래커로 실제로 돈다**는 것을 고정한다 (2026-09-12 수정).
+
+    수정 전에는 실제 트래커에 없는 ``set_state`` 를 불러 except 가 AttributeError 를
+    삼켰고, 그래서 신호 이력이 **한 번도 저장되지 않았다**. 여기서는 실제
+    ``WorkflowRiskTracker`` 인스턴스(sqlite, tmp_path)로 왕복해 저장·직렬화를 본다.
+    """
+
+    @staticmethod
+    def _real_tracker(tmp_path, features=frozenset({"state"})):
+        mod = pytest.importorskip(
+            "programgarden.database.workflow_risk_tracker",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        return mod.WorkflowRiskTracker(
+            db_path=str(tmp_path / "rt.db"),
+            job_id="pin", product="overseas_stock", provider="ls",
+            trading_mode="real", features=set(features),
+        )
+
+    @staticmethod
+    def _ctx(tracker):
+        class RealCtx:
+            risk_tracker = tracker
+        return RealCtx()
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_persists_last_signal_as_string(self, tmp_path):
+        """entry_z=1.0 / exit_z=2.0 이면 z 가 무엇이든 신호가 난다 → 저장값 == analysis.signal."""
+        tracker = self._real_tracker(tmp_path)
+        result = await pair_trading_condition(
+            data=_make_correlated_pair(70, "diverged"),
+            fields={"symbol_a": "AAPL", "symbol_b": "MSFT", "lookback": 60,
+                    "entry_z": 1.0, "exit_z": 2.0, "correlation_min": 0.0},
+            context=self._ctx(tracker),
+        )
+        signal = result["analysis"]["signal"]
+        assert signal in {"short_a_long_b", "long_a_short_b", "exit"}
+        saved = tracker.load_state("pair_AAPL_MSFT")
+        assert saved == signal
+        assert isinstance(saved, str)  # 'string' 타입 왕복
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_overwrites_signal_on_next_cycle(self, tmp_path):
+        tracker = self._real_tracker(tmp_path)
+        tracker.save_state("pair_AAPL_MSFT", "stale_signal")
+        await pair_trading_condition(
+            data=_make_correlated_pair(70, "diverged"),
+            fields={"symbol_a": "AAPL", "symbol_b": "MSFT", "lookback": 60,
+                    "entry_z": 1.0, "exit_z": 2.0, "correlation_min": 0.0},
+            context=self._ctx(tracker),
+        )
+        assert tracker.load_state("pair_AAPL_MSFT") != "stale_signal"
+
+    @pytest.mark.asyncio
+    async def test_tracker_without_state_feature_warns_instead_of_swallowing(self, tmp_path, caplog):
+        import logging
+        caplog.set_level(logging.WARNING)
+        tracker = self._real_tracker(tmp_path, features=frozenset())
+        result = await pair_trading_condition(
+            data=_make_correlated_pair(70, "diverged"),
+            fields={"symbol_a": "AAPL", "symbol_b": "MSFT", "lookback": 60,
+                    "entry_z": 1.0, "exit_z": 2.0, "correlation_min": 0.0},
+            context=self._ctx(tracker),
+        )
+        assert result["analysis"]["signal"] is not None  # 판정 자체는 그대로
+        assert tracker.load_state("pair_AAPL_MSFT") is None
+        assert any("PairTrading: 상태 저장 실패" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_foreign_tracker_variant_degrades_instead_of_crashing(self):
+        class Foreign:
+            def set_state(self, key, value):  # 옛 이름 — 실제 트래커엔 없다
+                raise AssertionError("must not be called")
+
+        class Ctx:
+            risk_tracker = Foreign()
+
+        result = await pair_trading_condition(
+            data=_make_correlated_pair(70, "diverged"),
+            fields={"symbol_a": "AAPL", "symbol_b": "MSFT", "lookback": 60,
+                    "entry_z": 1.0, "exit_z": 2.0, "correlation_min": 0.0},
+            context=Ctx(),
+        )
+        assert result["analysis"]["signal"] is not None
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/src/community/tests/test_partial_tp_plugin.py
+++ b/src/community/tests/test_partial_tp_plugin.py
@@ -1,24 +1,15 @@
 """
 PartialTakeProfit 플러그인 테스트
 
-🔴 이 파일의 ``MockRiskTracker`` 는 **실제 클래스에 없는 메서드를 제공한다** (관측 2026-09-12)
-------------------------------------------------------------------------------------------
-실제 트래커 ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 의
-실제 인터페이스와 대조한 결과:
-
-| 목이 제공하는 이름 | 실제 클래스 | 비고 |
-|---|---|---|
-| ``get_state``   | **없음** | 실제 이름은 ``load_state`` (동기) |
-| ``set_state``   | **없음** | 실제 이름은 ``save_state`` (동기) |
-| ``delete_state``| 있음     | 단 **동기** 메서드 — 플러그인은 ``await`` 한다 |
-| ``record_event``| **없음** | 실제 이름은 ``record_risk_event`` |
-
-즉 아래 상태 관련 테스트들은 '플러그인이 라이브에서 실제로 상태를 저장·복원한다'
-를 증명하지 않는다 — **목이 약속한 계약대로 플러그인이 호출한다**는 것만 증명한다.
-라이브에서는 (가) 실제 트래커를 넘기면 ``AttributeError`` 로 죽고, (나) 애초에
-실행기가 positions 기반 플러그인에 ``context`` 를 넘기지 않아 상태 경로가 아예
-돌지 않는다(플러그인 모듈 docstring 의 '상태 경로' 절 참조).
-목을 실제 시그니처로 맞추는 수정은 이번 회차 범위 밖이다 — 후속 필요.
+``MockRiskTracker`` 는 **실제 클래스의 시그니처와 같다** (2026-09-12 정정)
+------------------------------------------------------------------------
+실제 트래커 ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 는
+``load_state`` / ``save_state`` / ``delete_state`` 를 **동기** 메서드로 갖는다.
+종전 목은 실제에 없는 ``get_state``/``set_state`` 를 async 로 제공해, 상태 테스트가
+초록인데도 라이브에서는 AttributeError 로 죽는 상태를 가리고 있었다. 지금 목은
+같은 이름·같은 동기 호출 규약을 쓰므로, 플러그인이 목에서 통과하면 실제 트래커에서도
+같은 호출이 통한다(아래 ``TestLiveStatePathIsAlive`` 가 **실제 트래커 인스턴스**로
+한 번 더 고정한다).
 """
 
 import pytest
@@ -29,23 +20,23 @@ from programgarden_community.plugins.partial_take_profit import (
 
 
 class MockRiskTracker:
-    """strategy_state **목 계약** 모킹 — 실제 WorkflowRiskTracker 인터페이스가 아니다.
+    """strategy_state 모킹 — **실제 WorkflowRiskTracker 와 같은 이름·같은 동기 시그니처**.
 
-    ``get_state``/``set_state`` 는 실제 클래스에 없는 이름이고(실제: ``load_state``/
-    ``save_state``, 둘 다 동기), ``delete_state`` 는 이름은 같지만 실제로는 동기
-    메서드다. 파일 상단 주석 참조.
+    실제: ``load_state(key, default=None)`` / ``save_state(key, value) -> bool`` /
+    ``delete_state(key) -> bool`` (전부 동기). 파일 상단 주석 참조.
     """
     def __init__(self):
         self._state = {}
 
-    async def get_state(self, key):
-        return self._state.get(key)
+    def load_state(self, key, default=None):
+        return self._state.get(key, default)
 
-    async def set_state(self, key, value):
+    def save_state(self, key, value) -> bool:
         self._state[key] = value
+        return True
 
-    async def delete_state(self, key):
-        self._state.pop(key, None)
+    def delete_state(self, key) -> bool:
+        return self._state.pop(key, None) is not None
 
 
 class MockContext:
@@ -57,7 +48,7 @@ class TestPartialTakeProfitPlugin:
 
     @pytest.mark.asyncio
     async def test_level_triggered(self):
-        """1단계 익절 트리거 (context 경로는 목 계약 — 라이브에서는 context 가 오지 않는다)"""
+        """1단계 익절 트리거 (context 는 실행기의 positions 분기가 실제로 넘긴다)"""
         tracker = MockRiskTracker()
         context = MockContext(tracker)
 
@@ -146,10 +137,11 @@ class TestPartialTakeProfitPlugin:
 
     @pytest.mark.asyncio
     async def test_without_context(self):
-        """context 없이 실행 — **이것이 현재 라이브 실행기의 실제 모습이다**
+        """context 없이 실행 — 상태 없이도 죽지 않고 평가만 한다.
 
-        실행기의 positions 분기가 context 를 넘기지 않으므로 라이브는 항상 이
-        경로다. 매 호출이 level_index=0 을 다시 트리거한다(상태 없음).
+        (실행기의 positions 분기는 2026-09-12 부터 context 를 넘긴다. 이 경로는
+        context 를 넘기지 않는 외부 호출자·구버전 실행기용 하위 호환이다 —
+        상태가 없으니 매 호출이 같은 단계를 다시 트리거한다.)
         """
         positions = [
             {"symbol": "AAPL", "pnl_rate": 8.0, "qty": 100, "market_code": "82"},
@@ -361,20 +353,107 @@ if __name__ == "__main__":
     pytest.main([__file__, "-v"])
 
 
-class TestLiveStatePathIsDead:
-    """상태 경로가 라이브에서 죽어 있다는 **실제 동작**을 고정한다 (X4, 관측 2026-09-12).
+class TestLiveStatePathIsAlive:
+    """상태 경로가 **라이브에서 실제로 돈다**는 것을 고정한다 (2026-09-12 수정).
 
-    실행기의 positions 기반 분기(``ConditionNodeExecutor.execute``)는 plugin_kwargs
-    를 ``{"positions", "fields"}`` 로 고정해 ``context`` 를 넘기지 않는다. 따라서
-    라이브 호출은 항상 context=None 이고, 아래처럼 같은 단계가 매 사이클 재발동한다.
-
-    이 테스트가 초록인 것은 '정상' 이라는 뜻이 아니라 '아직 깨진 채다' 라는 뜻이다.
-    실행기가 context 를 넘기도록 고쳐지면 이 테스트가 빨개져야 하고, 그때 플러그인
-    docstring 의 '미검증' 문구도 함께 걷어내면 된다. 근본 수정은 이번 회차 범위 밖.
+    수정 전에는 두 군데가 끊겨 있었다:
+      1. 실행기의 positions 기반 분기가 plugin_kwargs 를 {"positions", "fields"} 로
+         고정해 ``context`` 를 넘기지 않았다 → has_state 가 항상 False.
+      2. 플러그인이 실제 트래커에 없는 ``get_state``/``set_state`` 를 await 했다 →
+         실제 트래커를 넘기면 AttributeError.
+    (1) 은 executor 쪽 테스트에서, (2) 는 아래에서 **실제 트래커 인스턴스**로 고정한다.
     """
+
+    @staticmethod
+    def _real_tracker(tmp_path):
+        mod = pytest.importorskip(
+            "programgarden.database.workflow_risk_tracker",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        return mod.WorkflowRiskTracker(
+            db_path=str(tmp_path / "rt.db"),
+            job_id="pin", product="overseas_stock", provider="ls",
+            trading_mode="real", features={"state"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_state_path_does_not_crash_and_persists(self, tmp_path):
+        """실제 트래커로 3사이클 — 1회차만 발동하고 이후는 hold (재발동 없음)."""
+        tracker = self._real_tracker(tmp_path)
+
+        class RealCtx:
+            risk_tracker = tracker
+
+        positions = [{"symbol": "AAPL", "pnl_rate": 6.0, "qty": 100, "market_code": "82"}]
+        levels = [{"pnl_pct": 5, "sell_pct": 50}, {"pnl_pct": 10, "sell_pct": 30}]
+
+        actions = []
+        for _ in range(3):
+            result = await partial_take_profit_condition(
+                positions=positions, fields={"levels": levels}, context=RealCtx(),
+            )
+            actions.append(result["symbol_results"][0]["action"])
+
+        assert actions == ["sell", "hold", "hold"], (
+            f"1단계는 한 번만 발동해야 한다. 관측: {actions}"
+        )
+        assert tracker.load_state("partial_tp.AAPL.completed_levels") == [0]
+        assert tracker.load_state("partial_tp.AAPL.original_qty") == 100
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_second_level_uses_original_quantity(self, tmp_path):
+        """2단계는 **최초 수량** 기준으로 계산된다 (상태에 저장된 original_qty)."""
+        tracker = self._real_tracker(tmp_path)
+
+        class RealCtx:
+            risk_tracker = tracker
+
+        levels = [{"pnl_pct": 5, "sell_pct": 50}, {"pnl_pct": 10, "sell_pct": 30}]
+        first = await partial_take_profit_condition(
+            positions=[{"symbol": "AAPL", "pnl_rate": 6.0, "qty": 100, "market_code": "82"}],
+            fields={"levels": levels}, context=RealCtx(),
+        )
+        assert first["symbol_results"][0]["sell_quantity"] == 50
+
+        # 50주 매도 체결 후 보유 50주 · 수익률 12% → 2단계 발동
+        second = await partial_take_profit_condition(
+            positions=[{"symbol": "AAPL", "pnl_rate": 12.0, "qty": 50, "market_code": "82"}],
+            fields={"levels": levels}, context=RealCtx(),
+        )
+        sr = second["symbol_results"][0]
+        assert sr["action"] == "sell"
+        assert sr["level_index"] == 1
+        assert sr["sell_quantity"] == 30, "최초 100주의 30% (현재 50주의 30% 가 아니다)"
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_clears_state_when_position_closed(self, tmp_path):
+        tracker = self._real_tracker(tmp_path)
+
+        class RealCtx:
+            risk_tracker = tracker
+
+        levels = [{"pnl_pct": 5, "sell_pct": 50}]
+        await partial_take_profit_condition(
+            positions=[{"symbol": "AAPL", "pnl_rate": 6.0, "qty": 100, "market_code": "82"}],
+            fields={"levels": levels}, context=RealCtx(),
+        )
+        assert tracker.load_state("partial_tp.AAPL.completed_levels") == [0]
+
+        await partial_take_profit_condition(
+            positions=[{"symbol": "AAPL", "pnl_rate": 0.0, "qty": 0, "market_code": "82"}],
+            fields={"levels": levels}, context=RealCtx(),
+        )
+        assert tracker.load_state("partial_tp.AAPL.completed_levels") is None
+        assert tracker.load_state("partial_tp.AAPL.original_qty") is None
 
     @pytest.mark.asyncio
     async def test_same_level_retriggers_every_cycle_without_context(self):
+        """context 를 안 넘기는 호출자(구버전 실행기·직접 호출)는 종전 그대로다.
+
+        상태가 없으니 같은 단계가 매 사이클 재발동한다 — 이건 '고쳐지지 않은 결함' 이
+        아니라 '상태 저장소가 없을 때의 정의된 동작' 이다. 라이브 실행기는 위
+        테스트들처럼 context 를 넘긴다.
+        """
         positions = [{"symbol": "AAPL", "pnl_rate": 6.0, "qty": 100, "market_code": "82"}]
         levels = [{"pnl_pct": 5, "sell_pct": 50}]
 
@@ -386,35 +465,7 @@ class TestLiveStatePathIsDead:
             sr = result["symbol_results"][0]
             seen.append((sr["level_index"], sr["sell_quantity"]))
 
-        assert seen == [(0, 50), (0, 50), (0, 50)], (
-            "상태가 저장·복원되지 않아 매 사이클 같은 단계가 재발동한다. "
-            f"관측: {seen}"
-        )
-
-    @pytest.mark.asyncio
-    async def test_real_tracker_would_crash_on_the_state_path(self):
-        """실제 트래커를 넘기면 상태 경로가 AttributeError 로 즉사한다."""
-        mod = pytest.importorskip(
-            "programgarden.database.workflow_risk_tracker",
-            reason="engine package not installed; live-truth pin skipped",
-        )
-        import tempfile, os
-
-        tracker = mod.WorkflowRiskTracker(
-            db_path=os.path.join(tempfile.mkdtemp(), "rt.db"),
-            job_id="pin", product="overseas_stock", provider="ls",
-            trading_mode="real", features={"state"},
-        )
-
-        class RealCtx:
-            risk_tracker = tracker
-
-        with pytest.raises(AttributeError, match="get_state"):
-            await partial_take_profit_condition(
-                positions=[{"symbol": "AAPL", "pnl_rate": 6.0, "qty": 100, "market_code": "82"}],
-                fields={"levels": [{"pnl_pct": 5, "sell_pct": 50}]},
-                context=RealCtx(),
-            )
+        assert seen == [(0, 50), (0, 50), (0, 50)], f"관측: {seen}"
 
 
 class TestUnreadableQuantityIsReachable:

--- a/src/community/tests/test_roll_management_plugin.py
+++ b/src/community/tests/test_roll_management_plugin.py
@@ -142,3 +142,95 @@ class TestRollManagementPlugin:
         result = await roll_management_condition(positions=positions, fields={})
         assert result["result"] is False
         assert len(result["failed_symbols"]) == 1
+
+
+def _current_month_contract() -> str:
+    """현재 월 월물(만기 = 이달 셋째 금요일 근사) — days_before_expiry=30 이면 항상 should_roll."""
+    now = datetime.now()
+    month_code_map = {1: "F", 2: "G", 3: "H", 4: "J", 5: "K", 6: "M",
+                      7: "N", 8: "Q", 9: "U", 10: "V", 11: "X", 12: "Z"}
+    return f"CL{month_code_map[now.month]}{str(now.year)[-2:]}"
+
+
+class TestLiveStatePathIsAlive:
+    """상태 경로가 **실제 트래커로 실제로 돈다**는 것을 고정한다 (2026-09-12 수정).
+
+    수정 전에는 실제 트래커에 없는 ``set_state`` 를 await 했고 ``except: pass`` 가 그
+    AttributeError 를 삼켜 롤 신호 이력이 **한 번도 저장되지 않았다**. 여기서는 실제
+    ``WorkflowRiskTracker`` 인스턴스(sqlite, tmp_path)로 저장·직렬화를 본다.
+    """
+
+    @staticmethod
+    def _real_tracker(tmp_path, features=frozenset({"state"})):
+        mod = pytest.importorskip(
+            "programgarden.database.workflow_risk_tracker",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        return mod.WorkflowRiskTracker(
+            db_path=str(tmp_path / "rt.db"),
+            job_id="pin", product="overseas_futures", provider="ls",
+            trading_mode="real", features=set(features),
+        )
+
+    @staticmethod
+    def _ctx(tracker):
+        class RealCtx:
+            risk_tracker = tracker
+        return RealCtx()
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_persists_roll_signal_date(self, tmp_path):
+        tracker = self._real_tracker(tmp_path)
+        symbol = _current_month_contract()
+        before = datetime.now().strftime("%Y-%m-%d")
+        result = await roll_management_condition(
+            positions=[{"symbol": symbol, "current_price": 70.5, "qty": 2, "market_code": "CME"}],
+            fields={"days_before_expiry": 30},
+            context=self._ctx(tracker),
+        )
+        after = datetime.now().strftime("%Y-%m-%d")
+        assert result["symbol_results"][0]["should_roll"] is True  # 전제
+        saved = tracker.load_state(f"roll.{symbol}.signal_date")
+        assert saved in {before, after}  # 자정 경계 허용
+        assert isinstance(saved, str)  # 'string' 타입 왕복
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_does_not_write_when_no_roll_signal(self, tmp_path):
+        tracker = self._real_tracker(tmp_path)
+        await roll_management_condition(
+            positions=[{"symbol": "CLZ30", "current_price": 72.0, "qty": 3, "market_code": "CME"}],
+            fields={"days_before_expiry": 5},
+            context=self._ctx(tracker),
+        )
+        assert tracker.load_state("roll.CLZ30.signal_date") is None
+
+    @pytest.mark.asyncio
+    async def test_tracker_without_state_feature_warns_instead_of_swallowing(self, tmp_path, caplog):
+        import logging
+        caplog.set_level(logging.WARNING)
+        tracker = self._real_tracker(tmp_path, features=frozenset())
+        symbol = _current_month_contract()
+        result = await roll_management_condition(
+            positions=[{"symbol": symbol, "current_price": 70.5, "qty": 2, "market_code": "CME"}],
+            fields={"days_before_expiry": 30},
+            context=self._ctx(tracker),
+        )
+        assert result["symbol_results"][0]["should_roll"] is True  # 판정 자체는 그대로
+        assert tracker.load_state(f"roll.{symbol}.signal_date") is None
+        assert any("RollManagement: 상태 저장 실패" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_foreign_tracker_variant_degrades_instead_of_crashing(self):
+        class Foreign:
+            async def set_state(self, key, value):  # 옛 이름 — 실제 트래커엔 없다
+                raise AssertionError("must not be called")
+
+        class Ctx:
+            risk_tracker = Foreign()
+
+        result = await roll_management_condition(
+            positions=[{"symbol": _current_month_contract(), "current_price": 70.5, "qty": 2, "market_code": "CME"}],
+            fields={"days_before_expiry": 30},
+            context=Ctx(),
+        )
+        assert result["symbol_results"][0]["should_roll"] is True

--- a/src/community/tests/test_time_exit_plugin.py
+++ b/src/community/tests/test_time_exit_plugin.py
@@ -1,54 +1,54 @@
 """
 TimeBasedExit 플러그인 테스트
 
-🔴 이 파일의 ``MockRiskTracker`` 는 **실제 클래스에 없는 메서드를 제공한다** (관측 2026-09-12)
+상태(strategy_state) 경로 — 2026-09-12 수정
 ------------------------------------------------------------------------------------------
-실제 트래커 ``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 의
-실제 인터페이스와 대조한 결과:
+이 파일의 ``FakeRiskTracker`` 는 실제 트래커
+``programgarden.database.workflow_risk_tracker.WorkflowRiskTracker`` 의 **실제 시그니처**
+(``load_state`` / ``save_state`` / ``delete_state`` / ``load_states`` — 전부 동기)를 그대로
+흉내낸다. 종전의 ``MockRiskTracker`` 는 실제 클래스에 없는 ``get_state``/``set_state``
+(그것도 async) 를 제공해, 테스트는 통과하는데 실제 트래커를 넘기면
+``AttributeError: 'WorkflowRiskTracker' object has no attribute 'get_state'`` 로 즉사했다.
 
-| 목이 제공하는 이름 | 실제 클래스 | 비고 |
-|---|---|---|
-| ``get_state``   | **없음** | 실제 이름은 ``load_state`` (동기) |
-| ``set_state``   | **없음** | 실제 이름은 ``save_state`` (동기) |
-| ``delete_state``| 있음     | 단 **동기** 메서드 — 플러그인은 ``await`` 한다 |
-| ``record_event``| **없음** | 실제 이름은 ``record_risk_event`` |
-
-즉 아래 상태 관련 테스트들은 '플러그인이 라이브에서 실제로 상태를 저장·복원한다'
-를 증명하지 않는다 — **목이 약속한 계약대로 플러그인이 호출한다**는 것만 증명한다.
-라이브에서는 (가) 실제 트래커를 넘기면 ``AttributeError`` 로 죽고, (나) 애초에
-실행기가 positions 기반 플러그인에 ``context`` 를 넘기지 않아 상태 경로가 아예
-돌지 않는다(플러그인 모듈 docstring 의 '상태 경로' 절 참조).
-목을 실제 시그니처로 맞추는 수정은 이번 회차 범위 밖이다 — 후속 필요.
+아래 ``TestLiveStatePathIsAlive`` 는 **실제 트래커 인스턴스**(sqlite, tmp_path)로 왕복해
+그 사실을 고정한다 — fake 로는 증명되지 않는 것(직렬화·재시작 복원·정리 스윕)만 거기서 본다.
 """
 
 import pytest
 from datetime import date, timedelta
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 from programgarden_community.plugins.time_based_exit import (
     time_based_exit_condition,
     TIME_BASED_EXIT_SCHEMA,
 )
 
 
-class MockRiskTracker:
-    """strategy_state **목 계약** 모킹 — 실제 WorkflowRiskTracker 인터페이스가 아니다.
+class FakeRiskTracker:
+    """실제 WorkflowRiskTracker 의 state 인터페이스와 **같은 이름·같은 동기 규약**의 fake.
 
-    ``get_state``/``set_state`` 는 실제 클래스에 없는 이름이고(실제: ``load_state``/
-    ``save_state``, 둘 다 동기), ``delete_state`` 는 이름은 같지만 실제로는 동기
-    메서드다. 파일 상단 주석 참조.
+    실제 클래스: load_state(key, default=None) / save_state(key, value) -> bool /
+    delete_state(key) -> bool / load_states(prefix) -> dict. 전부 동기.
     """
 
     def __init__(self):
         self._state = {}
 
-    async def get_state(self, key):
-        return self._state.get(key)
+    def load_state(self, key, default=None):
+        return self._state.get(key, default)
 
-    async def set_state(self, key, value):
+    def save_state(self, key, value):
         self._state[key] = value
+        return True
 
-    async def delete_state(self, key):
-        self._state.pop(key, None)
+    def delete_state(self, key):
+        return self._state.pop(key, None) is not None
+
+    def load_states(self, prefix):
+        return {k: v for k, v in self._state.items() if k.startswith(prefix)}
+
+
+# 기존 테스트 본문의 이름을 유지하기 위한 별칭 (실제 시그니처 fake 다 — 목 계약이 아니다)
+MockRiskTracker = FakeRiskTracker
 
 
 class MockContext:
@@ -60,7 +60,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_new_position_records_entry(self):
-        """[목 계약 — 라이브 아님] 신규 포지션 진입일 기록"""
+        """신규 포지션 진입일 기록"""
         tracker = MockRiskTracker()
         context = MockContext(tracker)
 
@@ -79,7 +79,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_exit_triggered(self):
-        """[목 계약 — 라이브 아님] 보유일 초과 시 청산 트리거"""
+        """보유일 초과 시 청산 트리거"""
         tracker = MockRiskTracker()
         entry = (date.today() - timedelta(days=6)).isoformat()
         tracker._state["time_exit.AAPL.entry_date"] = entry
@@ -98,7 +98,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_warn_triggered(self):
-        """[목 계약 — 라이브 아님] 경고 일수 도달"""
+        """경고 일수 도달"""
         tracker = MockRiskTracker()
         entry = (date.today() - timedelta(days=4)).isoformat()
         tracker._state["time_exit.AAPL.entry_date"] = entry
@@ -117,7 +117,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_position_closed_clears_state(self):
-        """[목 계약 — 라이브 아님] 포지션 청산 시 상태 삭제"""
+        """포지션 청산 시 상태 삭제"""
         tracker = MockRiskTracker()
         tracker._state["time_exit.AAPL.entry_date"] = "2025-01-01"
         context = MockContext(tracker)
@@ -145,7 +145,7 @@ class TestTimeBasedExitPlugin:
 
     @pytest.mark.asyncio
     async def test_multiple_symbols(self):
-        """[목 계약 — 라이브 아님] 여러 종목"""
+        """여러 종목"""
         tracker = MockRiskTracker()
         tracker._state["time_exit.AAPL.entry_date"] = (date.today() - timedelta(days=10)).isoformat()
         tracker._state["time_exit.NVDA.entry_date"] = (date.today() - timedelta(days=2)).isoformat()
@@ -219,7 +219,7 @@ class TestUnreadableQuantityIsReachable:
 
     @pytest.mark.asyncio
     async def test_unreadable_quantity_does_not_delete_entry_date_state(self):
-        """[목 계약] 청산인지 알 수 없으므로 진입일 상태를 지우지 않는다."""
+        """청산인지 알 수 없으므로 진입일 상태를 지우지 않는다."""
         tracker = MockRiskTracker()
         key = "time_exit.AAPL.entry_date"
         tracker._state[key] = (date.today() - timedelta(days=10)).isoformat()
@@ -235,3 +235,189 @@ class TestUnreadableQuantityIsReachable:
         of = TIME_BASED_EXIT_SCHEMA.output_fields
         assert "reason" in of
         assert "skip" in of["action"]["description"]
+
+
+class _FakeDate(date):
+    """``date.today()`` 를 고정/전진시키기 위한 date 서브클래스 (fromisoformat 은 그대로)."""
+
+    _today = date(2026, 9, 14)
+
+    @classmethod
+    def today(cls):
+        return cls._today
+
+
+class TestLiveStatePathIsAlive:
+    """상태 경로가 **실제 트래커로 실제로 돈다**는 것을 고정한다 (2026-09-12 수정).
+
+    수정 전에는 (1) 실행기의 positions 분기가 context 를 넘기지 않았고, (2) 플러그인이
+    실제 트래커에 없는 ``get_state``/``set_state`` 를 await 했다. (1) 은 executor 쪽
+    테스트에서, (2) 는 여기서 **실제 WorkflowRiskTracker 인스턴스**로 고정한다.
+
+    켜졌을 때의 의미(모듈 docstring 과 대조):
+    - entry_date 는 이 플러그인이 포지션을 **처음 관측한 날**로 고정되고, 이후 사이클에서
+      덮어쓰지 않는다 → hold_days 가 실제로 자란다(수정 전엔 매번 오늘 → 영영 0).
+    - 값은 ISO 문자열(YYYY-MM-DD) 로 저장되고 트래커의 'string' 타입으로 그대로 왕복한다.
+    - 같은 DB 를 다시 연 새 트래커(재시작)에서도 entry_date 가 복원된다.
+    - 포지션이 사라진 종목의 entry_date 는 정리된다(docstring 의 '자동 정리' 약속).
+    """
+
+    @staticmethod
+    def _real_tracker(tmp_path, features=frozenset({"state"}), name="rt.db"):
+        mod = pytest.importorskip(
+            "programgarden.database.workflow_risk_tracker",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        return mod.WorkflowRiskTracker(
+            db_path=str(tmp_path / name),
+            job_id="pin", product="overseas_stock", provider="ls",
+            trading_mode="real", features=set(features),
+        )
+
+    @staticmethod
+    def _ctx(tracker):
+        class RealCtx:
+            risk_tracker = tracker
+        return RealCtx()
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_does_not_crash_and_pins_first_observation_date(self, tmp_path):
+        """수정 전: AttributeError('WorkflowRiskTracker' object has no attribute 'get_state')."""
+        tracker = self._real_tracker(tmp_path)
+        positions = [{"symbol": "AAPL", "qty": 100, "market_code": "82"}]
+
+        with patch("programgarden_community.plugins.time_based_exit.date", _FakeDate):
+            _FakeDate._today = date(2026, 9, 14)
+            first = await time_based_exit_condition(
+                positions=positions, fields={"max_hold_days": 5}, context=self._ctx(tracker),
+            )
+            # 하루 뒤 — entry_date 는 첫 관측일 그대로여야 한다(덮어쓰지 않는다)
+            _FakeDate._today = date(2026, 9, 15)
+            second = await time_based_exit_condition(
+                positions=positions, fields={"max_hold_days": 5}, context=self._ctx(tracker),
+            )
+
+        assert first["symbol_results"][0]["hold_days"] == 0
+        assert second["symbol_results"][0]["entry_date"] == "2026-09-14"
+        assert second["symbol_results"][0]["hold_days"] == 1
+        # 트래커에 실제로 남은 값: ISO 문자열 그대로('string' 타입 왕복)
+        assert tracker.load_state("time_exit.AAPL.entry_date") == "2026-09-14"
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_hold_days_grow_until_exit(self, tmp_path):
+        """max_hold_days=5 → 6번째 날(hold_days=5)에 exit. 수정 전엔 영영 hold 였다."""
+        tracker = self._real_tracker(tmp_path)
+        positions = [{"symbol": "AAPL", "qty": 100, "market_code": "82"}]
+        actions, hold_days = [], []
+        with patch("programgarden_community.plugins.time_based_exit.date", _FakeDate):
+            for offset in range(6):
+                _FakeDate._today = date(2026, 9, 14) + timedelta(days=offset)
+                r = await time_based_exit_condition(
+                    positions=positions, fields={"max_hold_days": 5, "warn_days": 2},
+                    context=self._ctx(tracker),
+                )
+                sr = r["symbol_results"][0]
+                actions.append(sr["action"])
+                hold_days.append(sr["hold_days"])
+        assert hold_days == [0, 1, 2, 3, 4, 5]
+        assert actions == ["hold", "hold", "hold", "warn", "warn", "exit"], actions
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_entry_date_survives_restart(self, tmp_path):
+        """같은 DB 를 다시 연 새 트래커(워크플로우 재시작)에서 entry_date 가 복원된다."""
+        positions = [{"symbol": "AAPL", "qty": 100, "market_code": "82"}]
+        with patch("programgarden_community.plugins.time_based_exit.date", _FakeDate):
+            _FakeDate._today = date(2026, 9, 14)
+            await time_based_exit_condition(
+                positions=positions, fields={"max_hold_days": 5},
+                context=self._ctx(self._real_tracker(tmp_path)),
+            )
+            _FakeDate._today = date(2026, 9, 20)
+            restarted = self._real_tracker(tmp_path)  # 같은 rt.db
+            r = await time_based_exit_condition(
+                positions=positions, fields={"max_hold_days": 5},
+                context=self._ctx(restarted),
+            )
+        sr = r["symbol_results"][0]
+        assert sr["entry_date"] == "2026-09-14"
+        assert sr["hold_days"] == 6
+        assert sr["action"] == "exit"
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_closed_position_deletes_state(self, tmp_path):
+        tracker = self._real_tracker(tmp_path)
+        tracker.save_state("time_exit.AAPL.entry_date", "2026-01-01")
+        r = await time_based_exit_condition(
+            positions=[{"symbol": "AAPL", "qty": 0, "market_code": "82"}],
+            fields={}, context=self._ctx(tracker),
+        )
+        assert r["symbol_results"][0]["action"] == "cleared"
+        assert tracker.load_state("time_exit.AAPL.entry_date") is None
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_sweeps_symbols_no_longer_in_positions(self, tmp_path):
+        """전량 매도돼 positions 에서 **사라진** 종목의 entry_date 를 정리한다.
+
+        정리하지 않으면 재매수 직후 옛 entry_date 로 hold_days 가 커져 거짓 exit 가 난다.
+        """
+        tracker = self._real_tracker(tmp_path)
+        tracker.save_state("time_exit.AAPL.entry_date", "2026-01-01")
+        tracker.save_state("time_exit.BRK.B.entry_date", "2026-01-01")  # 점 포함 심볼
+        tracker.save_state("time_exit.NVDA.entry_date", "2026-01-01")
+        r = await time_based_exit_condition(
+            positions=[{"symbol": "NVDA", "qty": 10, "market_code": "82"}],
+            fields={"max_hold_days": 5}, context=self._ctx(tracker),
+        )
+        assert tracker.load_state("time_exit.AAPL.entry_date") is None
+        assert tracker.load_state("time_exit.BRK.B.entry_date") is None
+        assert tracker.load_state("time_exit.NVDA.entry_date") == "2026-01-01"
+        assert sorted(r["analysis"]["stale_state_cleared"]) == ["AAPL", "BRK.B"]
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_sweeps_everything_when_account_is_flat(self, tmp_path):
+        """positions 가 비면(전부 청산) 남은 entry_date 를 모두 정리한다."""
+        tracker = self._real_tracker(tmp_path)
+        tracker.save_state("time_exit.AAPL.entry_date", "2026-01-01")
+        r = await time_based_exit_condition(positions=[], fields={}, context=self._ctx(tracker))
+        assert r["result"] is False
+        assert tracker.load_state("time_exit.AAPL.entry_date") is None
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_reentry_after_full_exit_starts_fresh(self, tmp_path):
+        """매도(사라짐) → 재매수 시 hold_days 가 0 부터 다시 센다 — 거짓 exit 없음."""
+        tracker = self._real_tracker(tmp_path)
+        aapl = [{"symbol": "AAPL", "qty": 100, "market_code": "82"}]
+        with patch("programgarden_community.plugins.time_based_exit.date", _FakeDate):
+            _FakeDate._today = date(2026, 9, 1)
+            await time_based_exit_condition(positions=aapl, fields={"max_hold_days": 5}, context=self._ctx(tracker))
+            _FakeDate._today = date(2026, 9, 3)
+            await time_based_exit_condition(positions=[], fields={"max_hold_days": 5}, context=self._ctx(tracker))
+            _FakeDate._today = date(2026, 9, 20)
+            r = await time_based_exit_condition(positions=aapl, fields={"max_hold_days": 5}, context=self._ctx(tracker))
+        sr = r["symbol_results"][0]
+        assert sr["entry_date"] == "2026-09-20"
+        assert sr["hold_days"] == 0
+        assert sr["action"] == "hold"
+
+    @pytest.mark.asyncio
+    async def test_tracker_without_state_feature_degrades_to_stateless(self, tmp_path):
+        """'state' feature 없는 실제 트래커: load_state→None, save_state→False — 크래시 없이 무상태."""
+        tracker = self._real_tracker(tmp_path, features=frozenset())
+        r = await time_based_exit_condition(
+            positions=[{"symbol": "AAPL", "qty": 100, "market_code": "82"}],
+            fields={"max_hold_days": 5}, context=self._ctx(tracker),
+        )
+        assert r["symbol_results"][0]["hold_days"] == 0
+        assert tracker.load_state("time_exit.AAPL.entry_date") is None
+
+    @pytest.mark.asyncio
+    async def test_foreign_tracker_variant_degrades_instead_of_crashing(self):
+        """load/save/delete_state 가 없는 트래커 변종 → 상태 경로를 켜지 않는다(크래시 금지)."""
+        class Foreign:
+            def get_state(self, key):  # 옛 이름 — 실제 트래커엔 없다
+                raise AssertionError("must not be called")
+        r = await time_based_exit_condition(
+            positions=[{"symbol": "AAPL", "qty": 100, "market_code": "82"}],
+            fields={"max_hold_days": 5}, context=MockContext(Foreign()),
+        )
+        assert r["symbol_results"][0]["hold_days"] == 0

--- a/src/community/tests/test_var_cvar_monitor_plugin.py
+++ b/src/community/tests/test_var_cvar_monitor_plugin.py
@@ -12,18 +12,20 @@ from programgarden_community.plugins.var_cvar_monitor import (
 
 
 class MockRiskTracker:
-    """위험 이벤트 기록 **목 계약** — 실제 WorkflowRiskTracker 인터페이스가 아니다.
+    """실제 ``WorkflowRiskTracker.record_risk_event`` 와 같은 시그니처의 fake.
 
-    실제 클래스에는 ``record_event`` 가 없다(실제 이름은 ``record_risk_event``).
-    플러그인 쪽 호출은 ``except Exception: pass`` 로 감싸져 있어 라이브에서는
-    이벤트가 한 건도 기록되지 않는다 — 아래 이벤트 테스트는 '목이 약속한
-    계약대로 플러그인이 호출한다' 만 증명한다. 관측 2026-09-12.
+    (event_type, severity, symbol, exchange, details, node_id) → event_id. 실제 클래스에 없는
+    ``record_event`` 를 제공하던 옛 목은 '초록인데 라이브에선 0건' 을 가렸다(2026-09-12).
+    실제 트래커 왕복은 아래 TestLiveEventPathIsAlive 가 고정한다.
     """
     def __init__(self):
         self.events = []
 
-    def record_event(self, event_type, symbol, data):
-        self.events.append({"event_type": event_type, "symbol": symbol, "data": data})
+    def record_risk_event(self, event_type, severity="warning", symbol=None, exchange=None,
+                          details=None, node_id=None):
+        self.events.append({"event_type": event_type, "severity": severity, "symbol": symbol,
+                            "details": details})
+        return len(self.events)
 
 
 class MockContext:
@@ -218,6 +220,7 @@ class TestVarCvarMonitorPlugin:
         if result["result"]:
             assert len(ctx.risk_tracker.events) > 0
             assert ctx.risk_tracker.events[0]["event_type"] == "var_breach"
+            assert ctx.risk_tracker.events[0]["details"]["threshold"] == 0.1
 
     @pytest.mark.asyncio
     async def test_empty_data(self):
@@ -407,3 +410,43 @@ class TestReducePositionBelowOneShareIsNotSilent:
 
     def test_schema_declares_the_reason(self):
         assert "reduce_skipped_reason" in VAR_CVAR_MONITOR_SCHEMA.output_fields
+
+
+class TestLiveEventPathIsAlive:
+    """실제 WorkflowRiskTracker(sqlite) 로 var_breach 이벤트가 정말 기록되는지 — 목이 아니라."""
+
+    @staticmethod
+    def _real_tracker(tmp_path):
+        mod = pytest.importorskip(
+            "programgarden.database.workflow_risk_tracker",
+            reason="engine package not installed; live-truth pin skipped",
+        )
+        return mod.WorkflowRiskTracker(
+            db_path=str(tmp_path / "rt.db"),
+            job_id="pin", product="overseas_stock", provider="ls",
+            trading_mode="real", features={"events"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_real_tracker_records_var_breach(self, tmp_path):
+        import json
+        import random
+        random.seed(7)
+        data = []
+        for i in range(120):
+            data.append({"symbol": "VOL", "close": 100 + random.uniform(-30, 30), "date": f"2026-01-{i % 28 + 1:02d}"})
+        tracker = self._real_tracker(tmp_path)
+
+        class Ctx:
+            risk_tracker = tracker
+
+        result = await var_cvar_monitor_condition(
+            data=data, fields={"lookback": 60, "alert_threshold_pct": 0.1}, context=Ctx(),
+        )
+        assert result["result"] is True, result
+        events = tracker.get_risk_events(event_type="var_breach")
+        assert len(events) >= 1
+        assert events[0]["symbol"] == "VOL"
+        details = json.loads(events[0]["details"])
+        assert details["threshold"] == 0.1
+        assert "var_pct" in details and "action" in details

--- a/src/finance/CHANGELOG.md
+++ b/src/finance/CHANGELOG.md
@@ -1,3 +1,17 @@
+## [1.9.7] - 2026-09-12
+
+### Fixed
+- **실시간 리스너 레지스트리가 TR 코드당 하나만 잡던 결함 (`real_base._on_message`)** — `dict[key] = listener`
+  단일 대입이라, 같은 `Real` 객체(엔진 `LSClientManager` 가 product 별로 공유)에 두 경로가 같은 TR 을 걸면
+  나중 등록이 앞의 것을 **조용히 지웠다**. 엔진에서 체결 원장 구독(`on_sc1_message`/`on_as0_message`/
+  `on_tc3_message`)과 주문이벤트 노드 마스터가 정확히 이 조합이다(2026-09-12 국내 SC1 회귀 실측; 해외주식
+  AS0·해외선물 TC3 는 그 전부터 같은 구조). 이제 키당 **리스너 리스트** — 등록은 append(동일 객체 중복 없음),
+  디스패치는 등록된 전부에 전달(한 리스너의 예약 실패가 다른 리스너를 막지 않음), 제거는
+  `_on_remove_message(key, listener=None)` — 지정 리스너만 떼고 미지정이면 종전처럼 그 키 전체를 뗀다.
+  마지막 리스너가 사라질 때만 계좌 실시간 등록(`_as01234_connect`/`_sc01234_connect`)을 해제한다.
+- 모든 `on_remove_*_message(listener=None)` 래퍼(28개 client.py)가 리스너를 받아 넘긴다 — 인자 없이 부르면
+  종전 동작(그 TR 전체 제거)이라 하위호환.
+
 ## [1.9.6] - 2026-09-12
 
 ### Changed

--- a/src/finance/programgarden_finance/ls/common/real/JIF/client.py
+++ b/src/finance/programgarden_finance/ls/common/real/JIF/client.py
@@ -99,7 +99,7 @@ class RealJIF:
         self._parent._on_message("JIF", self._dispatch)
         self._parent._add_message_symbols(["0"], "JIF")
 
-    def on_remove_jif_message(self):
+    def on_remove_jif_message(self, listener=None):
         """Unsubscribe and drop the registered listener.
 
         EN:
@@ -114,7 +114,7 @@ class RealJIF:
         try:
             self._parent._remove_message_symbols(["0"], "JIF")
         finally:
-            self._parent._on_remove_message("JIF")
+            self._parent._on_remove_message("JIF", listener)
             self._user_listener = None
 
     # ------------------------------------------------------------------

--- a/src/finance/programgarden_finance/ls/korea_stock/real/DVI/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/DVI/client.py
@@ -95,7 +95,7 @@ class RealDVI():
         """
         return self._parent._on_message("DVI", listener)
 
-    def on_remove_dvi_message(self):
+    def on_remove_dvi_message(self, listener=None):
         """등록된 시간외단일가 VI발동해제 콜백을 제거합니다.
 
         EN:
@@ -104,4 +104,4 @@ class RealDVI():
         KO:
             등록된 DVI 메시지 리스너를 제거합니다.
         """
-        return self._parent._on_remove_message("DVI")
+        return self._parent._on_remove_message("DVI", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/H1_/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/H1_/client.py
@@ -51,6 +51,6 @@ class RealH1_():
         """
         return self._parent._on_message("H1_", listener)
 
-    def on_remove_h1__message(self):
+    def on_remove_h1__message(self, listener=None):
         """등록된 KOSPI 호가잔량 콜백을 제거합니다."""
-        return self._parent._on_remove_message("H1_")
+        return self._parent._on_remove_message("H1_", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/HA_/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/HA_/client.py
@@ -43,6 +43,6 @@ class RealHA_():
         """
         return self._parent._on_message("HA_", listener)
 
-    def on_remove_ha__message(self):
+    def on_remove_ha__message(self, listener=None):
         """등록된 KOSDAQ 호가잔량 콜백을 제거합니다."""
-        return self._parent._on_remove_message("HA_")
+        return self._parent._on_remove_message("HA_", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/IJ_/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/IJ_/client.py
@@ -96,7 +96,7 @@ class RealIJ_():
         """
         return self._parent._on_message("IJ_", listener)
 
-    def on_remove_ij__message(self):
+    def on_remove_ij__message(self, listener=None):
         """등록된 업종지수 콜백을 제거합니다.
 
         EN:
@@ -105,4 +105,4 @@ class RealIJ_():
         KO:
             등록된 IJ_ 메시지 리스너를 제거합니다.
         """
-        return self._parent._on_remove_message("IJ_")
+        return self._parent._on_remove_message("IJ_", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/K3_/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/K3_/client.py
@@ -51,6 +51,6 @@ class RealK3_():
         """
         return self._parent._on_message("K3_", listener)
 
-    def on_remove_k3__message(self):
+    def on_remove_k3__message(self, listener=None):
         """등록된 KOSDAQ 체결 콜백을 제거합니다."""
-        return self._parent._on_remove_message("K3_")
+        return self._parent._on_remove_message("K3_", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/NH1/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/NH1/client.py
@@ -105,7 +105,7 @@ class RealNH1():
         """
         return self._parent._on_message("NH1", listener)
 
-    def on_remove_nh1_message(self):
+    def on_remove_nh1_message(self, listener=None):
         """등록된 NXT 호가잔량 콜백을 제거합니다.
 
         EN:
@@ -114,4 +114,4 @@ class RealNH1():
         KO:
             등록된 NH1 메시지 리스너를 제거합니다.
         """
-        return self._parent._on_remove_message("NH1")
+        return self._parent._on_remove_message("NH1", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/NVI/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/NVI/client.py
@@ -104,7 +104,7 @@ class RealNVI():
         """
         return self._parent._on_message("NVI", listener)
 
-    def on_remove_nvi_message(self):
+    def on_remove_nvi_message(self, listener=None):
         """등록된 NXT VI발동해제 콜백을 제거합니다.
 
         EN:
@@ -113,4 +113,4 @@ class RealNVI():
         KO:
             등록된 NVI 메시지 리스너를 제거합니다.
         """
-        return self._parent._on_remove_message("NVI")
+        return self._parent._on_remove_message("NVI", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/S3_/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/S3_/client.py
@@ -81,7 +81,7 @@ class RealS3_():
         """
         return self._parent._on_message("S3_", listener)
 
-    def on_remove_s3__message(self):
+    def on_remove_s3__message(self, listener=None):
         """등록된 KOSPI 체결 콜백을 제거합니다.
 
         EN:
@@ -90,4 +90,4 @@ class RealS3_():
         KO:
             등록된 S3_ 메시지 리스너를 제거합니다.
         """
-        return self._parent._on_remove_message("S3_")
+        return self._parent._on_remove_message("S3_", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/SC0/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/SC0/client.py
@@ -71,7 +71,7 @@ class RealSC0():
         self._parent._add_real_order_korea()
         return self._parent._on_message("SC0", listener)
 
-    def on_remove_sc0_message(self):
+    def on_remove_sc0_message(self, listener=None):
         """등록된 주문접수 콜백을 제거합니다.
 
         EN:
@@ -86,4 +86,4 @@ class RealSC0():
         Returns:
             WebSocket 메시지 리스너 제거 결과
         """
-        return self._parent._on_remove_message("SC0")
+        return self._parent._on_remove_message("SC0", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/SC1/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/SC1/client.py
@@ -79,7 +79,7 @@ class RealSC1():
         self._parent._add_real_order_korea()
         return self._parent._on_message("SC1", listener)
 
-    def on_remove_sc1_message(self):
+    def on_remove_sc1_message(self, listener=None):
         """등록된 주문체결 콜백을 제거합니다.
 
         EN:
@@ -94,4 +94,4 @@ class RealSC1():
         Returns:
             WebSocket 메시지 리스너 제거 결과
         """
-        return self._parent._on_remove_message("SC1")
+        return self._parent._on_remove_message("SC1", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/SC2/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/SC2/client.py
@@ -84,7 +84,7 @@ class RealSC2():
         self._parent._add_real_order_korea()
         return self._parent._on_message("SC2", listener)
 
-    def on_remove_sc2_message(self):
+    def on_remove_sc2_message(self, listener=None):
         """등록된 주문정정 콜백을 제거합니다.
 
         EN:
@@ -99,4 +99,4 @@ class RealSC2():
         Returns:
             WebSocket 메시지 리스너 제거 결과
         """
-        return self._parent._on_remove_message("SC2")
+        return self._parent._on_remove_message("SC2", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/SC3/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/SC3/client.py
@@ -83,7 +83,7 @@ class RealSC3():
         self._parent._add_real_order_korea()
         return self._parent._on_message("SC3", listener)
 
-    def on_remove_sc3_message(self):
+    def on_remove_sc3_message(self, listener=None):
         """등록된 주문취소 콜백을 제거합니다.
 
         EN:
@@ -98,4 +98,4 @@ class RealSC3():
         Returns:
             WebSocket 메시지 리스너 제거 결과
         """
-        return self._parent._on_remove_message("SC3")
+        return self._parent._on_remove_message("SC3", listener)

--- a/src/finance/programgarden_finance/ls/korea_stock/real/SC4/client.py
+++ b/src/finance/programgarden_finance/ls/korea_stock/real/SC4/client.py
@@ -87,7 +87,7 @@ class RealSC4():
         self._parent._add_real_order_korea()
         return self._parent._on_message("SC4", listener)
 
-    def on_remove_sc4_message(self):
+    def on_remove_sc4_message(self, listener=None):
         """등록된 주문거부 콜백을 제거합니다.
 
         EN:
@@ -102,4 +102,4 @@ class RealSC4():
         Returns:
             WebSocket 메시지 리스너 제거 결과
         """
-        return self._parent._on_remove_message("SC4")
+        return self._parent._on_remove_message("SC4", listener)

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/real/OVC/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/real/OVC/client.py
@@ -21,5 +21,5 @@ class RealOVC():
     def on_ovc_message(self, listener: Callable[[OVCRealResponse], None]):
         return self._parent._on_message("OVC", listener)
 
-    def on_remove_ovc_message(self):
-        return self._parent._on_remove_message("OVC")
+    def on_remove_ovc_message(self, listener=None):
+        return self._parent._on_remove_message("OVC", listener)

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/real/OVH/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/real/OVH/client.py
@@ -21,5 +21,5 @@ class RealOVH():
     def on_ovh_message(self, listener: Callable[[OVHRealResponse], None]):
         return self._parent._on_message("OVH", listener)
 
-    def on_remove_ovh_message(self):
-        return self._parent._on_remove_message("OVH")
+    def on_remove_ovh_message(self, listener=None):
+        return self._parent._on_remove_message("OVH", listener)

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/real/TC1/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/real/TC1/client.py
@@ -16,5 +16,5 @@ class RealTC1():
         self._parent._add_real_order()
         return self._parent._on_message("TC1", listener)
 
-    def on_remove_tc1_message(self):
-        return self._parent._on_remove_message("TC1")
+    def on_remove_tc1_message(self, listener=None):
+        return self._parent._on_remove_message("TC1", listener)

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/real/TC2/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/real/TC2/client.py
@@ -16,5 +16,5 @@ class RealTC2():
         self._parent._add_real_order()
         return self._parent._on_message("TC2", listener)
 
-    def on_remove_tc2_message(self):
-        return self._parent._on_remove_message("TC2")
+    def on_remove_tc2_message(self, listener=None):
+        return self._parent._on_remove_message("TC2", listener)

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/real/TC3/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/real/TC3/client.py
@@ -16,5 +16,5 @@ class RealTC3():
         self._parent._add_real_order()
         return self._parent._on_message("TC3", listener)
 
-    def on_remove_tc3_message(self):
-        return self._parent._on_remove_message("TC3")
+    def on_remove_tc3_message(self, listener=None):
+        return self._parent._on_remove_message("TC3", listener)

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/real/WOC/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/real/WOC/client.py
@@ -21,5 +21,5 @@ class RealWOC():
     def on_woc_message(self, listener: Callable[[WOCRealResponse], None]):
         return self._parent._on_message("WOC", listener)
 
-    def on_remove_woc_message(self):
-        return self._parent._on_remove_message("WOC")
+    def on_remove_woc_message(self, listener=None):
+        return self._parent._on_remove_message("WOC", listener)

--- a/src/finance/programgarden_finance/ls/overseas_futureoption/real/WOH/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_futureoption/real/WOH/client.py
@@ -21,5 +21,5 @@ class RealWOH():
     def on_woh_message(self, listener: Callable[[WOHRealResponse], None]):
         return self._parent._on_message("WOH", listener)
 
-    def on_remove_woh_message(self):
-        return self._parent._on_remove_message("WOH")
+    def on_remove_woh_message(self, listener=None):
+        return self._parent._on_remove_message("WOH", listener)

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS0/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS0/client.py
@@ -16,5 +16,5 @@ class RealAS0():
         self._parent._add_real_order()
         return self._parent._on_message("AS0", listener)
 
-    def on_remove_as0_message(self):
-        return self._parent._on_remove_message("AS0")
+    def on_remove_as0_message(self, listener=None):
+        return self._parent._on_remove_message("AS0", listener)

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS1/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS1/client.py
@@ -16,5 +16,5 @@ class RealAS1():
         self._parent._add_real_order()
         return self._parent._on_message("AS1", listener)
 
-    def on_remove_as1_message(self):
-        return self._parent._on_remove_message("AS1")
+    def on_remove_as1_message(self, listener=None):
+        return self._parent._on_remove_message("AS1", listener)

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS2/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS2/client.py
@@ -16,5 +16,5 @@ class RealAS2():
         self._parent._add_real_order()
         return self._parent._on_message("AS2", listener)
 
-    def on_remove_as2_message(self):
-        return self._parent._on_remove_message("AS2")
+    def on_remove_as2_message(self, listener=None):
+        return self._parent._on_remove_message("AS2", listener)

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS3/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS3/client.py
@@ -16,5 +16,5 @@ class RealAS3():
         self._parent._add_real_order()
         return self._parent._on_message("AS3", listener)
 
-    def on_remove_as3_message(self):
-        return self._parent._on_remove_message("AS3")
+    def on_remove_as3_message(self, listener=None):
+        return self._parent._on_remove_message("AS3", listener)

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/AS4/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/AS4/client.py
@@ -16,5 +16,5 @@ class RealAS4():
         self._parent._add_real_order()
         return self._parent._on_message("AS4", listener)
 
-    def on_remove_as4_message(self):
-        return self._parent._on_remove_message("AS4")
+    def on_remove_as4_message(self, listener=None):
+        return self._parent._on_remove_message("AS4", listener)

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/GSC/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/GSC/client.py
@@ -21,5 +21,5 @@ class RealGSC():
     def on_gsc_message(self, listener: Callable[[GSCRealResponse], None]):
         return self._parent._on_message("GSC", listener)
 
-    def on_remove_gsc_message(self):
-        return self._parent._on_remove_message("GSC")
+    def on_remove_gsc_message(self, listener=None):
+        return self._parent._on_remove_message("GSC", listener)

--- a/src/finance/programgarden_finance/ls/overseas_stock/real/GSH/client.py
+++ b/src/finance/programgarden_finance/ls/overseas_stock/real/GSH/client.py
@@ -31,5 +31,5 @@ class RealGSH():
     def on_gsh_message(self, listener: Callable[[GSHRealResponse], None]):
         return self._parent._on_message("GSH", listener)
 
-    def on_remove_gsh_message(self):
-        return self._parent._on_remove_message("GSH")
+    def on_remove_gsh_message(self, listener=None):
+        return self._parent._on_remove_message("GSH", listener)

--- a/src/finance/programgarden_finance/ls/real_base.py
+++ b/src/finance/programgarden_finance/ls/real_base.py
@@ -104,7 +104,12 @@ class RealRequestAbstract(ABC):
         self._listen_task = None
         self._as01234_connect = False
         self._sc01234_connect = False
-        self._on_message_listeners: Dict[str, Callable[[Any], Any]] = {}
+        # TR 코드(키)당 **리스너 리스트**. 1.9.7 이전엔 단일 대입(`dict[key] = listener`)이라
+        # 같은 Real 객체(엔진 LSClientManager 가 product 별로 공유)에 두 경로 — 예: 체결 원장 구독
+        # (`on_sc1_message`) 과 주문이벤트 노드 마스터 — 가 같은 TR 을 걸면 나중 것이 앞의 것을
+        # 조용히 지웠다(2026-09-12 국내 SC1 회귀 실측, 해외주식 AS0·해외선물 TC3 도 동일 구조).
+        # 이제 등록은 append, 디스패치는 전부 호출, 제거는 지정 리스너만(미지정 시 그 키 전체).
+        self._on_message_listeners: Dict[str, List[Callable[[Any], Any]]] = {}
         self._ref_count = 0
         self._ref_lock = asyncio.Lock()  # ref_count 보호용 Lock
         # 구독 심볼 추적 (재연결 시 자동 재구독용)
@@ -332,7 +337,7 @@ class RealRequestAbstract(ABC):
 
                             try:
 
-                                on_message = self._on_message_listeners.get(tr_cd, None)
+                                listeners = list(self._on_message_listeners.get(tr_cd) or [])
 
                                 resp_header = resp_json.get('header', {})
 
@@ -354,36 +359,12 @@ class RealRequestAbstract(ABC):
                                 )
                                 resp.raw_data = resp_json
 
-                            if on_message is None:
+                            if not listeners:
                                 continue
 
                             loop = asyncio.get_running_loop()
-
-                            # async handler: schedule a task
-                            if inspect.iscoroutinefunction(on_message):
-                                try:
-                                    task = asyncio.create_task(on_message(resp))
-                                except Exception:
-                                    # if scheduling fails, skip
-                                    continue
-
-                                # attach simple exception logging to avoid silent failures
-                                def _on_done(t: asyncio.Task):
-                                    try:
-                                        exc = t.exception()
-                                        if exc is not None:
-                                            pass
-                                            # print(f"handler task error: {exc}")
-                                    except asyncio.CancelledError:
-                                        pass
-
-                                task.add_done_callback(_on_done)
-                            else:
-                                # sync handler: offload to default threadpool so recv loop isn't blocked
-                                try:
-                                    loop.run_in_executor(None, on_message, resp)
-                                except Exception:
-                                    continue
+                            for on_message in listeners:
+                                self._dispatch_to_listener(loop, on_message, resp)
 
                 except asyncio.CancelledError:
                     # allow cancellation to bubble up for clean shutdown
@@ -520,14 +501,49 @@ class RealRequestAbstract(ABC):
         """
         if not self._connected_event.is_set():
             raise RuntimeError("WebSocket is not connected")
-        self._on_message_listeners[message_key] = listener
+        bucket = self._on_message_listeners.setdefault(message_key, [])
+        if listener not in bucket:
+            bucket.append(listener)
 
-    def _on_remove_message(self, message_key: str):
+    @staticmethod
+    def _dispatch_to_listener(loop: asyncio.AbstractEventLoop, on_message: Callable[[Any], Any], resp: Any) -> None:
+        """한 리스너에게 응답 1건을 전달한다 — 비동기면 task, 동기면 threadpool.
+
+        리스너 하나의 예약 실패가 같은 TR 의 다른 리스너를 막지 않도록 예외는 여기서 끝낸다.
+        """
+        # async handler: schedule a task
+        if inspect.iscoroutinefunction(on_message):
+            try:
+                task = asyncio.create_task(on_message(resp))
+            except Exception:
+                # if scheduling fails, skip
+                return
+
+            # attach simple exception logging to avoid silent failures
+            def _on_done(t: asyncio.Task):
+                try:
+                    exc = t.exception()
+                    if exc is not None:
+                        pass
+                        # print(f"handler task error: {exc}")
+                except asyncio.CancelledError:
+                    pass
+
+            task.add_done_callback(_on_done)
+        else:
+            # sync handler: offload to default threadpool so recv loop isn't blocked
+            try:
+                loop.run_in_executor(None, on_message, resp)
+            except Exception:
+                return
+
+    def _on_remove_message(self, message_key: str, listener: Optional[Callable[[Any], Any]] = None):
         """Detach a registered listener and clean up order subscriptions.
 
         EN:
-            Removes the listener and, when no listeners remain, clears
-            auto-registered order streams.
+            Removes ``listener`` for ``message_key`` (or every listener under that
+            key when ``listener`` is None) and, when no listeners remain at all,
+            clears auto-registered order streams.
 
         KO:
             등록된 리스너를 제거하며 더 이상 리스너가 없을 경우 자동 주문 구독을
@@ -535,8 +551,18 @@ class RealRequestAbstract(ABC):
         """
         if not self._connected_event.is_set():
             raise RuntimeError("WebSocket is not connected")
-        if message_key in self._on_message_listeners:
-            del self._on_message_listeners[message_key]
+        bucket = self._on_message_listeners.get(message_key)
+        if bucket is not None:
+            if listener is None:
+                # 하위호환: 리스너 미지정이면 그 키의 리스너 전부 제거(1.9.6 이전 동작).
+                bucket.clear()
+            else:
+                try:
+                    bucket.remove(listener)
+                except ValueError:
+                    pass
+            if not bucket:
+                del self._on_message_listeners[message_key]
 
         if len(self._on_message_listeners) == 0:
             self._as01234_connect = False

--- a/src/finance/pyproject.toml
+++ b/src/finance/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden-finance"
-version = "1.9.6"
+version = "1.9.7"
 license = "AGPL-3.0-or-later"
 description = "프로그램 동산 운영진이 관리하는 증권사 데이터 오픈소스"
 readme = "README.md"

--- a/src/finance/tests/test_real_base_multi_listener.py
+++ b/src/finance/tests/test_real_base_multi_listener.py
@@ -1,0 +1,102 @@
+"""real_base 리스너 레지스트리 — 키(TR)당 다중 리스너 (1.9.7).
+
+배경: 1.9.6 까지 `_on_message` 가 `dict[key] = listener` 단일 대입이라 같은 Real 객체에 두 경로가
+같은 TR 을 걸면 나중 것이 앞의 것을 조용히 지웠다(엔진 체결 원장 구독 vs 주문이벤트 노드 마스터,
+2026-09-12 국내 SC1 회귀 실측). 이 테스트는 그 계약을 고정한다.
+"""
+import asyncio
+
+import pytest
+
+from programgarden_finance.ls.korea_stock.real import Real as KoreaReal
+from programgarden_finance.ls.token_manager import TokenManager
+
+
+def _real() -> KoreaReal:
+    real = KoreaReal(token_manager=TokenManager())  # 네트워크 없음 — 레지스트리만 본다
+    real._connected_event.set()  # _on_message 는 연결 전엔 RuntimeError
+    return real
+
+
+def test_two_listeners_on_same_key_both_survive():
+    real = _real()
+    a, b = (lambda r: None), (lambda r: None)
+    real._on_message("SC1", a)
+    real._on_message("SC1", b)
+    assert real._on_message_listeners["SC1"] == [a, b]
+
+
+def test_same_listener_registered_twice_is_kept_once():
+    real = _real()
+    a = lambda r: None  # noqa: E731
+    real._on_message("SC1", a)
+    real._on_message("SC1", a)
+    assert real._on_message_listeners["SC1"] == [a]
+
+
+def test_remove_specific_listener_keeps_the_other():
+    real = _real()
+    a, b = (lambda r: None), (lambda r: None)
+    real._on_message("SC1", a)
+    real._on_message("SC1", b)
+    real._on_remove_message("SC1", a)
+    assert real._on_message_listeners["SC1"] == [b]
+    # 남은 리스너가 있으므로 계좌 실시간 등록 플래그는 건드리지 않는다
+    real._sc01234_connect = True
+    real._on_remove_message("SC1", (lambda r: None))  # 미등록 리스너 제거는 무해
+    assert real._on_message_listeners["SC1"] == [b]
+    assert real._sc01234_connect is True
+
+
+def test_remove_without_listener_clears_whole_key_backward_compatible(monkeypatch):
+    real = _real()
+    # 마지막 리스너가 사라지면 계좌 실시간 해제를 시도한다 — 소켓이 없으므로 그 부분만 막는다
+    monkeypatch.setattr(real, "_remove_real_order_korea", lambda: None)
+    monkeypatch.setattr(real, "_remove_real_order", lambda: None)
+    a, b = (lambda r: None), (lambda r: None)
+    real._on_message("SC1", a)
+    real._on_message("SC1", b)
+    real._on_remove_message("SC1")
+    assert "SC1" not in real._on_message_listeners
+
+
+def test_last_listener_removed_resets_order_flags(monkeypatch):
+    real = _real()
+    a = lambda r: None  # noqa: E731
+    real._on_message("SC1", a)
+    real._sc01234_connect = True
+    real._as01234_connect = True
+    called = []
+    monkeypatch.setattr(real, "_remove_real_order_korea", lambda: called.append("kr"))
+    monkeypatch.setattr(real, "_remove_real_order", lambda: called.append("os"))
+    real._on_remove_message("SC1", a)
+    assert real._on_message_listeners == {}
+    assert real._sc01234_connect is False and real._as01234_connect is False
+    assert set(called) == {"kr", "os"}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_reaches_every_listener_sync_and_async():
+    real = _real()
+    got = []
+    done = asyncio.Event()
+
+    def sync_listener(resp):
+        got.append(("sync", resp))
+
+    async def async_listener(resp):
+        got.append(("async", resp))
+        done.set()
+
+    real._on_message("SC1", sync_listener)
+    real._on_message("SC1", async_listener)
+    loop = asyncio.get_running_loop()
+    for fn in list(real._on_message_listeners["SC1"]):
+        real._dispatch_to_listener(loop, fn, "frame")
+    await asyncio.wait_for(done.wait(), 2)
+    # sync 리스너는 threadpool 로 넘어가므로 잠깐 양보
+    for _ in range(50):
+        if len(got) == 2:
+            break
+        await asyncio.sleep(0.02)
+    assert sorted(got) == [("async", "frame"), ("sync", "frame")]

--- a/src/programgarden/CHANGELOG.md
+++ b/src/programgarden/CHANGELOG.md
@@ -1,3 +1,55 @@
+## [1.37.1] - 2026-09-12
+
+1.37.0 을 내면서 남긴 **장(브로커) 없이 고칠 수 있는 후속 결함** 묶음. 국내 주문이벤트 노드가 SC1~SC4 프레임을
+받지 못하던 것, TC3 체결가 갱신이 키 오타로 죽어 있던 것, 브로커 노드가 LS 로그인 실패를 삼키고 completed 로
+끝나던 것(2026-09-12 prod 실관측), 상태 기반 포지션 플러그인이 라이브에서 상태를 저장하지 못하던 것.
+
+### Fixed
+- **국내주식 주문이벤트 노드(`RealOrderEventNode`, SC0~SC4)가 SC1~SC4 프레임을 받지 못하던 결함** — 리스너를
+  `SC0().on_sc0_message` 하나만 등록한 채 핸들러 안에서 `tr_cd` 로 분기했는데, SDK 디스패치는 `tr_cd` 정확일치
+  키라 SC1(체결)·SC2(정정)·SC3(취소)·SC4(거부) 프레임은 노드에 도달조차 못 했다(`event_filter` 를 SC1 로 두면
+  출력 0건). 다섯 스트림을 각각 등록(`_KOREA_ORDER_EVENT_STREAMS`)하고 **스트림별 파서**로 분리 — 파서가 읽던
+  PascalCase 필드명(`OrdNo`/`ExecQty`…)은 SDK 블록에 존재하지 않아 전 필드가 0/빈값이었다(pydantic
+  `extra='ignore'`). 실제 필드(SC0 `ordno`/`ordqty`/`ordprice`/`expcode`…, SC1 계열 `execqty`/`execprc`/
+  `unercqty`/`exectime`/`execno`…)로 읽고, SC0(접수)에 없는 체결 필드는 0 으로 지어내지 않고
+  `filled_price_unavailable_reason` 으로 표시한다. 수량 `_qty_num`, 가격 float. SC1 체결가 반영 분기는 프레임의
+  주문일자를 쓴다. 체결 원장 경로(`on_sc1_event`)는 건드리지 않았다(별 표면).
+- **주문이벤트 노드 마스터가 체결 원장 구독을 덮어쓰던 회귀/결함** — SDK 리스너 레지스트리가 TR 당 하나였기 때문에
+  (finance ≤1.9.6), 같은 Real 객체에 원장 리스너(`on_sc1_event`/AS0·AS1/`on_tc3_event`)와 노드 마스터가 같은 TR 을
+  걸면 나중 등록이 앞의 것을 지웠다(국내 SC1 은 이번 변경으로 새로, 해외주식 AS0·해외선물 TC3 는 그 전부터).
+  finance 1.9.7(키당 다중 리스너)로 근본 수정하고, 정리 경로는 `context.set_order_event_masters` 에 기억해 둔
+  **노드 마스터 콜러블만** `on_remove_<tr>_message(master)` 로 뗀다 — 종전엔 SC0/AS0 키 전체를 떼어 원장 리스너까지
+  지웠고, SC1~SC4·AS1~AS4 마스터는 영영 남아 SDK 의 "리스너 0 → 계좌 실시간 해제" 조건에 도달하지 못했다.
+- **해외주식 주문이벤트 노드(`RealOrderEventNode`, AS0~AS4)도 같은 결함** — AS0 마스터 하나만 등록해 AS1(체결)·AS2·AS3·AS4
+  프레임이 노드에 도달하지 못했고, 체결가 갱신은 주문가(`sOrdPrc`)를 쓰는 데다 조건(`'11'`)이 AS0 enum 에 없어 한 번도
+  타지 않았다. 국내와 동형으로 스트림별 등록·파서 분리(AS0 접수 전용 / AS1~AS4 체결형), 체결가는 `sExecPrc`, 소수점
+  `sExecQty` 보존, 거래소는 검증된 코드(81/82/83)만 표시하고 미지 코드는 사유 표시. 뒤에 붙는 노드가 SDK 에 없는 스트림을
+  고르면 `unavailable_streams` + warning(조용한 실패 금지, 국내도 노드별로 통일).
+- **주문이벤트 출력에 선언 필드명 alias 추가** — core `ORDER_EVENT_FIELDS` 는 `order_id/quantity/filled_quantity/price` 를
+  선언하는데 파서 3종은 `order_no/order_qty/filled_qty/order_price` 만 실어 AI 가 예제대로 `{{ …order_id }}` 를 쓰면
+  빈값이 렌더됐다. 의미가 1:1 인 네 키만 alias 로 함께 싣는다(기존 키 유지, core 무변경). `event_type` 은 1:1 대응 키가
+  없어 alias 하지 않는다.
+- **positions 가 빈 리스트일 때 상태 플러그인이 아예 호출되지 않던 경로** — 전량 매도로 계좌가 비면 `time_based_exit` 의
+  진입일 정리 스윕이 돌지 않아 재매수 직후 옛 진입일로 거짓 청산이 날 수 있었다. `context` 를 선언한 플러그인은
+  `positions=[]` 로 한 번 호출(결과는 판정에 미반영, 예외는 warning).
+- **TC3(해외선물) 주문이벤트 체결가 갱신이 한 번도 호출되지 않던 결함** — 핸들러가 `fill_price` 키를 읽는데
+  `_parse_tc3_data` 는 `filled_price`(노드 선언 출력 필드명) 만 담아 항상 0 이었다. 리더 키를 고치고,
+  `ordr_dt` 기반 `order_date` 를 파서에 담아 그 값으로 갱신한다(비면 오늘 날짜로 지어내지 않고 건너뛴 사유를
+  warning 으로 남긴다).
+- **브로커 노드가 LS 로그인 실패를 삼키고 체결 구독 없이 completed 로 끝나던 결함(2026-09-12 prod 실관측)** —
+  주문 노드는 재로그인을 시도하므로 "주문은 나가는데 체결은 원장에 안 잡히는" 조합이 됐다. 체결 구독 로그인은
+  2회 백오프 재시도(2s·5s, LS 앱키 공유·전송수 제한 때문에 상한 고정) 후에도 실패하면 `ExecutionError` 로
+  **노드 실패**로 올리고 `CONNECTION_FAILED`(CRITICAL) 알림을 보낸다. 로그인 뒤 구독 자체 실패도 같은 경로.
+  체결 구독 호출부에만 없던 `dry_run` 게이트를 추가(모의 실행은 주문·체결이 없으므로 건너뛰고 info 로그).
+- **positions 기반 조건 플러그인에 `context` 가 전달되지 않아 상태 저장이 늘 꺼져 있던 결함** — data 분기와
+  같은 규약으로 `inspect.signature` 에 `context` 가 있을 때만 넘긴다. 이로써 `partial_take_profit` 등의
+  상태 경로가 처음으로 실제 동작한다(community 1.15.3 의 플러그인 수정과 짝).
+
+### Changed
+- deps: `programgarden-finance ^1.9.7`(실시간 리스너 레지스트리 키당 다중 리스너 — 주문이벤트 노드 마스터가 체결
+  원장 구독을 덮어쓰던 회귀의 근본 수정) · `programgarden-community ^1.15.3`(상태 기반 플러그인 5종 트래커 메서드명
+  수정). core 1.28.0 무변경.
+
 ## [1.37.0] - 2026-09-12
 
 LS 브로커 필드 의미를 오너가 확인해준 사실(체결번호·AP처리시각·소수점 주식·TC3 조건부 필드·국내 매체코드)로

--- a/src/programgarden/poetry.lock
+++ b/src/programgarden/poetry.lock
@@ -2589,14 +2589,14 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "programgarden-community"
-version = "1.15.0"
+version = "1.15.3"
 description = "ProgramGarden Community - 전략 플러그인 모음"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "programgarden_community-1.15.0-py3-none-any.whl", hash = "sha256:216acbf9c33d0ff2fd2bf94da90618955254976ced872a1fe6bc7279838c71e8"},
-    {file = "programgarden_community-1.15.0.tar.gz", hash = "sha256:5a65c8a74986398d3ebc7454a0fbf3276c8c5d5dde030c091f4544c732062412"},
+    {file = "programgarden_community-1.15.3-py3-none-any.whl", hash = "sha256:af5095a862d0b001762ccfd957d182f06029a5058247bc40f23cc325b2bb56d5"},
+    {file = "programgarden_community-1.15.3.tar.gz", hash = "sha256:fb2a8de99aedea781992e9434af6a44611fadabe5baddef81a875b935934bcc7"},
 ]
 
 [package.dependencies]
@@ -2610,14 +2610,14 @@ quant-all = ["packaging (>=23)", "pyportfolioopt (>=1.6,<2) ; python_version < \
 
 [[package]]
 name = "programgarden-core"
-version = "1.25.3"
+version = "1.28.0"
 description = "ProgramGarden Core - 노드 기반 DSL 핵심 타입 정의"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "programgarden_core-1.25.3-py3-none-any.whl", hash = "sha256:67a1acda5cf127d3f9ba3a7fead834323e6c83d6a23d6a63e3bf5957612bb78a"},
-    {file = "programgarden_core-1.25.3.tar.gz", hash = "sha256:70ef83eb725e89051737d54befd52667639533b3b62b89ad3d369255f5fea7a3"},
+    {file = "programgarden_core-1.28.0-py3-none-any.whl", hash = "sha256:b56ad13c6ef669f53b4d191d9b3426ed95461a4bc5d5eed7cc894828a9ac9ef6"},
+    {file = "programgarden_core-1.28.0.tar.gz", hash = "sha256:353c4b234004923ac3c7d0c84b5858974614cc1f2a7dc869c109de32323281bb"},
 ]
 
 [package.dependencies]
@@ -2625,14 +2625,14 @@ pydantic = ">=2.0.0,<3.0.0"
 
 [[package]]
 name = "programgarden-finance"
-version = "1.9.4"
+version = "1.9.7"
 description = "프로그램 동산 운영진이 관리하는 증권사 데이터 오픈소스"
 optional = false
 python-versions = ">=3.12"
 groups = ["main"]
 files = [
-    {file = "programgarden_finance-1.9.4-py3-none-any.whl", hash = "sha256:5de04e96537afe70da1ccd4241a1cb56b0650af072abad555a64c6ca056895f9"},
-    {file = "programgarden_finance-1.9.4.tar.gz", hash = "sha256:6a9c75dbaa5a1914067058d6d01e52e6b00b59d2adc589b1ccf105c76c77d5e9"},
+    {file = "programgarden_finance-1.9.7-py3-none-any.whl", hash = "sha256:1512b1c155f4e4575c61620c4e2288b70c310ca1d25bd37b3a626965bb787828"},
+    {file = "programgarden_finance-1.9.7.tar.gz", hash = "sha256:ca853c0ff12371412526a400f46203fa840bb5b98e41a6b86bfbc947081be07e"},
 ]
 
 [package.dependencies]
@@ -4179,4 +4179,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "6bdd030a8a8b436efcf1dd67a41e0c7817c7043dd76248de08152986e517e8b7"
+content-hash = "ec1c408b63c7cda257fee1ae18ced9451890f1055032594106950577b81f0d91"

--- a/src/programgarden/programgarden/context.py
+++ b/src/programgarden/programgarden/context.py
@@ -263,6 +263,10 @@ class ExecutionContext:
         # {product: {tr_cd: [(node_id, event_filter, handler)]}}
         self._order_event_handlers: Dict[str, Dict[str, List[tuple]]] = {}
         self._order_event_real_client: Dict[str, Any] = {}  # {product: real_client}
+        # {product: {stream(TR): master_callable}} — 주문이벤트 노드가 SDK 에 건 마스터 콜백.
+        # 정리 때 **이 콜러블만** 떼야 같은 Real 객체를 공유하는 체결 원장 구독(on_sc1_event 등)이
+        # 살아남는다(finance 1.9.7 키당 다중 리스너 + on_remove_*_message(listener)).
+        self._order_event_masters: Dict[str, Dict[str, Callable]] = {}
         
         # === New: Cleanup on flow end (stay_connected=False) ===
         # Stores trackers that should be cleaned up after each flow execution
@@ -1210,6 +1214,18 @@ class ExecutionContext:
         """Get the real_client for a product"""
         return self._order_event_real_client.get(product)
 
+    def set_order_event_masters(self, product: str, masters: Dict[str, Callable]) -> None:
+        """주문이벤트 노드가 SDK 에 등록한 마스터 콜백을 스트림(TR)별로 기억한다.
+
+        정리(`cleanup_persistent_nodes`)가 `on_remove_<tr>_message(master)` 로 **이 콜러블만** 떼어,
+        같은 Real 객체에 걸린 체결 원장 리스너를 지우지 않게 한다. 같은 product 에 다시 부르면 갱신.
+        """
+        self._order_event_masters[product] = dict(masters)
+
+    def get_order_event_masters(self, product: str) -> Dict[str, Callable]:
+        """등록된 마스터 콜백 {stream: callable} (없으면 빈 dict)."""
+        return dict(self._order_event_masters.get(product, {}))
+
     async def cleanup_persistent_nodes(self) -> None:
         """
         Cleanup all persistent nodes (call on job stop)
@@ -1296,6 +1312,28 @@ class ExecutionContext:
 
         # 4. Order event master callback SDK 레벨 해제
         for product, real_client in self._order_event_real_client.items():
+            masters = self._order_event_masters.get(product) or {}
+            if masters:
+                # 스트림별로 **우리 마스터만** 뗀다(리스너 인자). 리스너를 안 받는 구 SDK(<1.9.7)면
+                # 그 키 전체가 떨어지는 옛 동작으로 폴백 — 원장 구독이 같이 사라지므로 warning.
+                for stream, master in masters.items():
+                    try:
+                        client = getattr(real_client, stream)()
+                        remover = getattr(client, f"on_remove_{stream.lower()}_message")
+                        try:
+                            remover(master)
+                        except TypeError:
+                            remover()
+                            logger.warning(
+                                f"SDK on_remove_{stream.lower()}_message accepts no listener — "
+                                f"removed the whole {stream} key for {product} (ledger listener may be gone)"
+                            )
+                        logger.debug(f"Removed {stream} master callback for {product}")
+                    except RuntimeError:
+                        logger.debug(f"{stream} order event callback already detached for {product}")
+                    except (AttributeError, Exception) as e:
+                        logger.warning(f"Failed to remove {stream} order event callback for {product}: {e}")
+                continue
             try:
                 if product == "overseas_stock":
                     real_client.AS0().on_remove_as0_message()
@@ -1321,6 +1359,7 @@ class ExecutionContext:
 
         self._order_event_handlers.clear()
         self._order_event_real_client.clear()
+        self._order_event_masters.clear()
 
         # 5. Stop/Close all trackers (WebSocket clients 등)
         for node_id, tracker in self._persistent_nodes.items():

--- a/src/programgarden/programgarden/executor.py
+++ b/src/programgarden/programgarden/executor.py
@@ -4076,6 +4076,15 @@ class BrokerNodeExecutor(NodeExecutorBase):
     _PNL_DRAIN_TIMEOUT_SECONDS = 1.0
     _PNL_CANCEL_TIMEOUT_SECONDS = 0.25
 
+    # 체결 이벤트 구독 로그인 재시도 간격(초). 길이 = 재시도 횟수(최초 1회 + 2회 = 총 3회).
+    # 상한을 두는 이유: LS 앱키는 여러 서비스가 **공유**하고 oauth2/token 에 전송수
+    # 제한이 있다(이 저장소 운영 메모). 무한/무제한 재시도는 그 한도를 때려 다른
+    # 워크플로우의 로그인까지 같이 막는다. 반대로 0회면 2026-09-12 prod 사고처럼
+    # 일시적 접속 불가에 영구히 눈이 먼다 — 그 타협점이 3회/누적 7초다.
+    # (값의 근거는 '일시 장애면 수 초 안에 복구된다' 는 경험칙이지, 관측된 복구
+    #  시간 분포가 아니다 — LS 측 복구 시간은 우리가 관측한 적 없다.)
+    _FILL_SUBSCRIPTION_LOGIN_RETRY_DELAYS = (2.0, 5.0)
+
     def _start_background_task(
         self, context: ExecutionContext, coroutine, *, notification: bool = False,
     ) -> Optional[asyncio.Task]:
@@ -4374,7 +4383,13 @@ class BrokerNodeExecutor(NodeExecutorBase):
         # await로 실행하여 WebSocket 연결이 완료된 후 다음 노드 진행
         # 이렇게 해야 주문 시점에 체결 이벤트를 수신할 수 있음
         # ========================================
-        if appkey and appsecret and has_workflow_listener:
+        # dry_run 은 skip — 모의 실행은 주문/실시간 콜백을 모두 skip 하므로 기록할
+        # 체결 자체가 없고, 이 경로도 위 두 경로(_sync_fill_prices_from_history,
+        # _start_account_tracking)와 똑같이 실제 LS 로그인을 시도한다. 종전에는 이
+        # 하나만 dry_run 게이트가 없어, 더미 appsecret 으로 도는 검증 잡에서 매번
+        # 로그인 실패를 낸 뒤 조용히 통과했다(같은 이유로 저 둘은 이미 skip 이다 —
+        # 2026-08-29 Phase 9.6 실측 주석 참조).
+        if appkey and appsecret and has_workflow_listener and not context.is_dry_run:
             context.log("info", "Starting workflow fill event subscription for FIFO tracking", node_id)
             await self._subscribe_workflow_fill_events(
                 node_id=node_id,
@@ -4383,6 +4398,12 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 appsecret=appsecret,
                 paper_trading=paper_trading,
                 context=context,
+            )
+        elif appkey and appsecret and has_workflow_listener and context.is_dry_run:
+            context.log(
+                "info",
+                "dry_run: 체결 이벤트 구독을 건너뜁니다 (모의 실행에는 실제 체결이 없습니다)",
+                node_id,
             )
         
         # 🔐 `connection` 은 노드 출력이라 리스너(SSE) · get_state · 체크포인트로 외부에 나간다.
@@ -4507,16 +4528,38 @@ class BrokerNodeExecutor(NodeExecutorBase):
         LS 인스턴스를 공유합니다. 이로써 하나의 WebSocket 연결에서
         GSC(시세)와 AS0/AS1(주문) 이벤트를 모두 수신합니다.
         """
+        from programgarden_core.exceptions import ExecutionError
+
         try:
-            from datetime import datetime
-            
             # ensure_ls_login으로 동일한 LS 인스턴스 사용 (RealMarketDataNode와 공유)
+            # 🔴 로그인 실패를 **삼키지 않는다** (2026-09-12 prod 실관측):
+            #    LS OpenAPI 접속 불가 중에 뜬 파드가 `Token 요청 실패` 뒤 여기서 조용히
+            #    return 해 브로커 노드가 completed 로 끝났다. 그 파드는 실시간 체결을
+            #    영영 받지 못하는데, 주문 노드는 LSClientManager.get_or_create 가 매번
+            #    재로그인을 시도하므로 **주문은 나갔다** — 주문은 나가는데 체결은 원장에
+            #    안 잡히는 조합(FIFO 포지션·손익·리스크 판정이 전부 눈먼 상태)이다.
+            #    그래서 (가) 제한된 재시도 후에도 실패하면 (나) 노드 실패로 올린다.
+            delays = self._FILL_SUBSCRIPTION_LOGIN_RETRY_DELAYS
             ls, success, error = ensure_ls_login(appkey, appsecret, paper_trading, context, node_id, product)
-            
+            for attempt, delay in enumerate(delays, start=1):
+                if success:
+                    break
+                context.log(
+                    "warning",
+                    f"체결 이벤트 구독 로그인 실패 — {delay}초 후 재시도 "
+                    f"{attempt}/{len(delays)} (product={product}, node={node_id}): {error}",
+                    node_id,
+                )
+                await asyncio.sleep(delay)
+                ls, success, error = ensure_ls_login(appkey, appsecret, paper_trading, context, node_id, product)
+
             if not success:
-                context.log("error", f"Failed to login for fill event subscription (node={node_id}): {error}", node_id)
-                return
-            
+                raise ExecutionError(
+                    f"체결 이벤트 구독을 위한 LS 로그인이 재시도 {len(delays)}회 후에도 "
+                    f"실패했습니다 (product={product}): {error}",
+                    node_id=node_id,
+                )
+
             context.log("info", f"Using shared LS instance for fill event subscription (product={product})", node_id)
             
             if product == "overseas_stock":
@@ -4529,7 +4572,36 @@ class BrokerNodeExecutor(NodeExecutorBase):
                 context.log("warning", f"Unknown product type for fill subscription: {product}", node_id)
                 
         except Exception as e:
-            context.log("error", f"Failed to subscribe fill events: {e}", node_id)
+            # context.log("error") 는 stdout 에 남지 않는다 — 투자자 알림 채널로도
+            # 드러내고(구독 없이 주문만 나가는 상태를 사람이 알아야 한다), 노드를
+            # 실패시킨다. 구독이 없으면 체결 원장이 비어 손익·리스크가 전부 눈먼다.
+            message = (
+                f"체결 이벤트 구독에 실패했습니다 (product={product}): {e}. "
+                "실시간 체결이 원장에 기록되지 않으므로 주문을 내지 않고 중단합니다."
+            )
+            context.log("error", message, node_id)
+            try:
+                await context.send_notification(
+                    category=NotificationCategory.CONNECTION_FAILED,
+                    severity=NotificationSeverity.CRITICAL,
+                    title="체결 이벤트 구독 실패",
+                    message=message,
+                    node_id=node_id,
+                    node_type="BrokerNode",
+                    data={
+                        "product": product,
+                        "login_retry_count": len(self._FILL_SUBSCRIPTION_LOGIN_RETRY_DELAYS),
+                        "error": str(e),
+                    },
+                )
+            except Exception as notify_error:  # 알림 실패가 본래 실패를 가리지 않게
+                logger.warning(f"체결 구독 실패 알림 전송 실패: {notify_error}")
+            if isinstance(e, ExecutionError):
+                raise
+            raise ExecutionError(
+                f"Failed to subscribe fill events (product={product}): {e}",
+                node_id=node_id,
+            ) from e
     
     async def _subscribe_overseas_stock_fill_events(
         self,
@@ -8311,106 +8383,126 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
         stay_connected: bool,
         event_filter: str = "all",
     ) -> Dict[str, Any]:
-        """해외주식 실시간 주문 체결 이벤트 (AS0~AS4)
-        
-        AS0~AS4 중 하나만 등록해도 전체 수신됨.
-        여러 노드가 동시에 사용할 수 있도록 마스터 콜백 패턴 사용.
-        """
-        from datetime import datetime
-        
-        product = "overseas_stock"
-        
-        try:
-            # 현재 이벤트 루프 캡처 (콜백에서 사용)
-            loop = asyncio.get_running_loop()
-            
-            # 트리거할 하위 노드 목록
-            trigger_nodes = config.get("_trigger_on_update_nodes", [])
-            
-            # ========================================
-            # 노드별 핸들러 생성 및 등록
-            # ========================================
-            def create_handler(_node_id: str, _event_filter: str, _trigger_nodes: list):
-                """특정 노드용 핸들러 생성 (클로저로 값 캡처)"""
+        """해외주식 실시간 주문 체결 이벤트 (AS0~AS4).
 
+        🔴 종전 결함(국내 SC 와 동형): real_client.AS0().on_as0_message(master)
+        하나만 걸고 핸들러 안에서 tr_cd 로 AS1~AS4 를 분기했는데, SDK 디스패치는
+        tr_cd **정확일치 키**다(ls/real_base.py:340 _on_message_listeners.get(tr_cd)).
+        AS1(체결)·AS2(정정)·AS3(취소확인)·AS4(거부) 프레임은 리스너가 없어 이 노드에
+        **도달조차 못 했다** — filled/modified/cancelled/rejected 포트는 영구히 0건,
+        event_filter='AS1'~'AS4' 면 출력이 통째로 없었다. 게다가 체결가 갱신 분기는
+        주문가(sOrdPrc)를 체결가로 썼고 '11' 코드는 AS0 enum('01'/'03'/'12'/'13'/'14')에
+        없어 한 번도 타지 않았다. 이제 스트림마다 리스너를 따로 등록하고 AS1 체결가는
+        sExecPrc(파서의 filled_price)로 읽는다.
+
+        체결 원장 경로(_subscribe_overseas_stock_fill_events 의 AS0/AS1 리스너)는
+        같은 Real 객체를 공유하지만, SDK 가 키당 리스너 **리스트**로 바뀌어(append)
+        서로 덮어쓰지 않는다. 등록한 마스터는 context.set_order_event_masters 로
+        저장해, 정리 경로가 원장 리스너를 건드리지 않고 이 마스터만 떼게 한다.
+        """
+        product = "overseas_stock"
+
+        try:
+            loop = asyncio.get_running_loop()
+            trigger_nodes = config.get("_trigger_on_update_nodes", [])
+
+            wanted_streams = self._overseas_stock_order_event_streams(event_filter)
+            if not wanted_streams:
+                msg = (
+                    f"Unsupported event_filter for overseas_stock order events: "
+                    f"{event_filter} (allowed: all, AS0~AS4)"
+                )
+                context.log("error", msg, node_id)
+                return {"error": msg}
+
+            def create_handler(_node_id: str, _event_filter: str, _stream: str, _trigger_nodes: list):
                 def handler(resp):
                     if context.is_shutdown:
                         return
                     from datetime import datetime
 
-                    # header에서 tr_cd 확인하여 필터링
                     header = getattr(resp, 'header', None)
-                    tr_cd = getattr(header, 'tr_cd', 'AS0') if header else 'AS0'
-                    
-                    # event_filter가 'all'이 아니면 해당 TR만 처리
+                    # 헤더가 없으면 이 리스너가 등록된 스트림이 곧 TR 이다 —
+                    # real_base 는 tr_cd 정확일치로만 배달하므로 둘은 같다.
+                    tr_cd = (getattr(header, 'tr_cd', '') if header else '') or _stream
+
                     if _event_filter != "all" and tr_cd != _event_filter:
-                        return  # 필터링된 TR이 아니면 무시
-                    
-                    # body에서 필드 추출
-                    body = getattr(resp, 'body', resp)
-                    ord_type_code = getattr(body, 'sOrdxctPtnCode', '')
-                    
-                    event_data = {
-                        "timestamp": datetime.now().isoformat(),
-                        "tr_cd": tr_cd,
-                        "event_code": ord_type_code,
-                        "symbol": getattr(body, 'sShtnIsuNo', getattr(body, 'sIsuNo', '')),
-                        "symbol_name": getattr(body, 'sIsuNm', ''),
-                        "order_no": getattr(body, 'sOrdNo', 0),
-                        "orig_order_no": getattr(body, 'sOrgOrdNo', 0),
-                        "side": getattr(body, 'sOrdPtnCode', ''),
-                        "order_qty": _qty_num(getattr(body, 'sOrdQty', 0)),
-                        "order_price": float(getattr(body, 'sOrdPrc', 0)),
-                        "remain_qty": _qty_num(getattr(body, 'sOrgOrdUnercQty', 0)),
-                        "modified_qty": _qty_num(getattr(body, 'sOrgOrdMdfyQty', 0)),
-                        "cancelled_qty": _qty_num(getattr(body, 'sOrgOrdCancQty', 0)),
-                        "order_time": getattr(body, 'sOrdTime', ''),
-                        "market_code": getattr(body, 'sOrdMktCode', ''),
-                    }
-                    
-                    # 주문체결유형코드에 따라 포트 및 상태명 결정
-                    port_map = {
-                        '01': ('accepted', '신규접수'),
-                        '02': ('accepted', '정정접수'),
-                        '03': ('accepted', '취소접수'),
-                        '11': ('filled', '체결'),
-                        '12': ('modified', '정정완료'),
-                        '13': ('cancelled', '취소완료'),
-                        '14': ('rejected', '거부'),
-                    }
-                    
-                    port, status_name = port_map.get(ord_type_code, ('accepted', f'코드:{ord_type_code}'))
+                        return
+
+                    body = getattr(resp, 'body', None)
+                    if body is None:
+                        # real_base 는 바디 검증 실패 시 body=None + error_msg 로 만든다.
+                        # 그 프레임에서 필드를 읽으면 전부 기본값이 되어 '0원 0주' 를
+                        # 지어내므로 버린다.
+                        context.log(
+                            "warning",
+                            f"{tr_cd} frame without body (error_msg="
+                            f"{getattr(resp, 'error_msg', '')}) — skipped",
+                            _node_id,
+                        )
+                        return
+
+                    if tr_cd == "AS0":
+                        event_data = self._parse_overseas_stock_as0_event(body)
+                    elif tr_cd in self._OVERSEAS_STOCK_ORDER_EVENT_FILL_FAMILY:
+                        event_data = self._parse_overseas_stock_fill_family_event(body, tr_cd)
+                    else:
+                        # 모르는 TR 을 계열 파서에 넣으면 빈값 '이벤트' 를 만든다 —
+                        # 짐작하지 말고 버리고 사실만 남긴다.
+                        context.log(
+                            "warning",
+                            f"Unknown overseas_stock order event TR: {tr_cd} — frame skipped",
+                            _node_id,
+                        )
+                        return
+
+                    port, status_name = self._OVERSEAS_STOCK_ORDER_EVENT_PORTS[tr_cd]
                     event_data["status"] = status_name
-                    
-                    # 체결 이벤트('11')일 때 시장가 주문의 가격 업데이트
-                    if ord_type_code == '11' and event_data['order_price'] > 0:
-                        order_no_str = str(event_data['order_no'])
-                        order_date = getattr(body, 'sOrdDt', datetime.now().strftime('%Y%m%d'))
+
+                    # 체결(AS1)로 시장가 주문의 원장 가격을 실체결가로 채운다.
+                    # 🔴 체결가 = filled_price(=sExecPrc). 종전엔 order_price(sOrdPrc,
+                    #    주문가)를 썼다(AS0 엔 체결가 필드가 없다). 이 분기는 AS1 리스너가
+                    #    없던 종전에는 한 번도 실행되지 않았다.
+                    if (
+                        tr_cd == "AS1"
+                        and event_data.get("filled_price", 0) > 0
+                        and str(event_data.get("order_no") or "").strip()
+                    ):
+                        order_no_str = str(event_data["order_no"]).strip()
+                        # 🔴 AS1 프레임에는 주문일자 필드가 없다(AS1RealResponseBody 에
+                        # 일자 필드 자체가 부재 — SDK). 원장 쓰기 경로
+                        # (_subscribe_overseas_stock_fill_events)도 같은 이유로 로컬
+                        # 날짜를 키로 쓴다(executor.py:4693 "AS1에는 sOrdDt 없음").
+                        # 두 경로가 같은 규약을 써야 (order_no, order_date) 대조가 맞으므로
+                        # 여기서도 로컬 오늘 날짜를 쓴다.
+                        # ⚠️ 한계: 주문~체결 사이 로컬 자정을 넘기면 키가 어긋난다
+                        # (프로세스 TZ 가 UTC 면 KST 09:00=UTC 00:00). 쓰기·읽기 양쪽을
+                        # 함께 바꿔야 하는 별건이라 이 경로만 고치지 않는다(국내 SC1 동일).
+                        order_date = datetime.now().strftime("%Y%m%d")
                         context.update_workflow_order_fill_price(
                             order_no=order_no_str,
                             order_date=order_date,
-                            fill_price=event_data['order_price'],
+                            fill_price=event_data["filled_price"],
                         )
-                    
+
                     context.set_output(_node_id, port, event_data)
-                    
-                    side_name = "매수" if event_data['side'] == '02' else "매도"
-                    
-                    logger.debug(f"\n{'='*60}")
-                    logger.debug(f"[{datetime.now().strftime('%H:%M:%S')}] 📣 [{_node_id}] 해외주식 {status_name} ({side_name})")
-                    logger.debug(f"  종목: {event_data['symbol']} ({event_data['symbol_name']})")
-                    logger.debug(f"  주문번호: {event_data['order_no']}")
-                    logger.debug(f"{'='*60}\n")
-                    
+
+                    # 매매구분 '2'=매수 / '1'=매도 (blocks.py sBnsTp)
+                    side_name = "매수" if event_data.get("side") == "2" else "매도"
+                    logger.debug(
+                        f"[{datetime.now().strftime('%H:%M:%S')}] [{_node_id}] "
+                        f"해외주식 {status_name} ({side_name}) "
+                        f"{event_data.get('symbol', '')} #{event_data.get('order_no', '')}"
+                    )
+
                     asyncio.run_coroutine_threadsafe(
                         context.notify_output_update(
                             node_id=_node_id,
                             node_type="RealOrderEventNode",
                             outputs={port: event_data},
                         ),
-                        loop
+                        loop,
                     )
-                    
                     asyncio.run_coroutine_threadsafe(
                         context.emit_event(
                             event_type="order_event",
@@ -8418,65 +8510,124 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
                             data={port: event_data},
                             trigger_nodes=_trigger_nodes,
                         ),
-                        loop
+                        loop,
                     )
-                
+
                 return handler
-            
-            # 핸들러 등록 (AS0~AS4는 모두 같은 콜백으로 수신됨)
-            handler = create_handler(node_id, event_filter, trigger_nodes)
-            context.register_order_event_handler(product, "AS0", node_id, event_filter, handler)
-            
-            # ========================================
-            # 마스터 콜백 설정 (첫 번째 노드만)
-            # ========================================
+
+            # 이 노드가 듣기로 한 스트림마다 핸들러를 등록한다. 종전에는 filter 와
+            # 무관하게 "AS0" 키 하나에만 걸어 뒀다.
+            for stream in wanted_streams:
+                context.register_order_event_handler(
+                    product,
+                    stream,
+                    node_id,
+                    event_filter,
+                    create_handler(node_id, event_filter, stream, trigger_nodes),
+                )
+
             if not context.has_order_event_subscription(product):
                 real_client = ls.overseas_stock().real()
                 if not await real_client.is_connected():
                     await real_client.connect()
-                
-                context.set_order_event_real_client(product, real_client)
-                
-                # 마스터 콜백: 모든 등록된 핸들러에게 분배
-                def master_callback(resp):
-                    if context.is_shutdown:
-                        return
-                    handlers = context.get_order_event_handlers(product, "AS0")
-                    for (handler_node_id, handler_filter, handler_func) in handlers:
-                        try:
-                            handler_func(resp)
-                        except Exception as e:
-                            context.log("error", f"Handler error for {handler_node_id}: {e}", handler_node_id)
 
-                real_client.AS0().on_as0_message(master_callback)
-                context.log("info", f"Master order event callback registered for {product}", node_id)
-            
-            # ========================================
-            # stay_connected에 따라 등록 방식 결정
-            # ========================================
+                context.set_order_event_real_client(product, real_client)
+
+                def create_master(_stream: str):
+                    def master_callback(resp):
+                        if context.is_shutdown:
+                            return
+                        handlers = context.get_order_event_handlers(product, _stream)
+                        for (handler_node_id, handler_filter, handler_func) in handlers:
+                            try:
+                                handler_func(resp)
+                            except Exception as e:
+                                context.log("error", f"Handler error for {handler_node_id}: {e}", handler_node_id)
+                    return master_callback
+
+                # 마스터는 **항상 다섯 스트림 전부** 건다 — 뒤에 붙는 노드가 다른
+                # filter 를 쓰면 has_order_event_subscription 게이트에 막혀 여기를
+                # 다시 지나지 않기 때문이다. 스트림별 실제 전달 여부는 위의
+                # register_order_event_handler 키가 가른다.
+                registered_masters: Dict[str, Callable] = {}
+                missing_streams: List[str] = []
+                for stream in self._OVERSEAS_STOCK_ORDER_EVENT_STREAMS:
+                    stream_factory = getattr(real_client, stream, None)
+                    subscribe = None
+                    if callable(stream_factory):
+                        subscribe = getattr(
+                            stream_factory(), f"on_{stream.lower()}_message", None
+                        )
+                    if not callable(subscribe):
+                        missing_streams.append(stream)
+                        continue
+                    master = create_master(stream)
+                    subscribe(master)
+                    registered_masters[stream] = master
+
+                # 🔴 등록한 마스터만 스트림별로 저장 — 정리 경로가 이것만 떼어
+                # 체결 원장 리스너(_subscribe_overseas_stock_fill_events 의 AS0/AS1)를
+                # 지우지 않게 한다(SDK 가 키당 리스너 리스트로 바뀜).
+                context.set_order_event_masters(product, registered_masters)
+
+                if missing_streams:
+                    context.log(
+                        "warning",
+                        f"SDK has no listener API for overseas_stock order streams: "
+                        f"{', '.join(missing_streams)} — those events cannot be received",
+                        node_id,
+                    )
+                if not registered_masters:
+                    msg = "No overseas_stock order event stream could be registered (SDK listener API missing)"
+                    context.log("error", msg, node_id)
+                    return {"error": msg}
+
+                context.log(
+                    "info",
+                    f"Master order event callbacks registered for overseas_stock: "
+                    f"{', '.join(registered_masters)}",
+                    node_id,
+                )
+
+            # 이 노드가 고른 스트림 중 SDK 마스터가 없는 것 보고(첫 노드든 뒤 노드든).
+            # 뒤에 붙는 노드가 미등록 스트림을 filter 로 고르면 status='subscribed'
+            # 인데 이벤트 0건인 조용한 실패가 되므로, 노드별로 확인해 드러낸다.
+            available_masters = set(context.get_order_event_masters(product))
+            node_unavailable = [s for s in wanted_streams if s not in available_masters]
+            if node_unavailable:
+                context.log(
+                    "warning",
+                    f"event_filter 선택 스트림 중 SDK 미등록(수신 불가): "
+                    f"{', '.join(node_unavailable)}",
+                    node_id,
+                )
+
             real_client = context.get_order_event_real_client(product)
             if stay_connected:
                 context.register_persistent(node_id, real_client, metadata={"event_filter": event_filter})
-                context.log("info", f"AS0~AS4 order event subscription started (filter={event_filter}, stay_connected=True)", node_id)
+                context.log("info", f"AS0~AS4 order event subscription started (filter={event_filter}, streams={','.join(wanted_streams)}, stay_connected=True)", node_id)
             else:
                 context.register_cleanup_on_flow_end(node_id, real_client)
-                context.log("info", f"AS0~AS4 order event subscription started (filter={event_filter}, stay_connected=False)", node_id)
-            
+                context.log("info", f"AS0~AS4 order event subscription started (filter={event_filter}, streams={','.join(wanted_streams)}, stay_connected=False)", node_id)
+
             result = {
                 "status": "subscribed",
                 "product": "overseas_stock",
                 "event_type": "AS0~AS4",
                 "event_filter": event_filter,
+                "subscribed_streams": list(wanted_streams),
             }
-            
+            if node_unavailable:
+                result["unavailable_streams"] = node_unavailable
+
             asyncio.create_task(context.notify_output_update(
                 node_id=node_id,
                 node_type="RealOrderEventNode",
                 outputs=result,
             ))
-            
+
             return result
-            
+
         except Exception as e:
             context.log("error", f"AS0~AS4 subscription failed: {e}", node_id)
             return {"error": str(e)}
@@ -8540,15 +8691,30 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
                         event_data = self._parse_tc3_data(body)
                         port, status_name = 'filled', '체결'
                         
-                        # 체결 시 시장가 주문의 가격 업데이트
-                        fill_price = event_data.get('fill_price', 0)
-                        if fill_price > 0:
+                        # 체결 시 시장가 주문의 가격 업데이트.
+                        # 🔴 키는 `_parse_tc3_data` 가 **실제로 담는 이름**(filled_price)이다.
+                        #    종전 코드는 그 dict 에 없는 `fill_price` 를 읽어 늘 0 을 받았고,
+                        #    그래서 `if fill_price > 0:` 이 한 번도 참이 되지 않아
+                        #    시장가 주문의 체결가 갱신이 통째로 죽어 있었다
+                        #    (해외선물 주문이벤트 노드 경로, 관측 2026-09-12).
+                        fill_price = event_data.get('filled_price', 0)
+                        # 주문일자도 프레임의 ordr_dt 만 쓴다 — 없으면 갱신을 **건너뛴다**.
+                        # 종전의 `datetime.now()` 폴백은 파드 로컬(UTC) 날짜를 주문일자로
+                        # 지어내, 야간장처럼 브로커 영업일과 로컬 날짜가 어긋나는 구간에서
+                        # (order_no, order_date) 대조를 조용히 빗나가게 한다.
+                        order_date = str(event_data.get('order_date', '') or '').strip()
+                        if fill_price > 0 and order_date:
                             order_no_str = str(event_data.get('order_no', ''))
-                            order_date = event_data.get('order_date', datetime.now().strftime('%Y%m%d'))
                             context.update_workflow_order_fill_price(
                                 order_no=order_no_str,
                                 order_date=order_date,
                                 fill_price=fill_price,
+                            )
+                        elif fill_price > 0:
+                            logger.warning(
+                                "[TC3] 체결가 갱신 건너뜀 — 프레임에 주문일자(ordr_dt)가 없다 "
+                                f"(order_no={event_data.get('order_no', '')!r}, "
+                                f"filled_price={fill_price!r})"
                             )
                     else:
                         return
@@ -8617,10 +8783,20 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
                     return master_callback
                 
                 # TC1, TC2, TC3 마스터 콜백 등록
-                real_client.TC1().on_tc1_message(create_master_callback("TC1"))
-                real_client.TC2().on_tc2_message(create_master_callback("TC2"))
-                real_client.TC3().on_tc3_message(create_master_callback("TC3"))
-                
+                tc1_master = create_master_callback("TC1")
+                tc2_master = create_master_callback("TC2")
+                tc3_master = create_master_callback("TC3")
+                real_client.TC1().on_tc1_message(tc1_master)
+                real_client.TC2().on_tc2_message(tc2_master)
+                real_client.TC3().on_tc3_message(tc3_master)
+
+                # 🔴 등록한 마스터만 스트림별로 저장 — 정리 경로가 이것만 떼어
+                # 체결 원장 리스너(_subscribe_overseas_futures_fill_events)를 지우지
+                # 않게 한다(SDK 가 키당 리스너 리스트로 바뀜, 같은 Real 객체 공유).
+                context.set_order_event_masters(
+                    product, {"TC1": tc1_master, "TC2": tc2_master, "TC3": tc3_master}
+                )
+
                 context.log("info", f"Master order event callbacks registered for {product}", node_id)
             
             # ========================================
@@ -8657,7 +8833,7 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
     def _parse_tc1_data(self, body) -> Dict[str, Any]:
         """TC1 응답 파싱"""
         from datetime import datetime
-        return {
+        return self._with_order_event_aliases({
             "timestamp": datetime.now().isoformat(),
             "tr_cd": "TC1",
             "svc_id": getattr(body, 'svc_id', ''),
@@ -8669,8 +8845,8 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
             "order_qty": int(getattr(body, 'ordr_q', 0) or 0),
             "order_price": float(getattr(body, 'ordr_prc', 0) or 0),
             "order_time": getattr(body, 'ordr_tm', ''),
-        }
-    
+        })
+
     def _get_tc1_port_status(self, event_data: Dict) -> tuple:
         """TC1 포트 및 상태명 결정"""
         svc_id = event_data.get("svc_id", "")
@@ -8684,7 +8860,7 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
     def _parse_tc2_data(self, body) -> Dict[str, Any]:
         """TC2 응답 파싱"""
         from datetime import datetime
-        return {
+        return self._with_order_event_aliases({
             "timestamp": datetime.now().isoformat(),
             "tr_cd": "TC2",
             "svc_id": getattr(body, 'svc_id', ''),
@@ -8699,8 +8875,8 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
             "order_time": getattr(body, 'ordr_tm', ''),
             "reject_code": getattr(body, 'rfsl_cd', ''),
             "reject_reason": getattr(body, 'text', ''),
-        }
-    
+        })
+
     def _get_tc2_port_status(self, event_data: Dict) -> tuple:
         """TC2 포트 및 상태명 결정"""
         svc_id = event_data.get("svc_id", "")
@@ -8721,12 +8897,20 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
     def _parse_tc3_data(self, body) -> Dict[str, Any]:
         """TC3 응답 파싱"""
         from datetime import datetime
-        return {
+        return self._with_order_event_aliases({
             "timestamp": datetime.now().isoformat(),
             "tr_cd": "TC3",
             "svc_id": getattr(body, 'svc_id', ''),
             "symbol": getattr(body, 'is_cd', ''),
             "order_no": getattr(body, 'ordr_no', ''),
+            # 주문일자(ordr_dt) — TC3 프레임이 실제로 싣는 필드다
+            # (SDK overseas_futureoption/real/TC3/blocks.py, 같은 파일의 체결 원장
+            #  핸들러 on_tc3_event 가 이미 이 이름을 읽는다). 종전에는 파서가 이걸
+            # 아예 담지 않아, 아래 체결가 갱신 경로가 '오늘 날짜' 를 지어내 썼다.
+            # 값이 비면(브로커가 ordr_dt="" 를 실어 보내는 경우가 있다 —
+            # _usable_execution_identity 주석 참조) 빈 문자열 그대로 둔다.
+            # 소비처가 '오늘' 로 폴백하지 않고 갱신을 건너뛰게 하기 위해서다.
+            "order_date": str(getattr(body, 'ordr_dt', '') or '').strip(),
             "orig_order_no": getattr(body, 'orgn_ordr_no', ''),
             "side": getattr(body, 's_b_ccd', ''),
             "filled_qty": int(getattr(body, 'ccls_q', 0) or 0),
@@ -8737,7 +8921,389 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
             "pnl": float(getattr(body, 'clr_pl_amt', 0) or 0),
             "commission": float(getattr(body, 'ent_fee', 0) or 0),
             "currency": getattr(body, 'crncy_cd', 'USD'),
+        })
+
+    # ── 공용: core 선언 필드명 alias ─────────────────────────────────────────
+    @staticmethod
+    def _with_order_event_aliases(event_data: Dict[str, Any]) -> Dict[str, Any]:
+        """core ``base.ORDER_EVENT_FIELDS``(base.py:553-564)가 선언한 이름을 런타임
+        키의 **별칭**으로 함께 싣는다(기존 키는 유지 — 하위 호환).
+
+        선언은 ``order_id``/``quantity``/``filled_quantity``/``price`` 를 쓰지만 파서
+        3종(국내 SC0~SC4·해외주식 AS·해외선물 TC)은 ``order_no``/``order_qty``/
+        ``filled_qty``/``order_price`` 를 내보낸다. ``realtime_*.py`` 예제가
+        ``{{ nodes.order_event.rejected.order_id }}`` 를 템플릿하므로(예:
+        realtime_stock.py:563) AI 생성물이 그대로면 빈값이 렌더된다. core 를 바꾸면
+        lockstep 릴리스(버전 핀된 엔진엔 안 감)라 이번엔 파서에서 alias 한다.
+
+        🔴 의미가 1:1 인 것만 alias 한다. 그리고 **원 키가 실제로 있을 때만** —
+        SC0/AS0 처럼 체결 필드가 없는 접수 프레임에는 filled_qty 가 아예 없으므로
+        filled_quantity 도 만들지 않는다(0 지어내기 금지).
+          order_id ← order_no · quantity ← order_qty ·
+          filled_quantity ← filled_qty · price ← order_price
+        선언의 ``exchange``/``symbol``/``side``/``filled_price``/``timestamp`` 는
+        파서가 **이미 같은 이름**으로 싣는다 → alias 불필요.
+        선언의 ``event_type`` 은 런타임에 1:1 대응 키가 없다(``event_code``=원 LS 코드,
+        ``tr_cd``=스트림, ``status``=표시명 — 셋 다 의미가 다르다) → alias 하지 않는다.
+        이미 선언 키가 있으면 덮지 않는다(파서가 직접 실은 값 우선).
+        """
+        for declared, runtime in (
+            ("order_id", "order_no"),
+            ("quantity", "order_qty"),
+            ("filled_quantity", "filled_qty"),
+            ("price", "order_price"),
+        ):
+            if runtime in event_data and declared not in event_data:
+                event_data[declared] = event_data[runtime]
+        return event_data
+
+    # ── 해외주식 주문 이벤트(AS0~AS4) 스트림 정의 ─────────────────────────────
+    # AS0 는 '주문접수'(Acceptance) TR 이고 AS1~AS4 는 execution-shape 바디를 **각자
+    # 동일한 필드 집합**으로 선언한다. SDK 확인(programgarden_finance/ls/overseas_stock/real/):
+    #   · AS0/blocks.py:87  class AS0RealResponseBody(BaseModel)  — 접수 전용 필드
+    #     (체결수량/체결가/미체결/정정·취소확인/거부수량 **선언 자체가 없다**)
+    #   · AS1/blocks.py:83  class AS1RealResponseBody(BaseModel)  — 체결 필드 포함
+    #   · AS2/blocks.py:84 · AS3/blocks.py:84 · AS4/blocks.py:89
+    #     → module docstring: AS2=Modify / AS3=Cancel / AS4=Reject, "mirrors AS1's
+    #       execution shape". model_fields 동등성은 test_overseas_stock_order_event_streams 가 단언.
+    # 그래서 파서는 'AS0 용' 과 'AS1 계열용'(AS1~AS4) 둘이면 충분하다 — 국내 SC 와 동형.
+    _OVERSEAS_STOCK_ORDER_EVENT_FILL_FAMILY: Tuple[str, ...] = ("AS1", "AS2", "AS3", "AS4")
+    _OVERSEAS_STOCK_ORDER_EVENT_STREAMS: Tuple[str, ...] = ("AS0", "AS1", "AS2", "AS3", "AS4")
+
+    # tr_cd → (출력 포트, 상태명). 국내 SC 와 같이 **스트림 자체가 이벤트 종류**다
+    # (SDK module docstring: AS0=Acceptance, AS1=Execution, AS2=Modify, AS3=Cancel,
+    #  AS4=Reject). 포트명은 core OverseasStockRealOrderEventNode._outputs 와 일치
+    # (realtime_stock.py:618-622: accepted/filled/modified/cancelled/rejected).
+    # 상태 표시명은 노드 docstring(realtime_stock.py:479)의 한글 라벨을 따른다:
+    #  AS0(접수) AS1(체결) AS2(정정) AS3(취소확인) AS4(거부).
+    _OVERSEAS_STOCK_ORDER_EVENT_PORTS: Dict[str, Tuple[str, str]] = {
+        "AS0": ("accepted", "주문접수"),
+        "AS1": ("filled", "체결"),
+        "AS2": ("modified", "정정"),
+        "AS3": ("cancelled", "취소확인"),
+        "AS4": ("rejected", "거부"),
+    }
+
+    # 주문시장코드 → 거래소. 매핑 출처는 체결 원장 경로
+    # _subscribe_overseas_stock_fill_events 의 exchange_map(executor.py:4745,
+    # {'81':'NYSE','82':'NASDAQ','83':'AMEX'}). 🔴 원장 경로는 미지 코드를 'NASDAQ'
+    # 로 **기본값 처리**하지만(그 경로는 건드리지 않는다), 이 표시용 출력은 미관측
+    # 거래소를 지어내지 않는다 — 미지 코드면 exchange 키를 빼고 사유를 남기고
+    # market_code 원값은 그대로 싣는다(이 저장소 '안 보낸 값은 안 보냄' 규약).
+    _OVERSEAS_STOCK_MARKET_EXCHANGE: Dict[str, str] = {"81": "NYSE", "82": "NASDAQ", "83": "AMEX"}
+
+    @classmethod
+    def _overseas_stock_order_event_streams(cls, event_filter: str) -> Tuple[str, ...]:
+        """event_filter → 이 노드가 구독할 스트림 목록.
+
+        'all' 이면 다섯 개 전부, 'AS0'~'AS4' 면 그 하나. 그 외 값은 빈 튜플이고
+        호출부가 에러로 만든다(허용값 출처: OverseasStockRealOrderEventNode
+        .get_field_schema enum_values=["all","AS0","AS1","AS2","AS3","AS4"] —
+        realtime_stock.py:638)."""
+        if not event_filter or event_filter == "all":
+            return cls._OVERSEAS_STOCK_ORDER_EVENT_STREAMS
+        if event_filter in cls._OVERSEAS_STOCK_ORDER_EVENT_STREAMS:
+            return (event_filter,)
+        return ()
+
+    @classmethod
+    def _overseas_exchange_from_market(cls, market_code: str) -> Tuple[str, str]:
+        """주문시장코드 → (거래소, 미해석 사유). 미지 코드면 ('', 사유)."""
+        ex = cls._OVERSEAS_STOCK_MARKET_EXCHANGE.get(str(market_code or "").strip())
+        if ex:
+            return ex, ""
+        return "", "overseas_stock_market_code_not_in_known_exchange_map"
+
+    @classmethod
+    def _parse_overseas_stock_as0_event(cls, body: Any) -> Dict[str, Any]:
+        """AS0(해외주식 주문접수) 프레임 → 이벤트 dict.
+
+        AS0 는 주문접수 TR 이라 체결 관련 필드(체결수량/체결가/미체결수량/체결번호/
+        체결시각, 정정확인·취소확인·거부수량)가 **선언 자체가 없다**(SDK
+        overseas_stock/real/AS0/blocks.py — sExecQty/sExecPrc/sExecNO/sExecTime/
+        sMdfyCnfQty/sCancCnfQty/sRjtQty/sUnercQty 부재). 국내 SC0 과 같은 규약으로
+        0 을 지어내지 않고 키를 빼고 사유를 남긴다.
+
+        읽는 필드(AS0/blocks.py): sOrdxctPtnCode:323 · sOrdMktCode:333 ·
+        sOrdPtnCode:342 · sOrgOrdNo:348 · sIsuNo:366 · sShtnIsuNo:372 · sIsuNm:378 ·
+        sOrdQty:384(str) · sOrdPrc:390(float) · sOrdNo:438(int) · sOrdTime:444 ·
+        sOrgOrdUnercQty:456 · sOrgOrdMdfyQty:462 · sOrgOrdCancQty:468 · sBnsTp:489
+        """
+        market_code = str(getattr(body, "sOrdMktCode", "") or "").strip()
+        exchange, exchange_reason = cls._overseas_exchange_from_market(market_code)
+        event_data: Dict[str, Any] = {
+            "timestamp": datetime.now().isoformat(),
+            "tr_cd": "AS0",
+            # 주문체결유형코드: '01'=신규매매접수 '03'=취소주문접수 '12'=정정완료
+            # '13'=취소완료 '14'=거부완료 (AS0/blocks.py:323-331)
+            "event_code": getattr(body, "sOrdxctPtnCode", ""),
+            "symbol": str(getattr(body, "sShtnIsuNo", "") or "").strip(),
+            # sIsuNo 는 LS 내부 종목번호(거래소+티커, 예 '82AAPL') (blocks.py:366-370)
+            "symbol_full_code": str(getattr(body, "sIsuNo", "") or "").strip(),
+            "symbol_name": getattr(body, "sIsuNm", ""),
+            "order_no": getattr(body, "sOrdNo", ""),
+            "orig_order_no": getattr(body, "sOrgOrdNo", ""),
+            # 매매구분: '1'=매도 '2'=매수 (blocks.py:489-498, AS1 cross-ref).
+            # 원장 경로와 같이 sBnsTp 를 buy/sell 분류자로 쓴다(executor.py:4751).
+            "side": str(getattr(body, "sBnsTp", "") or "").strip(),
+            "order_qty": _qty_num(getattr(body, "sOrdQty", 0)),
+            "order_price": float(getattr(body, "sOrdPrc", 0) or 0),
+            "order_time": getattr(body, "sOrdTime", ""),
+            "market_code": market_code,
+            # 원주문(정정/취소접수 대상)의 수량들 — 이 주문 자체의 체결 상태가 아니다.
+            "orig_order_remain_qty": _qty_num(getattr(body, "sOrgOrdUnercQty", 0)),
+            "orig_order_modified_qty": _qty_num(getattr(body, "sOrgOrdMdfyQty", 0)),
+            "orig_order_cancelled_qty": _qty_num(getattr(body, "sOrgOrdCancQty", 0)),
         }
+        if exchange:
+            event_data["exchange"] = exchange
+        else:
+            event_data["exchange_unavailable_reason"] = exchange_reason
+        # 값을 지어내는 대신 '왜 없는지' 를 싣는다(국내 SC0 와 동일 규약).
+        reason = "as0_order_acceptance_frame_has_no_fill_fields"
+        event_data["filled_qty_unavailable_reason"] = reason
+        event_data["filled_price_unavailable_reason"] = reason
+        event_data["remain_qty_unavailable_reason"] = reason
+        return cls._with_order_event_aliases(event_data)
+
+    @classmethod
+    def _parse_overseas_stock_fill_family_event(cls, body: Any, tr_cd: str) -> Dict[str, Any]:
+        """AS1~AS4(체결/정정/취소확인/거부) 프레임 → 이벤트 dict.
+
+        네 TR 은 동일한 execution-shape 필드 집합을 쓴다(module docstring: AS2~AS4
+        "mirrors AS1's execution shape"). 필드명은 AS0 와 **다르다** — 특히
+        체결(sExecQty/sExecPrc)·미체결(sUnercQty)·정정확인(sMdfyCnfQty/sMdfyCnfPrc)·
+        취소확인(sCancCnfQty)·거부(sRjtQty/sRjtRsn)·체결번호(sExecNO)·체결시각
+        (sExecTime)은 AS1 계열에만 있다. AS0 용 파서를 재사용하면 전부 빈값이 된다.
+
+        읽는 필드(SDK overseas_stock/real/AS1/blocks.py):
+          sOrdxctPtnCode:319 · sOrdMktCode:329 · sIsuNo:362 · sIsuNm:368 ·
+          sOrdNo:374(int) · sOrgOrdNo:380(int) · sExecNO:386 · sOrdQty:398(float) ·
+          sOrdPrc:404 · sExecQty:413 · sExecPrc:419 · sMdfyCnfQty:428 ·
+          sMdfyCnfPrc:434 · sCancCnfQty:440 · sRjtQty:446 · sShtnIsuNo:482 ·
+          sUnercQty:494 · sStdIsuNo:530 · sBnsTp:536 · sExecTime:644 ·
+          sRcptExecTime:650 · sRjtRsn:656
+
+        🔴 AS1 계열에는 주문시각(sOrdTime)이 **선언되어 있지 않다** — 시각 필드는
+        체결시각(sExecTime)과 거래소수신체결시각(sRcptExecTime)뿐이다(국내 SC1 계열과
+        같은 상황). 그래서 order_time 을 체결시각으로 채우지 않고 키를 빼고 사유를
+        남긴다.
+        """
+        market_code = str(getattr(body, "sOrdMktCode", "") or "").strip()
+        exchange, exchange_reason = cls._overseas_exchange_from_market(market_code)
+        event_data: Dict[str, Any] = {
+            "timestamp": datetime.now().isoformat(),
+            "tr_cd": tr_cd,
+            "event_code": getattr(body, "sOrdxctPtnCode", ""),
+            "symbol": str(getattr(body, "sShtnIsuNo", "") or "").strip(),
+            "symbol_full_code": str(getattr(body, "sIsuNo", "") or "").strip(),
+            "symbol_std_code": str(getattr(body, "sStdIsuNo", "") or "").strip(),
+            "symbol_name": getattr(body, "sIsuNm", ""),
+            "order_no": getattr(body, "sOrdNo", ""),
+            "orig_order_no": getattr(body, "sOrgOrdNo", ""),
+            # 매매구분: '1'=매도 '2'=매수 (blocks.py:536-541)
+            "side": str(getattr(body, "sBnsTp", "") or "").strip(),
+            "order_qty": _qty_num(getattr(body, "sOrdQty", 0)),
+            "order_price": float(getattr(body, "sOrdPrc", 0) or 0),
+            # 🔴 체결수량/체결가 = sExecQty/sExecPrc (체결 전용 필드). 주문수량/주문가와
+            #    다르다 — 종전 단일 파서는 주문가(sOrdPrc)를 체결가로 썼다.
+            "filled_qty": _qty_num(getattr(body, "sExecQty", 0)),
+            "filled_price": float(getattr(body, "sExecPrc", 0) or 0),
+            "remain_qty": _qty_num(getattr(body, "sUnercQty", 0)),
+            "fill_no": getattr(body, "sExecNO", ""),
+            # 체결시각 → 거래소수신체결시각 우선순위(원장 경로와 동일, executor.py:4726).
+            "fill_time": (
+                str(getattr(body, "sExecTime", "") or "").strip()
+                or str(getattr(body, "sRcptExecTime", "") or "").strip()
+            ),
+            "modified_qty": _qty_num(getattr(body, "sMdfyCnfQty", 0)),
+            "modified_price": float(getattr(body, "sMdfyCnfPrc", 0) or 0),
+            "cancelled_qty": _qty_num(getattr(body, "sCancCnfQty", 0)),
+            "rejected_qty": _qty_num(getattr(body, "sRjtQty", 0)),
+            "reject_reason": getattr(body, "sRjtRsn", ""),
+            "market_code": market_code,
+            "order_time_unavailable_reason": "overseas_stock_fill_family_frame_has_no_order_time_field",
+        }
+        if exchange:
+            event_data["exchange"] = exchange
+        else:
+            event_data["exchange_unavailable_reason"] = exchange_reason
+        return cls._with_order_event_aliases(event_data)
+
+    # ── 국내주식 주문 이벤트(SC0~SC4) 스트림 정의 ────────────────────────────
+    # SC0 는 '주문접수' TR 이고 SC1~SC4 는 **같은 바디 모델**을 공유한다.
+    # SDK 확인(programgarden_finance/ls/korea_stock/real/):
+    #   · SC0/blocks.py:110 `class SC0RealResponseBody(BaseModel)`
+    #   · SC1/blocks.py:103 `class SC1RealResponseBody(BaseModel)`
+    #   · SC2/blocks.py:69 · SC3/blocks.py:69 · SC4/blocks.py:69
+    #     → 셋 다 `class SCxRealResponseBody(SC1RealResponseBody)` (필드 동일)
+    # 그래서 파서는 'SC0 용' 과 'SC1 계열용' 둘이면 충분하다.
+    _KOREA_ORDER_EVENT_SC1_FAMILY: Tuple[str, ...] = ("SC1", "SC2", "SC3", "SC4")
+    _KOREA_ORDER_EVENT_STREAMS: Tuple[str, ...] = ("SC0", "SC1", "SC2", "SC3", "SC4")
+
+    # tr_cd → (출력 포트, 상태명). SC0~SC4 는 **스트림 자체가 이벤트 종류**라
+    # body 코드가 아니라 TR 로 가른다. 출처는 각 SC 클라이언트 docstring:
+    # SC0/client.py:4 "order acceptance" · SC1/client.py:4 "order execution" ·
+    # SC2/client.py:4 "order modification" · SC3/client.py:4 "order cancellation" ·
+    # SC4/client.py:4 "order rejection".
+    _KOREA_ORDER_EVENT_PORTS: Dict[str, Tuple[str, str]] = {
+        "SC0": ("accepted", "주문접수"),
+        "SC1": ("filled", "체결"),
+        "SC2": ("modified", "정정확인"),
+        "SC3": ("cancelled", "취소확인"),
+        "SC4": ("rejected", "거부"),
+    }
+
+    @classmethod
+    def _korea_order_event_streams(cls, event_filter: str) -> Tuple[str, ...]:
+        """event_filter → 이 노드가 실제로 구독할 스트림 목록.
+
+        'all' 이면 다섯 개 전부, 'SC0'~'SC4' 면 그 하나. 그 외 값은 빈 튜플이고
+        호출부가 에러로 만든다 — 종전처럼 조용히 SC0 만 듣다가 출력 0건이 되는
+        것보다 착오를 즉시 드러내는 쪽이 낫다.
+        (허용값 출처: KoreaStockRealOrderEventNode.get_field_schema 의
+         enum_values=["all","SC0","SC1","SC2","SC3","SC4"] —
+         core/programgarden_core/nodes/realtime_korea_stock.py:635)
+        """
+        if not event_filter or event_filter == "all":
+            return cls._KOREA_ORDER_EVENT_STREAMS
+        if event_filter in cls._KOREA_ORDER_EVENT_STREAMS:
+            return (event_filter,)
+        return ()
+
+    @staticmethod
+    def _korea_price_num(value: Any, default: float = 0.0) -> float:
+        """가격 문자열 → float. SC 프레임의 가격 필드는 전부 ``str`` 이고
+        (SC0/blocks.py:213 ``ordprice: str`` · SC1/blocks.py:324 ``ordprc: str``)
+        해당 없는 이벤트에서는 ''/'0' 이 온다. ``float('')`` 은 ValueError 라
+        여기서 흡수한다."""
+        try:
+            return float(str(value).strip())
+        except (TypeError, ValueError):
+            return default
+
+    @staticmethod
+    def _korea_symbol_from_short_code(value: Any) -> str:
+        """단축종목번호 'A005930' → '005930'.
+
+        접두어 규약은 SDK 선언 그대로다 — "stock = 'A' + 6-digit code; ELW =
+        'J' + 6-digit code" (SC0/blocks.py:201-209 ``shtcode`` ·
+        SC1/blocks.py:159-167 ``shtnIsuno``). 원장 경로
+        (_subscribe_korea_stock_fill_events)와 국내 미체결 조회(t0425 ``expcode``)가
+        모두 6자리 코드를 쓰므로 이 출력 표면도 같은 모양으로 맞춘다.
+        규약에 안 맞는 값은 **손대지 않고 그대로** 내보낸다(짐작 금지)."""
+        code = str(value or "").strip()
+        if len(code) == 7 and code[0] in ("A", "J") and code[1:].isdigit():
+            return code[1:]
+        return code
+
+    @classmethod
+    def _parse_korea_sc0_event(cls, body: Any) -> Dict[str, Any]:
+        """SC0(국내주식 주문접수) 프레임 → 이벤트 dict.
+
+        🔴 SC0 의 필드명은 전부 **소문자**다. 종전 파서는 PascalCase
+        (OrdNo/OrdQty/OrdPrc/ExecQty/…)를 읽었는데 그런 속성은
+        ``SC0RealResponseBody`` 에 없고 pydantic v2 는 기본 ``extra='ignore'`` 라
+        전 필드가 getattr 기본값(0/'')으로 나갔다 — 즉 **출력이 통째로 가짜**였다.
+
+        읽는 필드(SDK korea_stock/real/SC0/blocks.py):
+          ordchegb:167 · marketgb:177 · orgordno:196 · expcode:200 · shtcode:201 ·
+          hname:211 · ordqty:212 · ordprice:213 · ordno:296 · ordtm:297 ·
+          orgordundrqty:300 · orgordmdfyqty:301 · ordordcancelqty:302 · bnstp:305
+
+        🔴 SC0 에는 체결 관련 필드(체결수량/체결가격/미체결수량)가 **선언 자체가
+        없다** — 주문접수 TR 이기 때문이다. 그래서 0 으로 지어내지 않고 키를 빼고
+        사유를 남긴다(이 저장소 규약: 안 보낸 값은 '안 보냄' 이라고 표시).
+        체결번호/체결시각도 같은 이유로 SC0 에는 없다(SC1 계열에만 있다).
+        """
+        short_code = getattr(body, "shtcode", "")
+        event_data: Dict[str, Any] = {
+            "timestamp": datetime.now().isoformat(),
+            "tr_cd": "SC0",
+            # 주문체결구분: '01'=주문 '02'=정정 '03'=취소 '11'=체결 '12'=정정확인
+            # '13'=취소확인 '14'=거부 'A1'=접수중 'AC'=접수완료 (blocks.py:167-174)
+            "event_code": getattr(body, "ordchegb", ""),
+            "symbol": cls._korea_symbol_from_short_code(short_code),
+            "symbol_short_code": str(short_code or "").strip(),
+            "symbol_std_code": str(getattr(body, "expcode", "") or "").strip(),
+            "symbol_name": getattr(body, "hname", ""),
+            "order_no": getattr(body, "ordno", ""),
+            "orig_order_no": getattr(body, "orgordno", ""),
+            # 매매구분: '1'=매도, '2'=매수 (blocks.py:305-310)
+            "side": getattr(body, "bnstp", ""),
+            "order_qty": _qty_num(getattr(body, "ordqty", 0)),
+            "order_price": cls._korea_price_num(getattr(body, "ordprice", 0)),
+            "order_time": getattr(body, "ordtm", ""),
+            # 국내주식의 거래소는 KOSPI/KOSDAQ/KONEX 모두 KRX 다. 원장·미체결
+            # 조회 경로가 쓰는 값과 같게 맞춘다(record_workflow_fill(exchange='KRX')).
+            "exchange": "KRX",
+            # 시장구분 원값: '10'=KOSPI '20'=KOSDAQ '23'=KONEX (blocks.py:177-183).
+            # 종전에는 프레임을 안 보고 상수 "KRX" 를 market_code 에 넣었다.
+            "market_code": getattr(body, "marketgb", ""),
+            # 원주문(정정/취소 접수 시 대상 주문)의 수량들 — SC0 가 싣는 값이다.
+            # 이 주문 자체의 체결 상태가 아니므로 이름을 분명히 구분한다.
+            "orig_order_remain_qty": _qty_num(getattr(body, "orgordundrqty", 0)),
+            "orig_order_modified_qty": _qty_num(getattr(body, "orgordmdfyqty", 0)),
+            "orig_order_cancelled_qty": _qty_num(getattr(body, "ordordcancelqty", 0)),
+        }
+        # 값을 지어내는 대신 '왜 없는지' 를 싣는다.
+        reason = "sc0_order_acceptance_frame_has_no_fill_fields"
+        event_data["filled_qty_unavailable_reason"] = reason
+        event_data["filled_price_unavailable_reason"] = reason
+        event_data["remain_qty_unavailable_reason"] = reason
+        return cls._with_order_event_aliases(event_data)
+
+    @classmethod
+    def _parse_korea_sc1_family_event(cls, body: Any, tr_cd: str) -> Dict[str, Any]:
+        """SC1~SC4(체결/정정확인/취소확인/거부) 프레임 → 이벤트 dict.
+
+        네 TR 은 ``SC1RealResponseBody`` 를 공유한다(SC2~SC4/blocks.py:69 상속).
+        필드명은 SC0 와 **다르다** — 종목/가격 계열이 특히 다르므로 SC0 용 파서를
+        재사용하면 전부 빈값이 된다.
+
+        읽는 필드(SDK korea_stock/real/SC1/blocks.py):
+          exectime:133 · mdfycnfqty:136 · execprc:139 · mdfycnfprc:140 ·
+          execno:147 · ordno:150 · shtnIsuno:159 · Isunm:171 · Isuno:174 ·
+          rjtqty:183 · ordxctptncode:197 · canccnfqty:207 · orgordno:255 ·
+          unercqty:269 · execqty:270 · ordqty:284 · ordmktcode:297 ·
+          bnstp:317 · ordprc:324
+
+        🔴 이 계열에는 **주문시각(ordtm)이 선언되어 있지 않다** — 시각 필드는
+        체결시각(exectime)과 거래소수신체결시각(rcptexectime)뿐이다. 그래서
+        ``order_time`` 을 체결시각으로 채우지 않고 키를 빼고 사유를 남긴다.
+        """
+        short_code = getattr(body, "shtnIsuno", "")
+        event_data: Dict[str, Any] = {
+            "timestamp": datetime.now().isoformat(),
+            "tr_cd": tr_cd,
+            # 주문체결유형코드: '01'=주문 '02'=정정 '03'=취소 '11'=체결
+            # '12'=정정확인 '13'=취소확인 '14'=거부 (blocks.py:197-205)
+            "event_code": getattr(body, "ordxctptncode", ""),
+            "symbol": cls._korea_symbol_from_short_code(short_code),
+            "symbol_short_code": str(short_code or "").strip(),
+            "symbol_std_code": str(getattr(body, "Isuno", "") or "").strip(),
+            "symbol_name": getattr(body, "Isunm", ""),
+            "order_no": getattr(body, "ordno", ""),
+            "orig_order_no": getattr(body, "orgordno", ""),
+            # 매매구분: '1'=매도, '2'=매수 (blocks.py:317-322)
+            "side": getattr(body, "bnstp", ""),
+            "order_qty": _qty_num(getattr(body, "ordqty", 0)),
+            "order_price": cls._korea_price_num(getattr(body, "ordprc", 0)),
+            "filled_qty": _qty_num(getattr(body, "execqty", 0)),
+            "filled_price": cls._korea_price_num(getattr(body, "execprc", 0)),
+            "remain_qty": _qty_num(getattr(body, "unercqty", 0)),
+            "fill_no": getattr(body, "execno", ""),
+            "fill_time": getattr(body, "exectime", ""),
+            "modified_qty": _qty_num(getattr(body, "mdfycnfqty", 0)),
+            "modified_price": cls._korea_price_num(getattr(body, "mdfycnfprc", 0)),
+            "cancelled_qty": _qty_num(getattr(body, "canccnfqty", 0)),
+            "rejected_qty": _qty_num(getattr(body, "rjtqty", 0)),
+            "exchange": "KRX",
+            # 주문시장코드 원값: '10'=KOSPI '20'=KOSDAQ (blocks.py:297-305)
+            "market_code": getattr(body, "ordmktcode", ""),
+            "order_time_unavailable_reason": "sc1_family_frame_has_no_order_time_field",
+        }
+        return cls._with_order_event_aliases(event_data)
 
     async def _ls_korea_stock_order_event(
         self,
@@ -8750,10 +9316,18 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
     ) -> Dict[str, Any]:
         """국내주식 실시간 주문 이벤트 (SC0~SC4)
 
-        SC0: 주문접수, SC1: 체결, SC2: 정정확인, SC3: 취소확인, SC4: 거부
-        하나만 등록해도 전체 수신됨.
+        SC0: 주문접수, SC1: 체결, SC2: 정정확인, SC3: 취소확인, SC4: 거부.
+
+        🔴 '계좌 실시간 등록' 은 SC0~SC4 중 하나만 보내면 되지만
+        (SDK ls/real_base.py:964 ``_add_real_order_korea`` — ``_sc01234_connect``
+        플래그로 중복 요청 방지), **콜백 디스패치는 tr_cd 정확일치 키**로 이뤄진다
+        (ls/real_base.py:335 ``self._on_message_listeners.get(tr_cd, None)``).
+        종전에는 ``SC0().on_sc0_message(...)`` 하나만 등록해 두고 핸들러 안에서
+        ``tr_cd`` 로 SC1~SC4 를 분기했는데, SC1~SC4 프레임에는 리스너가 없어
+        **그 프레임이 이 노드에 도달조차 못 했다** — filled/modified/cancelled/
+        rejected 포트는 영구히 0건이고, event_filter='SC1'~'SC4' 면 출력이 통째로
+        없었다. 이제 스트림마다 리스너를 따로 등록한다.
         """
-        from datetime import datetime
 
         product = "korea_stock"
 
@@ -8761,53 +9335,78 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
             loop = asyncio.get_running_loop()
             trigger_nodes = config.get("_trigger_on_update_nodes", [])
 
-            def create_handler(_node_id: str, _event_filter: str, _trigger_nodes: list):
+            wanted_streams = self._korea_order_event_streams(event_filter)
+            if not wanted_streams:
+                msg = (
+                    f"Unsupported event_filter for korea_stock order events: "
+                    f"{event_filter} (allowed: all, SC0~SC4)"
+                )
+                context.log("error", msg, node_id)
+                return {"error": msg}
+
+            def create_handler(_node_id: str, _event_filter: str, _stream: str, _trigger_nodes: list):
                 def handler(resp):
                     if context.is_shutdown:
                         return
                     from datetime import datetime
 
                     header = getattr(resp, 'header', None)
-                    tr_cd = getattr(header, 'tr_cd', 'SC0') if header else 'SC0'
+                    # 헤더가 없으면 이 리스너가 등록된 스트림이 곧 TR 이다 —
+                    # real_base 는 tr_cd 정확일치로만 배달하므로 둘은 같다.
+                    tr_cd = (getattr(header, 'tr_cd', '') if header else '') or _stream
 
                     if _event_filter != "all" and tr_cd != _event_filter:
                         return
 
-                    body = getattr(resp, 'body', resp)
+                    body = getattr(resp, 'body', None)
+                    if body is None:
+                        # real_base 는 바디 검증 실패 시 body=None + error_msg 로 만든다
+                        # (ls/real_base.py:346-354). 그 프레임에서 필드를 읽으면 전부
+                        # 기본값이 되어 '0원 0주 체결' 을 지어내게 되므로 버린다.
+                        context.log(
+                            "warning",
+                            f"{tr_cd} frame without body (error_msg="
+                            f"{getattr(resp, 'error_msg', '')}) — skipped",
+                            _node_id,
+                        )
+                        return
 
-                    # SC0~SC4 공통 필드 추출
-                    event_data = {
-                        "timestamp": datetime.now().isoformat(),
-                        "tr_cd": tr_cd,
-                        "symbol": getattr(body, 'shtnIsuNo', getattr(body, 'IsuNo', '')),
-                        "symbol_name": getattr(body, 'IsuNm', ''),
-                        "order_no": getattr(body, 'OrdNo', 0),
-                        "orig_order_no": getattr(body, 'OrgOrdNo', 0),
-                        "side": getattr(body, 'BnsTpCode', ''),
-                        "order_qty": int(getattr(body, 'OrdQty', 0)),
-                        "order_price": float(getattr(body, 'OrdPrc', 0)),
-                        "filled_qty": int(getattr(body, 'ExecQty', 0) or 0),
-                        "filled_price": float(getattr(body, 'ExecPrc', 0) or 0),
-                        "remain_qty": int(getattr(body, 'UnercQty', 0) or 0),
-                        "order_time": getattr(body, 'OrdTime', ''),
-                        "market_code": "KRX",
-                    }
+                    if tr_cd == "SC0":
+                        event_data = self._parse_korea_sc0_event(body)
+                    elif tr_cd in self._KOREA_ORDER_EVENT_SC1_FAMILY:
+                        event_data = self._parse_korea_sc1_family_event(body, tr_cd)
+                    else:
+                        # 모르는 TR 을 SC1 계열 파서에 넣으면 필드가 전부 빈값인
+                        # '이벤트' 를 만들어 낸다 — 그게 종전 결함의 모양이다.
+                        # 짐작하지 말고 버리고, 사실만 남긴다.
+                        context.log(
+                            "warning",
+                            f"Unknown korea_stock order event TR: {tr_cd} — frame skipped",
+                            _node_id,
+                        )
+                        return
 
-                    # TR별 포트/상태 결정
-                    port_map = {
-                        'SC0': ('accepted', '주문접수'),
-                        'SC1': ('filled', '체결'),
-                        'SC2': ('modified', '정정확인'),
-                        'SC3': ('cancelled', '취소확인'),
-                        'SC4': ('rejected', '거부'),
-                    }
-
-                    port, status_name = port_map.get(tr_cd, ('accepted', f'코드:{tr_cd}'))
+                    port, status_name = self._KOREA_ORDER_EVENT_PORTS[tr_cd]
                     event_data["status"] = status_name
 
-                    # 체결 이벤트(SC1)일 때 가격 업데이트
-                    if tr_cd == 'SC1' and event_data['filled_price'] > 0:
-                        order_no_str = str(event_data['order_no'])
+                    # 체결(SC1) 프레임으로 시장가 주문의 원장 가격을 실체결가로 채운다.
+                    # 이 분기는 SC1 리스너가 없던 종전에는 **한 번도 실행되지 않았다**.
+                    if (
+                        tr_cd == 'SC1'
+                        and event_data.get('filled_price', 0) > 0
+                        and str(event_data.get('order_no') or '').strip()
+                    ):
+                        order_no_str = str(event_data['order_no']).strip()
+                        # 🔴 주문일자는 프레임에 없다 — SC1RealResponseBody 의 130개
+                        # 필드 중 일자 필드는 대출일(Loandt, SC1/blocks.py:177) 하나뿐이고
+                        # 주문일자는 선언 자체가 없다(SC0 도 loandt 뿐). 원장 쓰기 쪽
+                        # (NewOrderNodeExecutor 의 국내주식 경로 record_workflow_order)도
+                        # 같은 이유로 **로컬 날짜**를 키로 쓴다 — 그 경로의 🔴 주석 참조.
+                        # 두 경로가 같은 규약을 써야 (order_no, order_date) 대조가 맞으므로
+                        # 여기서도 로컬 오늘 날짜를 쓴다.
+                        # ⚠️ 한계: 주문과 체결 사이에 **로컬 자정**을 넘기면 키가 어긋난다
+                        # (프로세스 TZ 가 UTC 면 KST 09:00 이 곧 UTC 00:00 이다). 쓰기·읽기
+                        # 양쪽을 함께 바꿔야 하는 별건이라 이 경로만 고치지 않는다.
                         order_date = datetime.now().strftime('%Y%m%d')
                         context.update_workflow_order_fill_price(
                             order_no=order_no_str,
@@ -8817,6 +9416,7 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
 
                     context.set_output(_node_id, port, event_data)
 
+                    # 매매구분 '2'=매수 / '1'=매도 (SC0 blocks.py:305 · SC1 blocks.py:317)
                     side_name = "매수" if event_data['side'] == '2' else "매도"
 
                     logger.debug(f"[{datetime.now().strftime('%H:%M:%S')}] [{_node_id}] 국내주식 {status_name} ({side_name})")
@@ -8843,8 +9443,23 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
 
                 return handler
 
-            handler = create_handler(node_id, event_filter, trigger_nodes)
-            context.register_order_event_handler(product, "SC0", node_id, event_filter, handler)
+            # 이 노드가 듣기로 한 스트림마다 핸들러를 등록한다. 종전에는 filter 와
+            # 무관하게 "SC0" 키 하나에만 걸어 뒀다.
+            for stream in wanted_streams:
+                context.register_order_event_handler(
+                    product,
+                    stream,
+                    node_id,
+                    event_filter,
+                    create_handler(node_id, event_filter, stream, trigger_nodes),
+                )
+
+            # SDK 에 등록 API 가 없어 **받을 수 없는** 스트림. 마스터를 거는 첫
+            # 노드만 채우고(뒤 노드는 아래 게이트에 막힌다) 그 노드의 warning 에만
+            # 쓰인다. 결과의 unavailable_streams 는 이것이 아니라 아래 node_unavailable
+            # (저장된 masters 키 대조)로 채운다 — 뒤 노드도 조용한 실패를 드러내도록.
+            # 비어 있는 게 정상이다(현재 SDK 는 SC0~SC4 전부 제공).
+            missing_streams: List[str] = []
 
             if not context.has_order_event_subscription(product):
                 real_client = ls.korea_stock().real()
@@ -8853,33 +9468,93 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
 
                 context.set_order_event_real_client(product, real_client)
 
-                def master_callback(resp):
-                    if context.is_shutdown:
-                        return
-                    handlers = context.get_order_event_handlers(product, "SC0")
-                    for (handler_node_id, handler_filter, handler_func) in handlers:
-                        try:
-                            handler_func(resp)
-                        except Exception as e:
-                            context.log("error", f"Handler error for {handler_node_id}: {e}", handler_node_id)
+                def create_master(_stream: str):
+                    def master_callback(resp):
+                        if context.is_shutdown:
+                            return
+                        handlers = context.get_order_event_handlers(product, _stream)
+                        for (handler_node_id, handler_filter, handler_func) in handlers:
+                            try:
+                                handler_func(resp)
+                            except Exception as e:
+                                context.log("error", f"Handler error for {handler_node_id}: {e}", handler_node_id)
+                    return master_callback
 
-                real_client.SC0().on_sc0_message(master_callback)
-                context.log("info", f"Master order event callback registered for korea_stock", node_id)
+                # 마스터는 **항상 다섯 스트림 전부** 건다 — 뒤에 붙는 노드가 다른
+                # filter 를 쓰면 has_order_event_subscription 게이트에 막혀 여기를
+                # 다시 지나지 않기 때문이다. 스트림별 실제 전달 여부는 위의
+                # register_order_event_handler 키가 가른다.
+                registered_masters: Dict[str, Callable] = {}
+                for stream in self._KOREA_ORDER_EVENT_STREAMS:
+                    stream_factory = getattr(real_client, stream, None)
+                    subscribe = None
+                    if callable(stream_factory):
+                        subscribe = getattr(
+                            stream_factory(), f"on_{stream.lower()}_message", None
+                        )
+                    if not callable(subscribe):
+                        missing_streams.append(stream)
+                        continue
+                    master = create_master(stream)
+                    subscribe(master)
+                    registered_masters[stream] = master
+
+                # 🔴 등록한 마스터만 스트림별로 저장 — 정리 경로가 이것만 떼어
+                # 체결 원장 리스너(_subscribe_korea_stock_fill_events 의 SC0/SC1)를
+                # 지우지 않게 한다(SDK 가 키당 리스너 리스트로 바뀜).
+                context.set_order_event_masters(product, registered_masters)
+
+                if missing_streams:
+                    # 짐작하지 않고 사실만 남긴다 — SDK 에 해당 스트림 등록 API 가 없다.
+                    context.log(
+                        "warning",
+                        f"SDK has no listener API for korea_stock order streams: "
+                        f"{', '.join(missing_streams)} — those events cannot be received",
+                        node_id,
+                    )
+                if not registered_masters:
+                    msg = "No korea_stock order event stream could be registered (SDK listener API missing)"
+                    context.log("error", msg, node_id)
+                    return {"error": msg}
+
+                context.log(
+                    "info",
+                    f"Master order event callbacks registered for korea_stock: "
+                    f"{', '.join(registered_masters)}",
+                    node_id,
+                )
+
+            # 디렉티브(3): 이 노드가 고른 스트림 중 SDK 마스터가 없는 것 보고
+            # (첫 노드든 뒤 노드든). 뒤에 붙는 노드가 미등록 스트림을 filter 로
+            # 고르면 status='subscribed' 인데 이벤트 0건인 조용한 실패가 되므로,
+            # context 에 저장된 masters 키로 노드별 확인해 드러낸다.
+            available_masters = set(context.get_order_event_masters(product))
+            node_unavailable = [s for s in wanted_streams if s not in available_masters]
+            if node_unavailable:
+                context.log(
+                    "warning",
+                    f"event_filter 선택 스트림 중 SDK 미등록(수신 불가): "
+                    f"{', '.join(node_unavailable)}",
+                    node_id,
+                )
 
             real_client = context.get_order_event_real_client(product)
             if stay_connected:
                 context.register_persistent(node_id, real_client, metadata={"event_filter": event_filter})
-                context.log("info", f"SC0~SC4 order event subscription started (filter={event_filter}, stay_connected=True)", node_id)
+                context.log("info", f"SC0~SC4 order event subscription started (filter={event_filter}, streams={','.join(wanted_streams)}, stay_connected=True)", node_id)
             else:
                 context.register_cleanup_on_flow_end(node_id, real_client)
-                context.log("info", f"SC0~SC4 order event subscription started (filter={event_filter}, stay_connected=False)", node_id)
+                context.log("info", f"SC0~SC4 order event subscription started (filter={event_filter}, streams={','.join(wanted_streams)}, stay_connected=False)", node_id)
 
             result = {
                 "status": "subscribed",
                 "product": "korea_stock",
                 "event_type": "SC0~SC4",
                 "event_filter": event_filter,
+                "subscribed_streams": list(wanted_streams),
             }
+            if node_unavailable:
+                result["unavailable_streams"] = node_unavailable
 
             asyncio.create_task(context.notify_output_update(
                 node_id=node_id,
@@ -8892,7 +9567,6 @@ class RealOrderEventNodeExecutor(NodeExecutorBase):
         except Exception as e:
             context.log("error", f"Korea stock order event error: {e}", node_id)
             return {"error": str(e)}
-
 
 class MarketStatusNodeExecutor(NodeExecutorBase):
     """MarketStatusNode executor — JIF 기반 실시간 시장 상태 추적.
@@ -10004,6 +10678,42 @@ class ConditionNodeExecutor(NodeExecutorBase):
                         f"ConditionNode '{node_id}': positions 비어있음 → 통과 종목 없음(정상 0건).",
                         node_id
                     )
+                    # 🔴 계좌가 **빈 리스트**(None 아님)일 때도 상태 기반 포지션 플러그인
+                    # (time_based_exit 등)은 '계좌가 비면 남은 entry_date 전부 정리' 스윕
+                    # 기회가 필요하다. 이 스윕이 실행기 경로에서 도달 불가였던 탓에,
+                    # 전량 매도 뒤 재매수하면 옛 entry_date 로 hold_days 가 부풀어 **거짓
+                    # exit** 가 났다(실행기+WorkflowRiskTracker 재현 2026-09-12).
+                    # positions 가 정확히 [](빈 리스트)이고 플러그인이 context 를 선언
+                    # (= 상태 사용)하면 positions=[] 로 한 번 호출해 스윕시킨다. 그 결과는
+                    # 조건 판정에 쓰지 않고(예외는 warning 으로 삼킴) 종전 빈 결과를
+                    # 그대로 돌려준다 — 이 경로로는 어차피 통과 종목이 0건이다.
+                    # (None = 미해결 바인딩이므로 isinstance list 가드로 스윕에서 제외.
+                    #  context 미선언 플러그인은 종전대로 호출하지 않는다 — data 분기 규약.)
+                    if plugin is not None and isinstance(positions, list):
+                        import inspect as _inspect
+                        try:
+                            _uses_context = "context" in _inspect.signature(plugin).parameters
+                        except (ValueError, TypeError):
+                            _uses_context = False
+                        if _uses_context:
+                            try:
+                                sweep_fields = fields or config.get("fields", {}) or config.get("params", {})
+                                if sweep_fields:
+                                    _expr_ctx = context.get_expression_context()
+                                    sweep_fields = ExpressionEvaluator(_expr_ctx).evaluate_fields(sweep_fields)
+                                await sandbox.execute(
+                                    plugin_id=plugin_id,
+                                    plugin_callable=plugin,
+                                    kwargs={"positions": [], "fields": sweep_fields, "context": context},
+                                )
+                                context.log("info",
+                                    f"ConditionNode '{node_id}': positions=[] — 상태 플러그인 스윕 1회(판정 미반영).",
+                                    node_id)
+                            except Exception as _sweep_err:
+                                # 스윕 실패는 조건 판정을 바꾸지 않는다 — 삼키고 경고만.
+                                context.log("warning",
+                                    f"ConditionNode '{node_id}': positions=[] 상태 플러그인 스윕 실패(무시): {_sweep_err}",
+                                    node_id)
                     return {
                         "symbols": [],
                         "result": False,
@@ -10026,13 +10736,28 @@ class ConditionNodeExecutor(NodeExecutorBase):
                 
                 if plugin:
                     try:
+                        plugin_kwargs: Dict[str, Any] = {
+                            "positions": positions,
+                            "fields": evaluated_fields,
+                        }
+                        # context 는 **시그니처에 있는 플러그인에만** 넘긴다
+                        # (items/data 기반 분기와 같은 규약 — _execute_condition_plugin).
+                        # 종전에는 positions 분기가 kwargs 를 {positions, fields} 로
+                        # 고정해 context 를 아예 넘기지 않았고, 그래서 strategy_state 를
+                        # 쓰는 포지션 플러그인(PartialTakeProfit)이 라이브에서 늘
+                        # has_state=False 로 떨어져 상태를 저장·복원하지 못했다
+                        # (분할 익절이 매 사이클 level_index=0 으로 재발동 — 관측 2026-09-12).
+                        import inspect as _inspect
+                        try:
+                            if "context" in _inspect.signature(plugin).parameters:
+                                plugin_kwargs["context"] = context
+                        except (ValueError, TypeError):
+                            pass
+
                         result = await sandbox.execute(
                             plugin_id=plugin_id,
                             plugin_callable=plugin,
-                            kwargs={
-                                "positions": positions,
-                                "fields": evaluated_fields,
-                            },
+                            kwargs=plugin_kwargs,
                         )
                         
                         context.log(

--- a/src/programgarden/pyproject.toml
+++ b/src/programgarden/pyproject.toml
@@ -5,7 +5,7 @@ authors = [
 homepage = "https://programgarden.com"
 requires-python = ">=3.12"
 name = "programgarden"
-version = "1.37.0"
+version = "1.37.1"
 license = "AGPL-3.0-or-later"
 description = "ProgramGarden - 노드 기반 자동매매 DSL 실행 엔진"
 readme = "README.md"
@@ -37,8 +37,8 @@ litellm = ">=1.40.0"
 # (1.26.0 이후로도 context.py 는 WorkflowPnLEvent(**event_data) 에 personal_metrics
 #  를 무조건 실으므로 그 하한 근거도 이 상한에 포함된다.)
 programgarden-core = "^1.28.0"
-programgarden-finance = "^1.9.6"
-programgarden-community = "^1.15.2"
+programgarden-finance = "^1.9.7"
+programgarden-community = "^1.15.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.0.0"

--- a/src/programgarden/tests/test_dry_run_skips_account_tracking.py
+++ b/src/programgarden/tests/test_dry_run_skips_account_tracking.py
@@ -1,9 +1,11 @@
-"""dry_run 에서는 브로커 노드가 계좌 추적기·체결내역 동기화를 띄우지 않는다 (Phase 9.6 실측, 2026-08-29).
+"""dry_run 에서는 브로커 노드가 계좌 추적기·체결내역 동기화·체결 이벤트 구독을 띄우지 않는다.
 
-두 경로는 별도 ``LS()`` 로 appkey/appsecret 직접 로그인한다(토큰 공급자 미상속). 서버 단일 발급
-토큰 + 더미 appsecret 으로 도는 트레이앱 검증 잡에서는 그 로그인이 403 → "Failed to login for
-account tracking" 이 errors[] 에 실려 모의 실행이 항상 실패했다. 모의 실행엔 주문·체결이 없으니
-둘 다 skip 이 맞다. runtime(실행) 은 종전대로 띄운다.
+(Phase 9.6 실측, 2026-08-29 / 체결 구독은 2026-09-12 추가)
+
+세 경로 모두 LS 로그인을 한다(앞의 둘은 별도 ``LS()`` 로 직접, 구독은 ``ensure_ls_login``).
+서버 단일 발급 토큰 + 더미 appsecret 으로 도는 트레이앱 검증 잡에서는 그 로그인이 403 →
+"Failed to login for account tracking" 이 errors[] 에 실려 모의 실행이 항상 실패했다.
+모의 실행엔 주문·체결이 없으니 전부 skip 이 맞다. runtime(실행) 은 종전대로 띄운다.
 """
 from __future__ import annotations
 
@@ -38,24 +40,30 @@ _CFG = {"appkey": "k", "appsecret": "dummy-secret", "paper_trading": False}
 
 async def _run_broker(ctx: ExecutionContext):
     ex = BrokerNodeExecutor()
+    # 체결 구독도 함께 막는다 — 실패 시 노드를 raise 시키는 경로라(2026-09-12) 더미
+    # 자격증명으로 실제 로그인을 시도하게 두면 이 테스트의 관심사(추적/동기화 게이트)와
+    # 무관한 실패가 난다.
     with patch.object(BrokerNodeExecutor, "_start_account_tracking", new=AsyncMock()) as track, \
-         patch.object(BrokerNodeExecutor, "_sync_fill_prices_from_history", new=AsyncMock()) as sync:
+         patch.object(BrokerNodeExecutor, "_sync_fill_prices_from_history", new=AsyncMock()) as sync, \
+         patch.object(BrokerNodeExecutor, "_subscribe_workflow_fill_events", new=AsyncMock()) as fills:
         out = await ex.execute("broker", "OverseasStockBrokerNode", dict(_CFG), ctx)
         await asyncio.sleep(0)  # create_task 된 코루틴이 있으면 여기서 시작된다
-    return out, track, sync
+    return out, track, sync, fills
 
 
 @pytest.mark.asyncio
 async def test_dry_run_broker_does_not_start_account_tracking_or_fill_sync():
-    out, track, sync = await _run_broker(_ctx(dry_run=True))
+    out, track, sync, fills = await _run_broker(_ctx(dry_run=True))
     assert out.get("connected") is True or out.get("connection")
     track.assert_not_awaited()
     sync.assert_not_awaited()
+    fills.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 async def test_runtime_broker_still_starts_account_tracking_and_fill_sync():
-    out, track, sync = await _run_broker(_ctx(dry_run=False))
+    out, track, sync, fills = await _run_broker(_ctx(dry_run=False))
     assert out.get("connected") is True or out.get("connection")
     track.assert_awaited_once()
     sync.assert_awaited_once()
+    fills.assert_awaited_once()

--- a/src/programgarden/tests/test_fill_subscription_login_not_silent.py
+++ b/src/programgarden/tests/test_fill_subscription_login_not_silent.py
@@ -1,0 +1,210 @@
+"""체결 이벤트 구독 로그인 실패는 조용히 넘어가지 않는다 (M2, 2026-09-12 prod 실관측).
+
+관측된 사고
+-----------
+prod 파드가 LS OpenAPI 접속 불가 중에 떴다. ``Token 요청 실패`` 2건 뒤 브로커 노드가
+**completed** 로 끝났고, ``_subscribe_workflow_fill_events`` 는
+``if not success: context.log("error", ...); return`` 으로 체결 구독을 건너뛰고
+반환했다. 그 파드는 실시간 체결을 영영 받지 못하는데, 주문 노드는
+``LSClientManager.get_or_create`` 가 매번 재로그인을 시도하므로 **주문은 나갈 수
+있다** — 주문은 나가는데 체결은 원장에 안 잡히는 조합이다(FIFO 포지션·손익·리스크
+판정이 전부 눈먼 상태).
+
+고친 방침 (가)+(나)
+-------------------
+(가) 제한된 재시도: ``_FILL_SUBSCRIPTION_LOGIN_RETRY_DELAYS`` 만큼만 백오프 재시도한다.
+     상한을 두는 이유는 LS 앱키가 공유 자원이고 토큰 발급에 전송수 제한이 있어서다.
+(나) 그래도 실패하면 **노드 실패로 올린다** + 투자자 알림(CRITICAL)을 낸다.
+     ``context.log("error")`` 는 stdout 에 남지 않으므로 알림 채널로도 드러낸다.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import BrokerNodeExecutor
+from programgarden_core.bases.listener import (
+    BaseExecutionListener,
+    NotificationCategory,
+    NotificationSeverity,
+    WorkflowPnLEvent,
+)
+from programgarden_core.exceptions import ExecutionError
+
+
+class _PnLListener(BaseExecutionListener):
+    async def on_workflow_pnl_update(self, event: WorkflowPnLEvent) -> None:  # pragma: no cover
+        pass
+
+
+class FakeContext:
+    """``_subscribe_workflow_fill_events`` 가 실제로 쓰는 표면만 구현."""
+
+    is_dry_run = False
+    is_shutdown = False
+
+    def __init__(self):
+        self.logs = []
+        self.notifications = []
+
+    def log(self, level, message, node_id=None, data=None):
+        self.logs.append((level, message))
+
+    async def send_notification(self, **kwargs):
+        self.notifications.append(kwargs)
+
+
+@pytest.fixture
+def no_real_sleep(monkeypatch):
+    """백오프 대기를 기록만 하고 실제로 자지 않는다."""
+    slept = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay, *args, **kwargs):
+        slept.append(delay)
+        return await real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+    return slept
+
+
+async def _subscribe(context, login_results):
+    """``ensure_ls_login`` 이 주어진 순서대로 응답하게 하고 구독을 돌린다."""
+    calls = []
+
+    def fake_login(appkey, appsecret, paper_trading, ctx, node_id, product, caller_name=""):
+        calls.append(product)
+        return login_results[min(len(calls) - 1, len(login_results) - 1)]
+
+    with patch("programgarden.executor.ensure_ls_login", side_effect=fake_login), \
+         patch.object(BrokerNodeExecutor, "_subscribe_overseas_futures_fill_events",
+                      new=AsyncMock()) as subscribe:
+        await BrokerNodeExecutor()._subscribe_workflow_fill_events(
+            node_id="broker", product="overseas_futures",
+            appkey="k", appsecret="s", paper_trading=False, context=context,
+        )
+    return calls, subscribe
+
+
+@pytest.mark.asyncio
+async def test_login_failure_retries_with_bounded_backoff_then_raises(no_real_sleep):
+    """로그인이 계속 실패하면 (가) 제한 재시도 후 (나) 노드 실패로 올린다."""
+    context = FakeContext()
+
+    with pytest.raises(ExecutionError) as ei:
+        await _subscribe(context, [(None, False, "Token 요청 실패")])
+
+    # 재시도는 유한하다 — 최초 1회 + 백오프 2회(간격 2s·5s, 누적 7초).
+    # 🔴 리터럴로 고정한다: 클래스 상수 _FILL_SUBSCRIPTION_LOGIN_RETRY_DELAYS 를
+    #    그대로 참조하면 상수가 (2.0, 5.0, 10.0) 처럼 늘어나도 비교 대상도 같이
+    #    늘어나 상한 초과를 못 잡는다(검증 에이전트 지적). 관측된 sleep 간격을
+    #    하드코딩된 기대값과 대조해야 상한이 진짜로 고정된다.
+    assert no_real_sleep == [2.0, 5.0], "백오프 간격/횟수가 상한을 벗어났다 (3회/누적 7초 초과)"
+    assert len(no_real_sleep) == 2, "재시도 횟수가 2회(백오프 길이)를 벗어났다"
+    assert "구독" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_login_failure_is_not_a_silent_completion(no_real_sleep):
+    """조용한 완료 금지 — 에러 로그 + 투자자 알림(CRITICAL)이 둘 다 남는다."""
+    context = FakeContext()
+
+    with pytest.raises(ExecutionError):
+        await _subscribe(context, [(None, False, "Token 요청 실패")])
+
+    assert any(level == "error" for level, _ in context.logs)
+    assert len(context.notifications) == 1
+    note = context.notifications[0]
+    assert note["category"] == NotificationCategory.CONNECTION_FAILED
+    assert note["severity"] == NotificationSeverity.CRITICAL
+    assert note["data"]["product"] == "overseas_futures"
+
+
+@pytest.mark.asyncio
+async def test_login_recovering_on_retry_subscribes_without_failing(no_real_sleep):
+    """1회차 실패 → 2회차 성공이면 구독을 정상 진행하고 노드를 실패시키지 않는다."""
+    context = FakeContext()
+
+    calls, subscribe = await _subscribe(
+        context,
+        [(None, False, "Token 요청 실패"), (object(), True, None)],
+    )
+
+    assert len(calls) == 2, "재시도가 실제로 재로그인을 호출해야 한다"
+    subscribe.assert_awaited_once()
+    assert no_real_sleep == [BrokerNodeExecutor._FILL_SUBSCRIPTION_LOGIN_RETRY_DELAYS[0]]
+    assert context.notifications == []
+
+
+@pytest.mark.asyncio
+async def test_subscription_error_after_login_also_raises(no_real_sleep):
+    """로그인은 됐는데 구독 자체가 실패해도 조용히 끝내지 않는다."""
+    context = FakeContext()
+
+    def fake_login(*args, **kwargs):
+        return object(), True, None
+
+    with patch("programgarden.executor.ensure_ls_login", side_effect=fake_login), \
+         patch.object(BrokerNodeExecutor, "_subscribe_overseas_futures_fill_events",
+                      new=AsyncMock(side_effect=RuntimeError("websocket refused"))):
+        with pytest.raises(ExecutionError) as ei:
+            await BrokerNodeExecutor()._subscribe_workflow_fill_events(
+                node_id="broker", product="overseas_futures",
+                appkey="k", appsecret="s", paper_trading=False, context=context,
+            )
+
+    assert "websocket refused" in str(ei.value)
+    assert len(context.notifications) == 1
+
+
+# ── 노드 레벨: 브로커 노드가 completed 로 끝나지 않는다 ──────────────────────
+
+
+def _ctx(dry_run: bool, tmp_path) -> ExecutionContext:
+    ctx = ExecutionContext(
+        job_id="j", workflow_id="wf",
+        context_params={"dry_run": dry_run}, storage_dir=str(tmp_path),
+    )
+    ctx.add_listener(_PnLListener())
+    assert ctx.is_dry_run is dry_run
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_broker_node_fails_when_fill_subscription_login_fails(no_real_sleep, tmp_path):
+    """브로커 노드가 connected=True 를 돌려주며 조용히 완료되지 않는다."""
+    ctx = _ctx(False, tmp_path)
+
+    with patch("programgarden.executor.ensure_ls_login",
+               side_effect=lambda *a, **k: (None, False, "Token 요청 실패")), \
+         patch.object(BrokerNodeExecutor, "_start_account_tracking", new=AsyncMock()), \
+         patch.object(BrokerNodeExecutor, "_sync_fill_prices_from_history", new=AsyncMock()):
+        with pytest.raises(ExecutionError):
+            await BrokerNodeExecutor().execute(
+                "broker", "OverseasStockBrokerNode",
+                {"appkey": "k", "appsecret": "s", "paper_trading": False}, ctx,
+            )
+
+
+@pytest.mark.asyncio
+async def test_dry_run_broker_does_not_attempt_fill_subscription(tmp_path):
+    """dry_run 은 구독 자체를 시도하지 않는다 (모의 실행엔 체결이 없다).
+
+    이 게이트가 없으면 더미 appsecret 으로 도는 검증 잡이 위 하드 실패에 걸린다 —
+    같은 이유로 계좌 추적·체결내역 동기화는 이미 dry_run 에서 skip 이다.
+    """
+    ctx = _ctx(True, tmp_path)
+
+    with patch.object(BrokerNodeExecutor, "_subscribe_workflow_fill_events",
+                      new=AsyncMock()) as subscribe, \
+         patch.object(BrokerNodeExecutor, "_start_account_tracking", new=AsyncMock()), \
+         patch.object(BrokerNodeExecutor, "_sync_fill_prices_from_history", new=AsyncMock()):
+        out = await BrokerNodeExecutor().execute(
+            "broker", "OverseasStockBrokerNode",
+            {"appkey": "k", "appsecret": "s", "paper_trading": False}, ctx,
+        )
+
+    subscribe.assert_not_awaited()
+    assert out["connected"] is True

--- a/src/programgarden/tests/test_futures_tc3_side.py
+++ b/src/programgarden/tests/test_futures_tc3_side.py
@@ -86,7 +86,9 @@ async def deliver_tc3(monkeypatch, side, *, managed=False, shutdown=False, **ove
     processed = asyncio.Event()
     try:
         await executor._subscribe_overseas_futures_fill_events(ls, "broker", context)
-        callback = real._on_message_listeners["TC3"]
+        registered = real._on_message_listeners["TC3"]
+        # finance 1.9.7 부터 키당 리스너 리스트 — 원장 리스너는 이 테스트에서 유일한 등록자다
+        callback = registered[0] if isinstance(registered, list) else registered
 
         def observe(response):
             try:
@@ -95,6 +97,9 @@ async def deliver_tc3(monkeypatch, side, *, managed=False, shutdown=False, **ove
             finally:
                 loop.call_soon_threadsafe(processed.set)
 
+        # finance 1.9.7: 키당 다중 리스너라 래퍼를 *추가*하면 원본도 같이 불려 체결이 두 번 기록된다 —
+        # 원본을 떼고 래퍼(원본을 안에서 호출)만 남긴다.
+        real.TC3().on_remove_tc3_message(callback)
         real.TC3().on_tc3_message(observe)
         await socket.messages.put(json.dumps(tc3_packet(side, **overrides)))
         await asyncio.wait_for(processed.wait(), timeout=2)

--- a/src/programgarden/tests/test_korea_stock_order_event_streams.py
+++ b/src/programgarden/tests/test_korea_stock_order_event_streams.py
@@ -1,0 +1,679 @@
+"""E1: 국내주식 주문이벤트 노드(KoreaStockRealOrderEventNode)의 스트림 등록·파서.
+
+수정 전 결함 두 가지:
+
+1. **파서가 존재하지 않는 필드명을 읽었다.** `_ls_korea_stock_order_event` 의
+   핸들러는 ``OrdNo``/``OrdQty``/``OrdPrc``/``ExecQty``/``ExecPrc``/``UnercQty``/
+   ``OrdTime``/``BnsTpCode``/``IsuNm``/``shtnIsuNo`` 같은 PascalCase 를 읽었는데,
+   SC0~SC4 바디의 실제 필드명은 전부 소문자다(SC0: ``ordno``/``ordqty``/
+   ``ordprice``/``shtcode``/``hname``/``ordtm``/``bnstp``, SC1 계열: ``ordno``/
+   ``ordqty``/``ordprc``/``execqty``/``execprc``/``unercqty``/``exectime``/
+   ``execno``/``shtnIsuno``/``Isunm``/``bnstp``). pydantic v2 는 기본
+   ``extra='ignore'`` 라 그런 속성이 아예 없고, getattr 기본값이 그대로 나가
+   **모든 필드가 0/빈값**이었다.
+
+2. **SC1~SC4 프레임은 노드에 도달조차 못 했다.** 리스너를 ``SC0()
+   .on_sc0_message(...)`` 하나만 걸고 핸들러 안에서 ``tr_cd`` 로 SC1~SC4 를
+   분기했는데, SDK 디스패치는 프레임 헤더 ``tr_cd`` **정확일치 키**로만 이뤄진다
+   (``ls/real_base.py`` ``self._on_message_listeners.get(tr_cd, None)``).
+
+이 테스트는 (가) 스트림마다 리스너가 실제로 등록되는지, (나) 스트림별 파서가
+SDK 의 실제 필드명을 읽는지, (다) SC0 에 없는 체결 필드를 0 으로 지어내지 않는지를
+단언한다. 프레임은 SDK 응답 모델(``SC0RealResponse``/``SCnRealResponse``)로 직접
+만들어, 필드명이 하나라도 틀리면 테스트가 깨지게 한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import RealOrderEventNodeExecutor
+
+from programgarden_finance.ls.korea_stock.real.SC0.blocks import (
+    SC0RealResponse,
+    SC0RealResponseBody,
+    SC0RealResponseHeader,
+)
+from programgarden_finance.ls.korea_stock.real.SC1.blocks import (
+    SC1RealResponse,
+    SC1RealResponseBody,
+    SC1RealResponseHeader,
+)
+from programgarden_finance.ls.korea_stock.real.SC2.blocks import (
+    SC2RealResponse,
+    SC2RealResponseBody,
+    SC2RealResponseHeader,
+)
+from programgarden_finance.ls.korea_stock.real.SC3.blocks import (
+    SC3RealResponse,
+    SC3RealResponseBody,
+    SC3RealResponseHeader,
+)
+from programgarden_finance.ls.korea_stock.real.SC4.blocks import (
+    SC4RealResponse,
+    SC4RealResponseBody,
+    SC4RealResponseHeader,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 프레임 빌더 — 전 필드가 required(str) 라 ''로 채운 뒤 관심 필드만 덮어쓴다.
+# ──────────────────────────────────────────────────────────────────────────
+
+_SC_MODELS = {
+    "SC0": (SC0RealResponse, SC0RealResponseHeader, SC0RealResponseBody),
+    "SC1": (SC1RealResponse, SC1RealResponseHeader, SC1RealResponseBody),
+    "SC2": (SC2RealResponse, SC2RealResponseHeader, SC2RealResponseBody),
+    "SC3": (SC3RealResponse, SC3RealResponseHeader, SC3RealResponseBody),
+    "SC4": (SC4RealResponse, SC4RealResponseHeader, SC4RealResponseBody),
+}
+
+
+def _body(tr_cd: str, **overrides: str):
+    _, _, body_model = _SC_MODELS[tr_cd]
+    payload: Dict[str, Any] = {name: "" for name in body_model.model_fields}
+    unknown = set(overrides) - set(payload)
+    assert not unknown, f"{tr_cd} 바디에 없는 필드명: {sorted(unknown)}"
+    payload.update(overrides)
+    return body_model.model_validate(payload)
+
+
+def _frame(tr_cd: str, **overrides: str):
+    response_model, header_model, _ = _SC_MODELS[tr_cd]
+    return response_model(
+        header=header_model(tr_cd=tr_cd),
+        body=_body(tr_cd, **overrides),
+        rsp_cd="",
+        rsp_msg="",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# SDK 모양을 흉내 낸 real client — 등록된 리스너 키를 그대로 보관한다.
+# ──────────────────────────────────────────────────────────────────────────
+
+class _FakeStream:
+    """``real.SC1()`` 이 돌려주는 객체. ``on_sc1_message`` 만 갖는다."""
+
+    def __init__(self, tr_cd: str, registry: Dict[str, Any]):
+        self._tr_cd = tr_cd
+        self._registry = registry
+
+    def _register(self, listener):
+        self._registry[self._tr_cd] = listener
+        return listener
+
+    def __getattr__(self, name: str):
+        if name == f"on_{self._tr_cd.lower()}_message":
+            return self._register
+        raise AttributeError(name)
+
+
+class _FakeRealClient:
+    def __init__(self, available: Optional[List[str]] = None):
+        self.listeners: Dict[str, Any] = {}
+        self.connect_calls = 0
+        self._available = tuple(available) if available is not None else ("SC0", "SC1", "SC2", "SC3", "SC4")
+        for tr_cd in self._available:
+            setattr(self, tr_cd, self._make_factory(tr_cd))
+
+    def _make_factory(self, tr_cd: str):
+        def factory():
+            return _FakeStream(tr_cd, self.listeners)
+        return factory
+
+    async def is_connected(self) -> bool:
+        return self.connect_calls > 0
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+
+
+class _FakeKoreaStock:
+    def __init__(self, real_client):
+        self._real = real_client
+
+    def real(self):
+        return self._real
+
+
+class _FakeLS:
+    def __init__(self, real_client):
+        self._korea = _FakeKoreaStock(real_client)
+
+    def korea_stock(self):
+        return self._korea
+
+
+def _context() -> ExecutionContext:
+    ctx = ExecutionContext(job_id="job-e1", workflow_id="wf-e1")
+    ctx.notified: List[Dict[str, Any]] = []          # type: ignore[attr-defined]
+    ctx.emitted: List[Dict[str, Any]] = []           # type: ignore[attr-defined]
+    ctx.fill_price_updates: List[Dict[str, Any]] = []  # type: ignore[attr-defined]
+    ctx.logs: List[tuple] = []                       # type: ignore[attr-defined]
+
+    async def _notify(node_id, node_type, outputs, **kwargs):
+        ctx.notified.append({"node_id": node_id, "node_type": node_type, "outputs": outputs})
+
+    async def _emit(**kwargs):
+        ctx.emitted.append(kwargs)
+
+    def _update_fill_price(order_no, order_date, fill_price):
+        ctx.fill_price_updates.append(
+            {"order_no": order_no, "order_date": order_date, "fill_price": fill_price}
+        )
+        return True
+
+    def _log(level, message, node_id=None, *args, **kwargs):
+        ctx.logs.append((level, message, node_id))
+
+    ctx.notify_output_update = _notify        # type: ignore[assignment]
+    ctx.emit_event = _emit                    # type: ignore[assignment]
+    ctx.update_workflow_order_fill_price = _update_fill_price  # type: ignore[assignment]
+    ctx.log = _log                            # type: ignore[assignment]
+    return ctx
+
+
+async def _drain(cycles: int = 5) -> None:
+    """``asyncio.run_coroutine_threadsafe`` 로 예약된 콜백까지 실제로 돌린다.
+
+    핸들러는 동기 콜백이라 notify/emit 를 루프에 예약만 한다 — 한 틱으로는
+    예약만 처리되고 코루틴 본문이 아직 안 돈다.
+    """
+    for _ in range(cycles):
+        await asyncio.sleep(0)
+
+
+async def _subscribe(ctx, real_client, event_filter="all", node_id="order_event", stay_connected=True):
+    executor = RealOrderEventNodeExecutor()
+    return await executor._ls_korea_stock_order_event(
+        _FakeLS(real_client),
+        node_id,
+        {},
+        ctx,
+        stay_connected,
+        event_filter,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 1. 종전 파서가 읽던 PascalCase 필드는 SDK 바디에 존재하지 않는다 (결함의 근거)
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestOldFieldNamesDoNotExist:
+    def test_sc0_body_has_no_pascal_case_fields(self):
+        body = _body("SC0")
+        for legacy in ("OrdNo", "OrdQty", "OrdPrc", "ExecQty", "ExecPrc",
+                       "UnercQty", "OrdTime", "BnsTpCode", "IsuNm", "shtnIsuNo"):
+            assert not hasattr(body, legacy), f"SC0 바디에 {legacy} 가 생겼다 — 파서 재확인 필요"
+
+    def test_sc1_body_has_no_pascal_case_fields(self):
+        body = _body("SC1")
+        for legacy in ("OrdNo", "OrdQty", "OrdPrc", "ExecQty", "ExecPrc",
+                       "UnercQty", "OrdTime", "BnsTpCode", "IsuNm", "shtnIsuNo"):
+            assert not hasattr(body, legacy), f"SC1 바디에 {legacy} 가 생겼다 — 파서 재확인 필요"
+
+    def test_sc2_sc3_sc4_share_the_sc1_body_model(self):
+        """SC2~SC4 는 SC1RealResponseBody 를 상속한다 → SC1 계열 파서 하나로 충분."""
+        assert issubclass(SC2RealResponseBody, SC1RealResponseBody)
+        assert issubclass(SC3RealResponseBody, SC1RealResponseBody)
+        assert issubclass(SC4RealResponseBody, SC1RealResponseBody)
+        assert list(SC2RealResponseBody.model_fields) == list(SC1RealResponseBody.model_fields)
+
+    def test_sc0_body_really_has_no_fill_fields(self):
+        """SC0 는 주문접수 TR — 체결수량/체결가격/미체결수량 선언 자체가 없다."""
+        fields = set(SC0RealResponseBody.model_fields)
+        assert "execqty" not in fields
+        assert "execprc" not in fields
+        assert "unercqty" not in fields
+        assert "execno" not in fields
+        assert "exectime" not in fields
+        # 반대로 SC1 계열에는 전부 있다.
+        sc1_fields = set(SC1RealResponseBody.model_fields)
+        assert {"execqty", "execprc", "unercqty", "execno", "exectime"} <= sc1_fields
+        # 그리고 SC1 계열에는 주문시각(ordtm)이 없다.
+        assert "ordtm" not in sc1_fields
+        assert "ordtm" in fields
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 2. 스트림별 파서
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestSc0Parser:
+    def test_reads_sc0_lowercase_fields(self):
+        body = _body(
+            "SC0",
+            ordchegb="01",
+            marketgb="10",
+            orgordno="0",
+            expcode="KR7005930003",
+            shtcode="A005930",
+            hname="삼성전자",
+            ordqty="10",
+            ordprice="73500",
+            ordno="1234567",
+            ordtm="090015123",
+            bnstp="2",
+            orgordundrqty="3",
+            orgordmdfyqty="2",
+            ordordcancelqty="1",
+        )
+        event = RealOrderEventNodeExecutor._parse_korea_sc0_event(body)
+
+        assert event["tr_cd"] == "SC0"
+        assert event["event_code"] == "01"
+        assert event["symbol"] == "005930"          # 'A' 접두어 제거
+        assert event["symbol_short_code"] == "A005930"
+        assert event["symbol_std_code"] == "KR7005930003"
+        assert event["symbol_name"] == "삼성전자"
+        assert event["order_no"] == "1234567"
+        assert event["orig_order_no"] == "0"
+        assert event["side"] == "2"
+        assert event["order_qty"] == 10
+        assert event["order_price"] == 73500.0
+        assert event["order_time"] == "090015123"
+        assert event["exchange"] == "KRX"
+        assert event["market_code"] == "10"         # 상수 'KRX' 가 아니라 프레임 값
+        assert event["orig_order_remain_qty"] == 3
+        assert event["orig_order_modified_qty"] == 2
+        assert event["orig_order_cancelled_qty"] == 1
+
+    def test_does_not_invent_fill_fields(self):
+        body = _body("SC0", ordno="1234567", ordqty="10", ordprice="73500")
+        event = RealOrderEventNodeExecutor._parse_korea_sc0_event(body)
+
+        for key in ("filled_qty", "filled_price", "remain_qty"):
+            assert key not in event, f"SC0 에 없는 {key} 를 지어냈다"
+            assert event[f"{key}_unavailable_reason"] == "sc0_order_acceptance_frame_has_no_fill_fields"
+
+    def test_empty_price_does_not_raise(self):
+        """해당 없는 이벤트는 ''를 싣는다 — float('') 로 터지면 안 된다."""
+        event = RealOrderEventNodeExecutor._parse_korea_sc0_event(_body("SC0"))
+        assert event["order_price"] == 0.0
+        assert event["order_qty"] == 0
+        assert event["symbol"] == ""
+
+
+class TestSc1FamilyParser:
+    def test_reads_sc1_lowercase_fields(self):
+        body = _body(
+            "SC1",
+            ordxctptncode="11",
+            shtnIsuno="A005930",
+            Isuno="KR7005930003",
+            Isunm="삼성전자",
+            ordno="1234567",
+            orgordno="0",
+            bnstp="2",
+            ordqty="10",
+            ordprc="73500",
+            execqty="4",
+            execprc="73400",
+            unercqty="6",
+            execno="9876543",
+            exectime="091532123",
+            ordmktcode="10",
+        )
+        event = RealOrderEventNodeExecutor._parse_korea_sc1_family_event(body, "SC1")
+
+        assert event["tr_cd"] == "SC1"
+        assert event["event_code"] == "11"
+        assert event["symbol"] == "005930"
+        assert event["symbol_short_code"] == "A005930"
+        assert event["symbol_std_code"] == "KR7005930003"
+        assert event["symbol_name"] == "삼성전자"
+        assert event["order_no"] == "1234567"
+        assert event["side"] == "2"
+        assert event["order_qty"] == 10
+        assert event["order_price"] == 73500.0
+        assert event["filled_qty"] == 4
+        assert event["filled_price"] == 73400.0
+        assert event["remain_qty"] == 6
+        assert event["fill_no"] == "9876543"
+        assert event["fill_time"] == "091532123"
+        assert event["exchange"] == "KRX"
+        assert event["market_code"] == "10"
+
+    def test_does_not_pretend_to_know_order_time(self):
+        """SC1 계열에는 주문시각 필드가 없다 — 체결시각으로 채우지 않는다."""
+        body = _body("SC1", exectime="091532123")
+        event = RealOrderEventNodeExecutor._parse_korea_sc1_family_event(body, "SC1")
+        assert "order_time" not in event
+        assert event["order_time_unavailable_reason"] == "sc1_family_frame_has_no_order_time_field"
+        assert event["fill_time"] == "091532123"
+
+    def test_sc2_modify_confirm_fields(self):
+        body = _body("SC2", ordxctptncode="12", ordno="1234567",
+                     mdfycnfqty="7", mdfycnfprc="73900")
+        event = RealOrderEventNodeExecutor._parse_korea_sc1_family_event(body, "SC2")
+        assert event["tr_cd"] == "SC2"
+        assert event["modified_qty"] == 7
+        assert event["modified_price"] == 73900.0
+
+    def test_sc3_cancel_confirm_fields(self):
+        body = _body("SC3", ordxctptncode="13", ordno="1234567", canccnfqty="5")
+        event = RealOrderEventNodeExecutor._parse_korea_sc1_family_event(body, "SC3")
+        assert event["tr_cd"] == "SC3"
+        assert event["cancelled_qty"] == 5
+
+    def test_sc4_reject_fields(self):
+        body = _body("SC4", ordxctptncode="14", ordno="1234567", rjtqty="10")
+        event = RealOrderEventNodeExecutor._parse_korea_sc1_family_event(body, "SC4")
+        assert event["tr_cd"] == "SC4"
+        assert event["rejected_qty"] == 10
+
+    def test_non_standard_symbol_code_is_passed_through(self):
+        """규약('A'/'J' + 6자리)에 안 맞으면 손대지 않는다."""
+        body = _body("SC1", shtnIsuno="005930")
+        event = RealOrderEventNodeExecutor._parse_korea_sc1_family_event(body, "SC1")
+        assert event["symbol"] == "005930"
+        assert event["symbol_short_code"] == "005930"
+
+    def test_fractional_exec_qty_is_preserved(self):
+        """소수점 체결수량은 int() 절단 없이 보존된다 (_qty_num 경로 고정).
+
+        국내주식에 소수점 체결은 드물지만, 파서가 ``_qty_num`` 을 쓰는 한 int 절단
+        회귀(0.5 → 0)가 생기면 체결 이벤트가 조용히 사라진다. 경로를 고정한다."""
+        body = _body("SC1", ordno="1234567", execqty="0.5", execprc="73400")
+        event = RealOrderEventNodeExecutor._parse_korea_sc1_family_event(body, "SC1")
+        assert event["filled_qty"] == 0.5
+        assert isinstance(event["filled_qty"], float)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 3. 리스너 등록 — 어떤 키로 등록되는가
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestStreamRegistration:
+    @pytest.mark.asyncio
+    async def test_all_five_streams_get_a_listener(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+
+        result = await _subscribe(ctx, real_client, event_filter="all")
+        await _drain()
+
+        # SDK 리스너 키 — 종전에는 'SC0' 하나뿐이라 SC1~SC4 프레임이 버려졌다.
+        assert sorted(real_client.listeners) == ["SC0", "SC1", "SC2", "SC3", "SC4"]
+        # 노드 핸들러도 스트림마다 등록된다.
+        for tr_cd in ("SC0", "SC1", "SC2", "SC3", "SC4"):
+            handlers = ctx.get_order_event_handlers("korea_stock", tr_cd)
+            assert [h[0] for h in handlers] == ["order_event"], tr_cd
+        assert result["status"] == "subscribed"
+        assert result["subscribed_streams"] == ["SC0", "SC1", "SC2", "SC3", "SC4"]
+        assert "unavailable_streams" not in result
+
+    @pytest.mark.asyncio
+    async def test_filtered_node_registers_only_its_stream(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+
+        result = await _subscribe(ctx, real_client, event_filter="SC1")
+        await _drain()
+
+        assert result["subscribed_streams"] == ["SC1"]
+        assert ctx.get_order_event_handlers("korea_stock", "SC1")
+        for tr_cd in ("SC0", "SC2", "SC3", "SC4"):
+            assert ctx.get_order_event_handlers("korea_stock", tr_cd) == []
+        # 마스터는 그래도 다섯 개 전부 — 뒤에 붙는 다른 filter 노드를 위해서다.
+        assert sorted(real_client.listeners) == ["SC0", "SC1", "SC2", "SC3", "SC4"]
+
+    @pytest.mark.asyncio
+    async def test_second_node_with_other_filter_reuses_masters(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+
+        await _subscribe(ctx, real_client, event_filter="SC1", node_id="node_fill")
+        await _subscribe(ctx, real_client, event_filter="SC4", node_id="node_reject")
+        await _drain()
+
+        assert real_client.connect_calls == 1
+        assert [h[0] for h in ctx.get_order_event_handlers("korea_stock", "SC1")] == ["node_fill"]
+        assert [h[0] for h in ctx.get_order_event_handlers("korea_stock", "SC4")] == ["node_reject"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_filter_is_an_error(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+
+        result = await _subscribe(ctx, real_client, event_filter="SC9")
+
+        assert "error" in result
+        assert real_client.listeners == {}
+
+    @pytest.mark.asyncio
+    async def test_missing_sdk_stream_is_reported_not_guessed(self):
+        """SDK 에 등록 API 가 없는 스트림은 조용히 넘어가지 않고 사실로 보고된다."""
+        ctx = _context()
+        real_client = _FakeRealClient(available=["SC0", "SC1", "SC2"])
+
+        result = await _subscribe(ctx, real_client, event_filter="all")
+        await _drain()
+
+        assert sorted(real_client.listeners) == ["SC0", "SC1", "SC2"]
+        assert result["unavailable_streams"] == ["SC3", "SC4"]
+        warnings = [m for lvl, m, _ in ctx.logs if lvl == "warning"]
+        assert any("SC3, SC4" in m for m in warnings), warnings
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 4. 종단 — 프레임이 실제로 포트까지 도달하는가
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestFrameReachesPorts:
+    @pytest.mark.asyncio
+    async def test_sc1_fill_frame_reaches_filled_port(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.listeners["SC1"](
+            _frame(
+                "SC1",
+                ordxctptncode="11",
+                shtnIsuno="A005930",
+                Isunm="삼성전자",
+                ordno="1234567",
+                bnstp="2",
+                ordqty="10",
+                ordprc="73500",
+                execqty="10",
+                execprc="73400",
+                unercqty="0",
+                execno="9876543",
+                exectime="091532123",
+                ordmktcode="10",
+            )
+        )
+        await _drain()
+
+        output = ctx.get_output("order_event", "filled")
+        assert output is not None, "SC1 프레임이 filled 포트에 도달하지 않았다"
+        assert output["symbol"] == "005930"
+        assert output["filled_qty"] == 10
+        assert output["filled_price"] == 73400.0
+        assert output["status"] == "체결"
+        # 구독 결과 알림과 이벤트 알림이 같은 큐에 섞이므로 순서를 가정하지 않는다.
+        port_notifications = [n for n in ctx.notified if "filled" in n["outputs"]]
+        assert len(port_notifications) == 1
+        assert port_notifications[0]["node_type"] == "KoreaStockRealOrderEventNode"
+        assert port_notifications[0]["outputs"]["filled"]["filled_price"] == 73400.0
+        assert [e["event_type"] for e in ctx.emitted] == ["order_event"]
+
+    @pytest.mark.asyncio
+    async def test_sc1_fill_updates_order_fill_price_with_local_date(self):
+        """프레임에 주문일자 필드가 없어 로컬 날짜를 쓴다 — 원장 쓰기 쪽과 같은 규약."""
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.listeners["SC1"](
+            _frame("SC1", ordno="1234567", execqty="10", execprc="73400")
+        )
+        await _drain()
+
+        assert ctx.fill_price_updates == [
+            {
+                "order_no": "1234567",
+                "order_date": datetime.now().strftime("%Y%m%d"),
+                "fill_price": 73400.0,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fill_price_update_skipped_without_order_no(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.listeners["SC1"](_frame("SC1", execqty="10", execprc="73400"))
+        await _drain()
+
+        assert ctx.fill_price_updates == []
+
+    @pytest.mark.asyncio
+    async def test_sc0_frame_reaches_accepted_port_without_fake_fill(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.listeners["SC0"](
+            _frame(
+                "SC0",
+                ordchegb="01",
+                marketgb="20",
+                shtcode="A035420",
+                hname="NAVER",
+                ordqty="3",
+                ordprice="180000",
+                ordno="7654321",
+                ordtm="090015123",
+                bnstp="1",
+            )
+        )
+        await _drain()
+
+        output = ctx.get_output("order_event", "accepted")
+        assert output is not None
+        assert output["symbol"] == "035420"
+        assert output["order_qty"] == 3
+        assert output["order_price"] == 180000.0
+        assert output["order_time"] == "090015123"
+        assert output["market_code"] == "20"
+        assert output["status"] == "주문접수"
+        assert "filled_qty" not in output and "filled_price" not in output
+        assert ctx.fill_price_updates == []
+
+    @pytest.mark.parametrize(
+        "tr_cd,port,status",
+        [
+            ("SC2", "modified", "정정확인"),
+            ("SC3", "cancelled", "취소확인"),
+            ("SC4", "rejected", "거부"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_sc2_sc3_sc4_reach_their_own_ports(self, tr_cd, port, status):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.listeners[tr_cd](
+            _frame(tr_cd, ordno="1234567", shtnIsuno="A005930", bnstp="2")
+        )
+        await _drain()
+
+        output = ctx.get_output("order_event", port)
+        assert output is not None, f"{tr_cd} 프레임이 {port} 포트에 도달하지 않았다"
+        assert output["tr_cd"] == tr_cd
+        assert output["status"] == status
+        assert output["symbol"] == "005930"
+
+    @pytest.mark.asyncio
+    async def test_filtered_node_only_sees_its_own_stream(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="SC4", node_id="only_rejects")
+
+        real_client.listeners["SC1"](_frame("SC1", ordno="1", execqty="1", execprc="100"))
+        real_client.listeners["SC4"](_frame("SC4", ordno="2", rjtqty="1"))
+        await _drain()
+
+        assert ctx.get_output("only_rejects", "filled") is None
+        rejected = ctx.get_output("only_rejects", "rejected")
+        assert rejected is not None and rejected["order_no"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_unknown_tr_frame_is_skipped_not_parsed_as_sc1(self):
+        """모르는 TR 은 SC1 계열 파서로 넘기지 않는다 — 빈값 이벤트를 만들지 않는다."""
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        mislabelled = SC1RealResponse(
+            header=SC1RealResponseHeader(tr_cd="SC9"),
+            body=_body("SC1", ordno="1234567", execqty="10", execprc="73400"),
+            rsp_cd="",
+            rsp_msg="",
+        )
+        real_client.listeners["SC1"](mislabelled)
+        await _drain()
+
+        assert ctx.get_all_outputs("order_event") == {}
+        assert ctx.fill_price_updates == []
+        assert any("SC9" in m for lvl, m, _ in ctx.logs if lvl == "warning")
+
+    @pytest.mark.asyncio
+    async def test_body_less_frame_is_skipped_not_zero_filled(self):
+        """real_base 는 바디 검증 실패 시 body=None 으로 준다 — 0짜리 체결을 만들지 않는다."""
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        broken = SC1RealResponse(
+            header=SC1RealResponseHeader(tr_cd="SC1"),
+            body=None,
+            rsp_cd="",
+            rsp_msg="",
+            error_msg="validation failed",
+        )
+        real_client.listeners["SC1"](broken)
+        await _drain()
+
+        assert ctx.get_output("order_event", "filled") is None
+        assert ctx.fill_price_updates == []
+        assert any(lvl == "warning" for lvl, _, _ in ctx.logs)
+
+    @pytest.mark.asyncio
+    async def test_header_none_frame_falls_back_to_registered_stream(self):
+        """헤더 없이 body 만 있는 프레임은 **등록된 스트림**을 TR 로 삼는다.
+
+        real_base 는 tr_cd 정확일치로만 배달하므로, SC1 리스너에 온 프레임은 설령
+        header 가 없어도 SC1 이다. 핸들러는 `(header.tr_cd if header else '') or _stream`
+        으로 등록 스트림에 폴백해야 한다 — 종전처럼 'SC0' 으로 떨어지면 엉뚱한 파서로
+        간다."""
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        frame = SC1RealResponse(
+            header=None,
+            body=_body("SC1", ordno="1234567", execqty="10", execprc="73400", shtnIsuno="A005930"),
+            rsp_cd="",
+            rsp_msg="",
+        )
+        real_client.listeners["SC1"](frame)
+        await _drain()
+
+        output = ctx.get_output("order_event", "filled")
+        assert output is not None, "header=None 프레임이 filled 포트에 도달하지 않았다"
+        assert output["tr_cd"] == "SC1"
+        assert output["filled_qty"] == 10
+        assert output["symbol"] == "005930"
+        assert output["status"] == "체결"

--- a/src/programgarden/tests/test_overseas_stock_order_event_streams.py
+++ b/src/programgarden/tests/test_overseas_stock_order_event_streams.py
@@ -1,0 +1,757 @@
+"""해외주식 주문이벤트 노드(OverseasStockRealOrderEventNode)의 스트림 등록·파서.
+
+수정 전 결함(국내 SC 와 **동형**):
+
+1. **AS1~AS4 프레임이 노드에 도달조차 못 했다.** 리스너를 ``AS0().on_as0_message(...)``
+   하나만 걸고 핸들러 안에서 ``tr_cd`` 로 AS1~AS4 를 분기했는데, SDK 디스패치는
+   프레임 ``tr_cd`` **정확일치 키**로만 이뤄진다
+   (``ls/real_base.py`` ``self._on_message_listeners.get(tr_cd)``). 그래서 AS1(체결)·
+   AS2(정정)·AS3(취소확인)·AS4(거부) 프레임은 리스너가 없어 버려졌다 —
+   filled/modified/cancelled/rejected 포트는 영구히 0건.
+
+2. **체결가 갱신이 주문가를 체결가로 썼다.** 체결('11') 분기가 ``sOrdPrc``(주문가)를
+   체결가로 썼는데 체결가는 ``sExecPrc`` 다. 게다가 '11' 은 AS0 의 enum
+   ('01'/'03'/'12'/'13'/'14')에 없어 그 분기는 한 번도 타지 않았다(AS1 도 안 왔다).
+
+이 테스트는 실제 SDK 응답 모델(``AS0RealResponse``/``AS1RealResponse`` 등)로 프레임을
+만들어 (가) 스트림마다 리스너가 실제로 등록되는지, (나) 스트림별 파서가 SDK 의 실제
+필드명을 읽는지, (다) AS0 에 없는 체결 필드를 0 으로 지어내지 않는지, (라) 소수점
+``sExecQty`` 가 보존되는지, (마) event_filter 로 AS1 을 고르면 AS1 프레임이 filled 포트에
+도달하는지를 단언한다. 또한 체결 원장 리스너가 노드 마스터 등록 후에도 보존되는지
+(SDK 가 키당 리스너 리스트로 바뀐 전제)와 core 선언 필드명 alias 를 확인한다.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import RealOrderEventNodeExecutor
+
+from programgarden_finance.ls.overseas_stock.real.AS0.blocks import (
+    AS0RealResponse,
+    AS0RealResponseBody,
+    AS0RealResponseHeader,
+)
+from programgarden_finance.ls.overseas_stock.real.AS1.blocks import (
+    AS1RealResponse,
+    AS1RealResponseBody,
+    AS1RealResponseHeader,
+)
+from programgarden_finance.ls.overseas_stock.real.AS2.blocks import (
+    AS2RealResponse,
+    AS2RealResponseBody,
+    AS2RealResponseHeader,
+)
+from programgarden_finance.ls.overseas_stock.real.AS3.blocks import (
+    AS3RealResponse,
+    AS3RealResponseBody,
+    AS3RealResponseHeader,
+)
+from programgarden_finance.ls.overseas_stock.real.AS4.blocks import (
+    AS4RealResponse,
+    AS4RealResponseBody,
+    AS4RealResponseHeader,
+)
+from programgarden_finance.ls.korea_stock.real.SC1.blocks import SC1RealResponseBody
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 프레임 빌더 — AS 바디는 str/int/float 혼합이라 타입별 기본값으로 채운 뒤
+# 관심 필드만 덮어쓴다. 필드명이 하나라도 틀리면 _body 가 단언으로 깨진다.
+# ──────────────────────────────────────────────────────────────────────────
+
+_AS_MODELS = {
+    "AS0": (AS0RealResponse, AS0RealResponseHeader, AS0RealResponseBody),
+    "AS1": (AS1RealResponse, AS1RealResponseHeader, AS1RealResponseBody),
+    "AS2": (AS2RealResponse, AS2RealResponseHeader, AS2RealResponseBody),
+    "AS3": (AS3RealResponse, AS3RealResponseHeader, AS3RealResponseBody),
+    "AS4": (AS4RealResponse, AS4RealResponseHeader, AS4RealResponseBody),
+}
+
+
+def _body(tr_cd: str, **overrides: Any):
+    body_model = _AS_MODELS[tr_cd][2]
+    payload: Dict[str, Any] = {}
+    for name, field in body_model.model_fields.items():
+        ann = field.annotation
+        if ann is int:
+            payload[name] = 0
+        elif ann is float:
+            payload[name] = 0.0
+        else:
+            payload[name] = ""
+    unknown = set(overrides) - set(payload)
+    assert not unknown, f"{tr_cd} 바디에 없는 필드명: {sorted(unknown)}"
+    payload.update(overrides)
+    return body_model.model_validate(payload)
+
+
+def _frame(tr_cd: str, *, with_header: bool = True, **overrides: Any):
+    response_model, header_model, _ = _AS_MODELS[tr_cd]
+    header = header_model(tr_cd=tr_cd) if with_header else None
+    return response_model(
+        header=header,
+        body=_body(tr_cd, **overrides),
+        rsp_cd="",
+        rsp_msg="",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# SDK 모양을 흉내 낸 real client. 🔴 새 SDK 는 키당 리스너를 **리스트로 append**
+# 한다(real_base._on_message). 원장 리스너를 노드 마스터가 덮어쓰지 않는지 보려면
+# 가짜도 append 여야 한다.
+# ──────────────────────────────────────────────────────────────────────────
+
+class _FakeStream:
+    def __init__(self, tr_cd: str, registry: Dict[str, List[Any]]):
+        self._tr_cd = tr_cd
+        self._registry = registry
+
+    def _register(self, listener):
+        self._registry.setdefault(self._tr_cd, []).append(listener)
+        return listener
+
+    def __getattr__(self, name: str):
+        if name == f"on_{self._tr_cd.lower()}_message":
+            return self._register
+        raise AttributeError(name)
+
+
+class _FakeRealClient:
+    def __init__(self, available: Optional[List[str]] = None):
+        self.listeners: Dict[str, List[Any]] = {}
+        self.connect_calls = 0
+        self._available = tuple(available) if available is not None else ("AS0", "AS1", "AS2", "AS3", "AS4")
+        for tr_cd in self._available:
+            setattr(self, tr_cd, self._make_factory(tr_cd))
+
+    def _make_factory(self, tr_cd: str):
+        def factory():
+            return _FakeStream(tr_cd, self.listeners)
+        return factory
+
+    async def is_connected(self) -> bool:
+        return self.connect_calls > 0
+
+    async def connect(self) -> None:
+        self.connect_calls += 1
+
+    def dispatch(self, tr_cd: str, frame) -> None:
+        """SDK 디스패치 흉내 — tr_cd 키에 등록된 **모든** 리스너를 호출."""
+        for listener in list(self.listeners.get(tr_cd, [])):
+            listener(frame)
+
+
+class _FakeOverseasStock:
+    def __init__(self, real_client):
+        self._real = real_client
+
+    def real(self):
+        return self._real
+
+
+class _FakeLS:
+    def __init__(self, real_client):
+        self._os = _FakeOverseasStock(real_client)
+
+    def overseas_stock(self):
+        return self._os
+
+
+def _context() -> ExecutionContext:
+    ctx = ExecutionContext(job_id="job-as", workflow_id="wf-as")
+    ctx.notified: List[Dict[str, Any]] = []            # type: ignore[attr-defined]
+    ctx.emitted: List[Dict[str, Any]] = []             # type: ignore[attr-defined]
+    ctx.fill_price_updates: List[Dict[str, Any]] = []  # type: ignore[attr-defined]
+    ctx.logs: List[tuple] = []                         # type: ignore[attr-defined]
+
+    async def _notify(node_id, node_type, outputs, **kwargs):
+        ctx.notified.append({"node_id": node_id, "node_type": node_type, "outputs": outputs})
+
+    async def _emit(**kwargs):
+        ctx.emitted.append(kwargs)
+
+    def _update_fill_price(order_no, order_date, fill_price):
+        ctx.fill_price_updates.append(
+            {"order_no": order_no, "order_date": order_date, "fill_price": fill_price}
+        )
+        return True
+
+    def _log(level, message, node_id=None, *args, **kwargs):
+        ctx.logs.append((level, message, node_id))
+
+    ctx.notify_output_update = _notify          # type: ignore[assignment]
+    ctx.emit_event = _emit                      # type: ignore[assignment]
+    ctx.update_workflow_order_fill_price = _update_fill_price  # type: ignore[assignment]
+    ctx.log = _log                              # type: ignore[assignment]
+    return ctx
+
+
+async def _drain(cycles: int = 5) -> None:
+    for _ in range(cycles):
+        await asyncio.sleep(0)
+
+
+async def _subscribe(ctx, real_client, event_filter="all", node_id="order_event", stay_connected=True):
+    executor = RealOrderEventNodeExecutor()
+    return await executor._ls_stock_order_event(
+        _FakeLS(real_client),
+        node_id,
+        {},
+        ctx,
+        stay_connected,
+        event_filter,
+    )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 1. AS1 계열 바디는 AS0 와 **다른** 필드 집합을 쓴다 (결함의 근거)
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestBodyShapes:
+    def test_as0_has_no_fill_fields(self):
+        """AS0 는 주문접수 TR — 체결/정정확인/취소확인/거부 필드 선언 자체가 없다."""
+        fields = set(AS0RealResponseBody.model_fields)
+        for absent in ("sExecQty", "sExecPrc", "sExecNO", "sExecTime",
+                       "sMdfyCnfQty", "sCancCnfQty", "sRjtQty", "sUnercQty"):
+            assert absent not in fields, f"AS0 에 {absent} 가 생겼다 — 파서 재확인 필요"
+
+    def test_as1_family_has_execution_fields(self):
+        """AS1~AS4 는 execution-shape 필드를 공유한다(module docstring: mirrors AS1)."""
+        expected = {"sExecQty", "sExecPrc", "sExecNO", "sExecTime",
+                    "sMdfyCnfQty", "sMdfyCnfPrc", "sCancCnfQty", "sRjtQty", "sUnercQty"}
+        for model in (AS1RealResponseBody, AS2RealResponseBody,
+                      AS3RealResponseBody, AS4RealResponseBody):
+            assert expected <= set(model.model_fields), model.__name__
+        # AS1 계열에는 주문시각(sOrdTime)이 없다 — 시각은 sExecTime/sRcptExecTime 뿐.
+        assert "sOrdTime" not in set(AS1RealResponseBody.model_fields)
+        # 반대로 AS0 에는 sOrdTime 이 있다.
+        assert "sOrdTime" in set(AS0RealResponseBody.model_fields)
+
+    def test_as2_as3_as4_share_as1_parsed_field_set(self):
+        """파서가 읽는 필드는 AS1~AS4 에 **모두** 있다(계열 파서 하나로 충분).
+
+        관측(SDK 2026-09-12): AS1/AS2/AS3 는 108개 필드로 완전히 동일하고, AS4 는
+        103개 — 뒤쪽 잔고/증거금 5개(sOrdAbleSubstAmt·sMgntrnCode·sRuseAbleAmt·
+        sCsgnSubstMgn·sOrdAbleMny)를 빼고 선언한다. 그 5개는 파서가 읽지 않으므로
+        계열 파서 공유에 영향이 없다. 중요한 건 파서가 실제로 읽는 필드의 공통 존재다.
+        """
+        parsed = {
+            "sOrdxctPtnCode", "sOrdMktCode", "sShtnIsuNo", "sIsuNo", "sStdIsuNo",
+            "sIsuNm", "sOrdNo", "sOrgOrdNo", "sBnsTp", "sOrdQty", "sOrdPrc",
+            "sExecQty", "sExecPrc", "sUnercQty", "sExecNO", "sExecTime",
+            "sRcptExecTime", "sMdfyCnfQty", "sMdfyCnfPrc", "sCancCnfQty",
+            "sRjtQty", "sRjtRsn",
+        }
+        for model in (AS1RealResponseBody, AS2RealResponseBody,
+                      AS3RealResponseBody, AS4RealResponseBody):
+            assert parsed <= set(model.model_fields), (
+                model.__name__, sorted(parsed - set(model.model_fields))
+            )
+        # AS1/AS2/AS3 는 완전히 동일, AS4 만 뒤쪽 잔고/증거금 필드 5개를 뺀다.
+        assert list(AS2RealResponseBody.model_fields) == list(AS1RealResponseBody.model_fields)
+        assert list(AS3RealResponseBody.model_fields) == list(AS1RealResponseBody.model_fields)
+        assert set(AS1RealResponseBody.model_fields) - set(AS4RealResponseBody.model_fields) == {
+            "sOrdAbleSubstAmt", "sMgntrnCode", "sRuseAbleAmt", "sCsgnSubstMgn", "sOrdAbleMny",
+        }
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 2. 스트림별 파서
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestAs0Parser:
+    def test_reads_as0_acceptance_fields(self):
+        body = _body(
+            "AS0",
+            sOrdxctPtnCode="01",
+            sOrdMktCode="82",
+            sShtnIsuNo="AAPL",
+            sIsuNo="82AAPL",
+            sIsuNm="애플",
+            sOrdNo=231,
+            sOrgOrdNo=0,
+            sBnsTp="2",
+            sOrdQty="10",
+            sOrdPrc=180.5,
+            sOrdTime="093015",
+            sOrgOrdUnercQty=3.0,
+            sOrgOrdMdfyQty=1.0,
+            sOrgOrdCancQty=0.0,
+        )
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_as0_event(body)
+
+        assert event["tr_cd"] == "AS0"
+        assert event["event_code"] == "01"
+        assert event["symbol"] == "AAPL"
+        assert event["symbol_full_code"] == "82AAPL"
+        assert event["symbol_name"] == "애플"
+        assert event["order_no"] == 231
+        assert event["side"] == "2"
+        assert event["order_qty"] == 10
+        assert event["order_price"] == 180.5
+        assert event["order_time"] == "093015"
+        assert event["market_code"] == "82"
+        assert event["exchange"] == "NASDAQ"       # 82 → NASDAQ (원장 경로와 같은 맵)
+        assert event["orig_order_remain_qty"] == 3
+
+    def test_does_not_invent_fill_fields(self):
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_as0_event(
+            _body("AS0", sOrdNo=231, sOrdQty="10", sOrdPrc=180.5)
+        )
+        for key in ("filled_qty", "filled_price", "remain_qty"):
+            assert key not in event, f"AS0 에 없는 {key} 를 지어냈다"
+            assert event[f"{key}_unavailable_reason"] == "as0_order_acceptance_frame_has_no_fill_fields"
+
+    def test_unknown_market_code_does_not_invent_exchange(self):
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_as0_event(
+            _body("AS0", sOrdMktCode="99")
+        )
+        assert "exchange" not in event
+        assert event["exchange_unavailable_reason"] == "overseas_stock_market_code_not_in_known_exchange_map"
+        assert event["market_code"] == "99"        # 원값은 그대로 싣는다
+
+    def test_empty_price_does_not_raise(self):
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_as0_event(_body("AS0"))
+        assert event["order_price"] == 0.0
+        assert event["order_qty"] == 0
+        assert event["symbol"] == ""
+
+
+class TestAs1FamilyParser:
+    def test_reads_as1_execution_fields(self):
+        body = _body(
+            "AS1",
+            sOrdxctPtnCode="11",
+            sOrdMktCode="81",
+            sShtnIsuNo="AAPL",
+            sIsuNo="82AAPL",
+            sStdIsuNo="US0378331005",
+            sIsuNm="애플",
+            sOrdNo=1234567,
+            sOrgOrdNo=0,
+            sBnsTp="2",
+            sOrdQty=10.0,
+            sOrdPrc=180.0,
+            sExecQty=4.0,
+            sExecPrc=181.25,
+            sUnercQty=6.0,
+            sExecNO="E99",
+            sExecTime="093015",
+        )
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_fill_family_event(body, "AS1")
+
+        assert event["tr_cd"] == "AS1"
+        assert event["symbol"] == "AAPL"
+        assert event["symbol_std_code"] == "US0378331005"
+        assert event["order_no"] == 1234567
+        assert event["side"] == "2"
+        assert event["order_qty"] == 10
+        assert event["order_price"] == 180.0
+        # 🔴 체결가/체결수량은 sExecPrc/sExecQty 다 (주문가/주문수량이 아니다)
+        assert event["filled_qty"] == 4
+        assert event["filled_price"] == 181.25
+        assert event["remain_qty"] == 6
+        assert event["fill_no"] == "E99"
+        assert event["fill_time"] == "093015"
+        assert event["market_code"] == "81"
+        assert event["exchange"] == "NYSE"         # 81 → NYSE
+
+    def test_fractional_exec_qty_is_preserved(self):
+        """소수점 체결수량(prod 관측 IBM 0.847972주)은 int() 절단 없이 보존된다."""
+        body = _body("AS1", sOrdNo=1, sExecQty=0.532, sExecPrc=181.25)
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_fill_family_event(body, "AS1")
+        assert event["filled_qty"] == 0.532
+        assert isinstance(event["filled_qty"], float)
+
+    def test_does_not_pretend_to_know_order_time(self):
+        """AS1 계열에는 주문시각 필드가 없다 — 체결시각으로 채우지 않는다."""
+        body = _body("AS1", sExecTime="093015")
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_fill_family_event(body, "AS1")
+        assert "order_time" not in event
+        assert event["order_time_unavailable_reason"] == "overseas_stock_fill_family_frame_has_no_order_time_field"
+        assert event["fill_time"] == "093015"
+
+    def test_fill_time_falls_back_to_rcpt_exec_time(self):
+        body = _body("AS1", sExecTime="", sRcptExecTime="093020")
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_fill_family_event(body, "AS1")
+        assert event["fill_time"] == "093020"
+
+    def test_as2_modify_confirm_fields(self):
+        body = _body("AS2", sOrdNo=1, sMdfyCnfQty=7.0, sMdfyCnfPrc=182.0)
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_fill_family_event(body, "AS2")
+        assert event["tr_cd"] == "AS2"
+        assert event["modified_qty"] == 7
+        assert event["modified_price"] == 182.0
+
+    def test_as3_cancel_confirm_fields(self):
+        body = _body("AS3", sOrdNo=1, sCancCnfQty=5.0)
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_fill_family_event(body, "AS3")
+        assert event["tr_cd"] == "AS3"
+        assert event["cancelled_qty"] == 5
+
+    def test_as4_reject_fields(self):
+        body = _body("AS4", sOrdNo=1, sRjtQty=10.0, sRjtRsn="한도초과")
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_fill_family_event(body, "AS4")
+        assert event["tr_cd"] == "AS4"
+        assert event["rejected_qty"] == 10
+        assert event["reject_reason"] == "한도초과"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 3. 리스너 등록 — 어떤 키로 등록되는가
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestStreamRegistration:
+    @pytest.mark.asyncio
+    async def test_all_five_streams_get_a_listener(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+
+        result = await _subscribe(ctx, real_client, event_filter="all")
+        await _drain()
+
+        # SDK 리스너 키 — 종전에는 'AS0' 하나뿐이라 AS1~AS4 프레임이 버려졌다.
+        assert sorted(real_client.listeners) == ["AS0", "AS1", "AS2", "AS3", "AS4"]
+        for tr_cd in ("AS0", "AS1", "AS2", "AS3", "AS4"):
+            handlers = ctx.get_order_event_handlers("overseas_stock", tr_cd)
+            assert [h[0] for h in handlers] == ["order_event"], tr_cd
+        assert result["status"] == "subscribed"
+        assert result["subscribed_streams"] == ["AS0", "AS1", "AS2", "AS3", "AS4"]
+        assert "unavailable_streams" not in result
+        # 마스터가 스트림별로 저장된다 (정리 경로가 이것만 뗀다).
+        assert set(ctx.get_order_event_masters("overseas_stock")) == {"AS0", "AS1", "AS2", "AS3", "AS4"}
+
+    @pytest.mark.asyncio
+    async def test_filtered_node_registers_only_its_stream(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+
+        result = await _subscribe(ctx, real_client, event_filter="AS1")
+        await _drain()
+
+        assert result["subscribed_streams"] == ["AS1"]
+        assert ctx.get_order_event_handlers("overseas_stock", "AS1")
+        for tr_cd in ("AS0", "AS2", "AS3", "AS4"):
+            assert ctx.get_order_event_handlers("overseas_stock", tr_cd) == []
+        # 마스터는 그래도 다섯 개 전부 — 뒤에 붙는 다른 filter 노드를 위해서다.
+        assert sorted(real_client.listeners) == ["AS0", "AS1", "AS2", "AS3", "AS4"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_filter_is_an_error(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+
+        result = await _subscribe(ctx, real_client, event_filter="AS9")
+
+        assert "error" in result
+        assert real_client.listeners == {}
+
+    @pytest.mark.asyncio
+    async def test_missing_sdk_stream_is_reported_not_guessed(self):
+        """SDK 에 등록 API 가 없는 스트림은 조용히 넘어가지 않고 사실로 보고된다."""
+        ctx = _context()
+        real_client = _FakeRealClient(available=["AS0", "AS1", "AS2"])
+
+        result = await _subscribe(ctx, real_client, event_filter="all")
+        await _drain()
+
+        assert sorted(real_client.listeners) == ["AS0", "AS1", "AS2"]
+        assert result["unavailable_streams"] == ["AS3", "AS4"]
+        warnings = [m for lvl, m, _ in ctx.logs if lvl == "warning"]
+        assert any("AS3, AS4" in m for m in warnings), warnings
+
+    @pytest.mark.asyncio
+    async def test_second_node_picking_missing_stream_is_not_a_silent_success(self):
+        """디렉티브(3): 첫 노드가 마스터를 건 뒤, 두 번째 노드가 SDK 에 없는 스트림을
+        filter 로 고르면 status='subscribed' 인데 이벤트 0건인 조용한 실패가 된다.
+        저장된 masters 키로 노드별 확인해 unavailable_streams + warning 을 싣는다."""
+        ctx = _context()
+        real_client = _FakeRealClient(available=["AS0", "AS1", "AS2"])
+
+        first = await _subscribe(ctx, real_client, event_filter="AS1", node_id="node_fill")
+        assert "unavailable_streams" not in first   # AS1 은 등록됨
+
+        second = await _subscribe(ctx, real_client, event_filter="AS4", node_id="node_reject")
+        assert real_client.connect_calls == 1        # 마스터는 첫 노드만 등록
+        assert second["subscribed_streams"] == ["AS4"]
+        assert second["unavailable_streams"] == ["AS4"]
+        warnings = [m for lvl, m, _ in ctx.logs if lvl == "warning"]
+        assert any("AS4" in m for m in warnings), warnings
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 4. 체결 원장 리스너 보존 (디렉티브 2 — SDK 키당 리스너 리스트)
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestLedgerListenerPreserved:
+    @pytest.mark.asyncio
+    async def test_node_master_does_not_clobber_pre_registered_ledger_listener(self):
+        """같은 Real 객체에 체결 원장 리스너가 먼저 걸려 있어도, 노드 마스터 등록 후
+        두 리스너가 **모두** 남고 둘 다 호출된다(덮어쓰기 금지)."""
+        ctx = _context()
+        real_client = _FakeRealClient()
+
+        ledger_as0: List[Any] = []
+        ledger_as1: List[Any] = []
+        real_client.AS0().on_as0_message(lambda resp: ledger_as0.append(resp))
+        real_client.AS1().on_as1_message(lambda resp: ledger_as1.append(resp))
+
+        await _subscribe(ctx, real_client, event_filter="all")
+        await _drain()
+
+        # AS0/AS1 키에는 원장 리스너 + 노드 마스터 둘 다.
+        assert len(real_client.listeners["AS0"]) == 2
+        assert len(real_client.listeners["AS1"]) == 2
+        # 노드만 건 스트림은 하나.
+        assert len(real_client.listeners["AS2"]) == 1
+        # 저장된 마스터는 노드 마스터뿐(원장 리스너는 아니다).
+        assert set(ctx.get_order_event_masters("overseas_stock")) == {"AS0", "AS1", "AS2", "AS3", "AS4"}
+
+        # AS1 체결 프레임을 배달 → 원장 리스너 **와** 노드 마스터 둘 다 동작.
+        real_client.dispatch(
+            "AS1", _frame("AS1", sOrdNo=1, sExecQty=1.0, sExecPrc=100.0, sShtnIsuNo="AAPL")
+        )
+        await _drain()
+
+        assert len(ledger_as1) == 1, "원장 리스너가 노드 마스터에 덮어쓰여 사라졌다"
+        assert ctx.get_output("order_event", "filled") is not None, "노드 마스터가 동작하지 않았다"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 5. 종단 — 프레임이 실제로 포트까지 도달하는가
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestFrameReachesPorts:
+    @pytest.mark.asyncio
+    async def test_as1_fill_frame_reaches_filled_port(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.dispatch(
+            "AS1",
+            _frame(
+                "AS1",
+                sOrdxctPtnCode="11",
+                sOrdMktCode="82",
+                sShtnIsuNo="AAPL",
+                sIsuNm="애플",
+                sOrdNo=1234567,
+                sBnsTp="2",
+                sOrdQty=10.0,
+                sOrdPrc=180.0,
+                sExecQty=10.0,
+                sExecPrc=181.25,
+                sUnercQty=0.0,
+                sExecNO="E99",
+                sExecTime="093015",
+            ),
+        )
+        await _drain()
+
+        output = ctx.get_output("order_event", "filled")
+        assert output is not None, "AS1 프레임이 filled 포트에 도달하지 않았다"
+        assert output["symbol"] == "AAPL"
+        assert output["filled_qty"] == 10
+        assert output["filled_price"] == 181.25     # 체결가 = sExecPrc (주문가 아님)
+        assert output["status"] == "체결"
+        port_notifications = [n for n in ctx.notified if "filled" in n["outputs"]]
+        assert len(port_notifications) == 1
+        assert port_notifications[0]["node_type"] == "RealOrderEventNode"
+        assert [e["event_type"] for e in ctx.emitted] == ["order_event"]
+
+    @pytest.mark.asyncio
+    async def test_as1_fill_updates_order_fill_price_with_exec_price_and_local_date(self):
+        """🔴 체결가 갱신은 sExecPrc(체결가)로, 주문일자는 로컬 오늘(AS1 엔 일자 필드
+        없음 — 원장 경로와 같은 규약)로 한다."""
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.dispatch(
+            "AS1",
+            _frame("AS1", sOrdNo=1234567, sOrdPrc=180.0, sExecQty=10.0, sExecPrc=181.25),
+        )
+        await _drain()
+
+        assert ctx.fill_price_updates == [
+            {
+                "order_no": "1234567",
+                "order_date": datetime.now().strftime("%Y%m%d"),
+                "fill_price": 181.25,       # 주문가 180.0 이 아니라 체결가 181.25
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_fill_price_update_skipped_without_order_no(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.dispatch("AS1", _frame("AS1", sOrdNo=0, sExecQty=10.0, sExecPrc=181.25))
+        await _drain()
+
+        assert ctx.fill_price_updates == []
+
+    @pytest.mark.asyncio
+    async def test_as0_frame_reaches_accepted_port_without_fake_fill(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.dispatch(
+            "AS0",
+            _frame(
+                "AS0",
+                sOrdxctPtnCode="01",
+                sOrdMktCode="82",
+                sShtnIsuNo="TSLA",
+                sIsuNm="테슬라",
+                sOrdNo=7654321,
+                sBnsTp="1",
+                sOrdQty="3",
+                sOrdPrc=250.0,
+                sOrdTime="090015",
+            ),
+        )
+        await _drain()
+
+        output = ctx.get_output("order_event", "accepted")
+        assert output is not None
+        assert output["symbol"] == "TSLA"
+        assert output["order_qty"] == 3
+        assert output["order_price"] == 250.0
+        assert output["order_time"] == "090015"
+        assert output["status"] == "주문접수"
+        assert "filled_qty" not in output and "filled_price" not in output
+        assert ctx.fill_price_updates == []
+
+    @pytest.mark.parametrize(
+        "tr_cd,port,status",
+        [
+            ("AS2", "modified", "정정"),
+            ("AS3", "cancelled", "취소확인"),
+            ("AS4", "rejected", "거부"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_as2_as3_as4_reach_their_own_ports(self, tr_cd, port, status):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.dispatch(tr_cd, _frame(tr_cd, sOrdNo=1, sShtnIsuNo="AAPL", sBnsTp="2"))
+        await _drain()
+
+        output = ctx.get_output("order_event", port)
+        assert output is not None, f"{tr_cd} 프레임이 {port} 포트에 도달하지 않았다"
+        assert output["tr_cd"] == tr_cd
+        assert output["status"] == status
+        assert output["symbol"] == "AAPL"
+
+    @pytest.mark.asyncio
+    async def test_event_filter_as1_only_sees_as1(self):
+        """(마) event_filter 로 AS1 을 고르면 AS1 프레임이 filled 포트에 도달하고,
+        다른 스트림 프레임은 이 노드로 오지 않는다."""
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="AS1", node_id="only_fills")
+
+        real_client.dispatch("AS4", _frame("AS4", sOrdNo=2, sRjtQty=1.0))   # 이 노드 무관
+        real_client.dispatch("AS1", _frame("AS1", sOrdNo=1, sExecQty=1.0, sExecPrc=100.0, sShtnIsuNo="AAPL"))
+        await _drain()
+
+        assert ctx.get_output("only_fills", "rejected") is None
+        filled = ctx.get_output("only_fills", "filled")
+        assert filled is not None and filled["order_no"] == 1
+
+    @pytest.mark.asyncio
+    async def test_header_none_frame_falls_back_to_registered_stream(self):
+        """헤더 없이 body 만 있는 프레임은 등록된 스트림을 TR 로 삼는다(종전 'AS0' 고정 결함)."""
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        real_client.dispatch(
+            "AS1",
+            _frame("AS1", with_header=False, sOrdNo=1, sExecQty=5.0, sExecPrc=99.0, sShtnIsuNo="AAPL"),
+        )
+        await _drain()
+
+        output = ctx.get_output("order_event", "filled")
+        assert output is not None, "header=None 프레임이 filled 포트에 도달하지 않았다"
+        assert output["tr_cd"] == "AS1"
+        assert output["filled_qty"] == 5
+
+    @pytest.mark.asyncio
+    async def test_body_less_frame_is_skipped_not_zero_filled(self):
+        ctx = _context()
+        real_client = _FakeRealClient()
+        await _subscribe(ctx, real_client, event_filter="all")
+
+        broken = AS1RealResponse(
+            header=AS1RealResponseHeader(tr_cd="AS1"),
+            body=None,
+            rsp_cd="",
+            rsp_msg="",
+            error_msg="validation failed",
+        )
+        real_client.dispatch("AS1", broken)
+        await _drain()
+
+        assert ctx.get_output("order_event", "filled") is None
+        assert ctx.fill_price_updates == []
+        assert any(lvl == "warning" for lvl, _, _ in ctx.logs)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# 6. core 선언 필드명 alias (과제 B) — 세 파서 각각 1건
+# ──────────────────────────────────────────────────────────────────────────
+
+class TestOrderEventAliases:
+    """선언(order_id/quantity/filled_quantity/price)과 런타임(order_no/order_qty/
+    filled_qty/order_price)의 이름 불일치를 alias 로 메운다. 의미 1:1 인 것만,
+    원 키가 있을 때만."""
+
+    def test_overseas_stock_fill_family_aliases(self):
+        body = _body("AS1", sOrdNo=1234567, sOrdQty=10.0, sOrdPrc=180.0, sExecQty=4.0, sExecPrc=181.25)
+        event = RealOrderEventNodeExecutor._parse_overseas_stock_fill_family_event(body, "AS1")
+        assert event["order_id"] == event["order_no"] == 1234567
+        assert event["quantity"] == event["order_qty"] == 10
+        assert event["filled_quantity"] == event["filled_qty"] == 4
+        assert event["price"] == event["order_price"] == 180.0
+
+    def test_korea_sc1_family_aliases(self):
+        body = SC1RealResponseBody.model_validate(
+            {name: "" for name in SC1RealResponseBody.model_fields}
+            | {"ordno": "1234567", "ordqty": "10", "ordprc": "73500", "execqty": "4", "execprc": "73400"}
+        )
+        event = RealOrderEventNodeExecutor._parse_korea_sc1_family_event(body, "SC1")
+        assert event["order_id"] == event["order_no"] == "1234567"
+        assert event["quantity"] == event["order_qty"] == 10
+        assert event["filled_quantity"] == event["filled_qty"] == 4
+        assert event["price"] == event["order_price"] == 73500.0
+
+    def test_tc3_aliases(self):
+        # TC3 파서는 getattr 기반이라 SimpleNamespace 로 충분(선물 SDK 블록 불필요).
+        # TC3 은 order_qty/order_price 를 싣지 않으므로 quantity/price alias 는 없고,
+        # order_id(←order_no)·filled_quantity(←filled_qty)만 생긴다.
+        body = SimpleNamespace(
+            svc_id="", is_cd="ESZ5", ordr_no="A1", ordr_dt="20260912",
+            orgn_ordr_no="", s_b_ccd="2", ccls_q=3, ccls_prc=5000.0,
+            ccls_no="C1", ccls_tm="093015", avg_byng_uprc=0.0, clr_pl_amt=0.0,
+            ent_fee=0.0, crncy_cd="USD",
+        )
+        event = RealOrderEventNodeExecutor()._parse_tc3_data(body)
+        assert event["order_id"] == event["order_no"] == "A1"
+        assert event["filled_quantity"] == event["filled_qty"] == 3
+        # TC3 에 없는 원 키는 alias 도 만들지 않는다(지어내기 금지).
+        assert "quantity" not in event and "price" not in event

--- a/src/programgarden/tests/test_positions_plugin_state_path.py
+++ b/src/programgarden/tests/test_positions_plugin_state_path.py
@@ -1,0 +1,223 @@
+"""positions 기반 조건 플러그인의 strategy_state 경로 (M3, 2026-09-12).
+
+무엇이 깨져 있었나
+------------------
+``ConditionNodeExecutor`` 의 positions 기반 분기는 plugin_kwargs 를
+``{"positions", "fields"}`` 로 **고정**해 ``context`` 를 넘기지 않았다. 그래서
+strategy_state 를 쓰는 포지션 플러그인(PartialTakeProfit)이 라이브에서 늘
+``has_state=False`` 로 떨어져 상태를 저장·복원하지 못했고, 분할 익절이 매 사이클
+``level_index=0`` 으로 재발동했다(3사이클 연속 50% 매도 재현).
+
+같은 회차에 플러그인 쪽 메서드명도 실제 트래커
+(``WorkflowRiskTracker.load_state``/``save_state``/``delete_state`` — 전부 동기)에
+맞췄다. 여기서는 그 둘이 합쳐져 **실행기 경로로 상태가 실제로 유지되는지**를 본다.
+
+items/data 기반 분기와 같은 규약이므로, ``context`` 파라미터가 없는 플러그인에는
+종전대로 넘기지 않는다(아래 마지막 테스트).
+"""
+
+import inspect
+
+import pytest
+
+from programgarden.context import ExecutionContext
+from programgarden.executor import ConditionNodeExecutor
+
+
+def _ctx(tmp_path, *, with_state_tracker: bool) -> ExecutionContext:
+    ctx = ExecutionContext(job_id="j", workflow_id="wf", storage_dir=str(tmp_path))
+    if with_state_tracker:
+        # BrokerNode 가 하는 일과 같다 — 플러그인이 선언한 risk feature 로 트래커 생성.
+        ctx.init_risk_tracker(
+            features={"state"}, product="overseas_stock",
+            provider="ls-sec.co.kr", paper_trading=False,
+        )
+        assert ctx.risk_tracker is not None
+    return ctx
+
+
+def _plugin(plugin_id):
+    """resolver 와 같은 경로로 플러그인 callable 을 얻는다(resolver.py: plugin_registry.get)."""
+    import programgarden_community  # noqa: F401 — 플러그인 자동 등록 트리거
+    from programgarden_core.registry import PluginRegistry
+
+    plugin = PluginRegistry().get(plugin_id)
+    assert plugin is not None, f"{plugin_id} 플러그인이 등록되지 않았다"
+    return plugin
+
+
+async def _run(ctx, qty, pnl_rate, levels):
+    return await ConditionNodeExecutor().execute(
+        "cond", "ConditionNode",
+        {
+            "plugin": "PartialTakeProfit",
+            "positions": [
+                {"symbol": "AAPL", "pnl_rate": pnl_rate, "qty": qty, "market_code": "82"}
+            ],
+            "fields": {"levels": levels},
+        },
+        ctx,
+        plugin=_plugin("PartialTakeProfit"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_partial_take_profit_does_not_retrigger_every_cycle(tmp_path):
+    """같은 단계가 매 사이클 재발동하지 않는다 (구 동작: sell 3연속)."""
+    ctx = _ctx(tmp_path, with_state_tracker=True)
+    levels = [{"pnl_pct": 5, "sell_pct": 50}, {"pnl_pct": 10, "sell_pct": 30}]
+
+    actions = []
+    for _ in range(3):
+        out = await _run(ctx, qty=100, pnl_rate=6.0, levels=levels)
+        actions.append(out["symbol_results"][0]["action"])
+
+    assert actions == ["sell", "hold", "hold"], f"관측: {actions}"
+    assert ctx.risk_tracker.load_state("partial_tp.AAPL.completed_levels") == [0]
+
+
+@pytest.mark.asyncio
+async def test_second_level_sizes_off_the_stored_original_quantity(tmp_path):
+    """2단계 수량은 상태에 저장된 최초 수량 기준 — 상태가 실제로 복원된다는 증거."""
+    ctx = _ctx(tmp_path, with_state_tracker=True)
+    levels = [{"pnl_pct": 5, "sell_pct": 50}, {"pnl_pct": 10, "sell_pct": 30}]
+
+    first = await _run(ctx, qty=100, pnl_rate=6.0, levels=levels)
+    assert first["symbol_results"][0]["sell_quantity"] == 50
+
+    second = await _run(ctx, qty=50, pnl_rate=12.0, levels=levels)
+    sr = second["symbol_results"][0]
+    assert sr["level_index"] == 1
+    assert sr["sell_quantity"] == 30, "최초 100주의 30% (현재 50주의 30% 가 아니다)"
+
+
+@pytest.mark.asyncio
+async def test_without_state_tracker_falls_back_to_stateless(tmp_path):
+    """트래커가 없으면(= state feature 미선언/dry_run) 종전처럼 매번 재발동한다.
+
+    조용한 실패가 아니라 '상태 저장소가 없을 때의 정의된 동작' 이다.
+    """
+    ctx = _ctx(tmp_path, with_state_tracker=False)
+    levels = [{"pnl_pct": 5, "sell_pct": 50}]
+
+    actions = [
+        (await _run(ctx, qty=100, pnl_rate=6.0, levels=levels))["symbol_results"][0]["action"]
+        for _ in range(2)
+    ]
+    assert actions == ["sell", "sell"]
+
+
+@pytest.mark.asyncio
+async def test_context_only_goes_to_plugins_that_declare_it(tmp_path):
+    """context 를 선언하지 않은 포지션 플러그인에는 넘기지 않는다 (data 분기와 같은 규약)."""
+    plugin = _plugin("StopLoss")
+    assert "context" not in inspect.signature(plugin).parameters
+
+    ctx = _ctx(tmp_path, with_state_tracker=True)
+    out = await ConditionNodeExecutor().execute(
+        "cond", "ConditionNode",
+        {
+            "plugin": "StopLoss",
+            "positions": [
+                {"symbol": "AAPL", "pnl_rate": -9.0, "qty": 10, "market_code": "82"}
+            ],
+            "fields": {"stop_loss_pct": 5},
+        },
+        ctx,
+        plugin=plugin,
+    )
+    # 넘기지 않아도 정상 평가된다 (TypeError 로 죽지 않는다).
+    assert out["passed_symbols"][0]["symbol"] == "AAPL"
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# M3b(2026-09-12): 계좌가 **빈 리스트**일 때도 상태 플러그인(time_based_exit)의
+# '남은 entry_date 전부 정리' 스윕이 실행기 경로에서 도달 가능해야 한다.
+#
+# 무엇이 깨져 있었나: positions 분기는 positions 가 빈 리스트면 플러그인을 **아예
+# 호출하지 않고** 조기 return 했다. 그래서 전량 매도 → 계좌 빔 → 스윕 미실행 →
+# 재매수 시 옛 entry_date 가 살아남아 hold_days 가 크게 잡혀 **거짓 exit** 가 났다.
+# 고친 동작: positions 가 정확히 [] 이고 플러그인이 context 를 선언하면(= 상태 사용)
+# positions=[] 로 한 번 호출해 스윕 기회를 준다. 결과는 조건 판정에 쓰지 않고
+# (예외는 warning 으로 삼킴) 종전의 빈 결과를 그대로 돌려준다.
+#
+# context 미선언 플러그인은 종전대로 호출하지 않는다(data 분기와 같은 규약).
+# ──────────────────────────────────────────────────────────────────────────
+
+_EMPTY_RESULT = {
+    "symbols": [],
+    "result": False,
+    "is_condition_met": False,
+    "passed_symbols": [],
+    "failed_symbols": [],
+    "symbol_results": [],
+    "values": [],
+}
+
+
+async def _run_empty(ctx, plugin, *, plugin_id="StopLoss", fields=None):
+    """positions=[] (빈 계좌)로 positions 기반 조건을 돌린다. plugin_id 는 스키마가
+    positions-based(required_data=['positions'])인 실제 플러그인 이름을 빌려 쓰고,
+    실행될 callable 은 주입한 fake 다."""
+    return await ConditionNodeExecutor().execute(
+        "cond", "ConditionNode",
+        {"plugin": plugin_id, "positions": [], "fields": fields or {}},
+        ctx,
+        plugin=plugin,
+    )
+
+
+@pytest.mark.asyncio
+async def test_empty_account_sweeps_context_declaring_plugin(tmp_path):
+    """(a) 계좌가 비어도(=[]), context 를 받는 상태 플러그인(time_based_exit 류)은
+    positions=[] 로 한 번 호출돼 스윕 기회를 얻는다 — 실제 risk tracker 경로."""
+    ctx = _ctx(tmp_path, with_state_tracker=True)
+    calls = []
+
+    def sweeping_plugin(positions, fields, context):
+        calls.append({"positions": positions})
+        # time_based_exit 의 스윕 흉내 — 계좌가 비면 상태를 정리한다.
+        if not positions and getattr(context, "risk_tracker", None) is not None:
+            context.risk_tracker.save_state("time_based_exit.swept", True)
+        return {"passed_symbols": [], "failed_symbols": [], "symbol_results": [], "values": [], "result": False}
+
+    out = await _run_empty(ctx, sweeping_plugin, fields={"max_hold_days": 5})
+
+    assert len(calls) == 1, "빈 계좌에서 상태 플러그인이 스윕 호출되지 않았다"
+    assert calls[0]["positions"] == []
+    # 스윕이 실제 트래커 상태까지 도달했다(실행기 경로로 상태가 유지된다는 증거).
+    assert ctx.risk_tracker.load_state("time_based_exit.swept") is True
+    # 스윕 결과는 조건 판정에 반영하지 않는다 — 종전의 빈 결과 그대로.
+    assert out == _EMPTY_RESULT
+
+
+@pytest.mark.asyncio
+async def test_empty_account_does_not_call_stateless_plugin(tmp_path):
+    """(b) context 를 선언하지 않은(= 무상태) 플러그인은 빈 계좌에서 호출하지 않는다."""
+    ctx = _ctx(tmp_path, with_state_tracker=True)
+    calls = []
+
+    def stateless_plugin(positions, fields):   # context 파라미터 없음
+        calls.append(positions)
+        return {"passed_symbols": [], "failed_symbols": [], "symbol_results": [], "values": [], "result": False}
+
+    out = await _run_empty(ctx, stateless_plugin, fields={"stop_loss_pct": 5})
+
+    assert calls == [], "context 미선언 플러그인을 빈 계좌에서 호출했다"
+    assert out == _EMPTY_RESULT
+
+
+@pytest.mark.asyncio
+async def test_empty_account_sweep_exception_does_not_break_node(tmp_path):
+    """(c) 빈 계좌 스윕 호출이 예외를 던져도 노드 결과는 종전의 빈 결과다(삼킨다)."""
+    ctx = _ctx(tmp_path, with_state_tracker=True)
+    calls = []
+
+    def raising_plugin(positions, fields, context):
+        calls.append(positions)
+        raise RuntimeError("sweep boom")
+
+    out = await _run_empty(ctx, raising_plugin, fields={"max_hold_days": 5})
+
+    assert calls == [[]], "스윕 호출 자체가 일어나지 않았다"
+    assert out == _EMPTY_RESULT, "스윕 예외가 노드 결과/흐름을 깨뜨렸다"

--- a/src/programgarden/tests/test_realtime_callback_cleanup.py
+++ b/src/programgarden/tests/test_realtime_callback_cleanup.py
@@ -372,3 +372,55 @@ class TestBrokerFillSubscriptionCleanup:
 
         await executor.cleanup_fill_subscriptions("job-3")
         assert "job-3_broker_fill_sub" not in executor._active_trackers
+
+
+class TestMasterCallbackRemovalKeepsLedgerListeners:
+    """finance 1.9.7 — 정리는 노드 마스터 **콜러블만** 뗀다(같은 Real 의 원장 리스너는 남는다)."""
+
+    @pytest.mark.asyncio
+    async def test_masters_removed_by_listener_not_by_key(self, context):
+        removed = {}
+
+        def make_client(stream):
+            client = MagicMock()
+            setattr(client, f"on_remove_{stream.lower()}_message",
+                    MagicMock(side_effect=lambda listener=None, _s=stream: removed.__setitem__(_s, listener)))
+            return client
+
+        clients = {s: make_client(s) for s in ("SC0", "SC1", "SC2", "SC3", "SC4")}
+        real_client = MagicMock()
+        for s, c in clients.items():
+            setattr(real_client, s, MagicMock(return_value=c))
+        masters = {s: (lambda r, _s=s: None) for s in clients}
+
+        context._order_event_real_client["korea_stock"] = real_client
+        context.set_order_event_masters("korea_stock", masters)
+
+        await context.cleanup_persistent_nodes()
+
+        # 다섯 스트림 전부, 각각 **그 마스터 객체**를 인자로 떼었다(키 전체 제거 아님)
+        assert set(removed) == {"SC0", "SC1", "SC2", "SC3", "SC4"}
+        for s, master in masters.items():
+            assert removed[s] is master
+            getattr(clients[s], f"on_remove_{s.lower()}_message").assert_called_once_with(master)
+        assert context.get_order_event_masters("korea_stock") == {}
+
+    @pytest.mark.asyncio
+    async def test_old_sdk_without_listener_param_falls_back_to_key_removal(self, context):
+        client = MagicMock()
+        calls = []
+
+        def remover(*args):
+            if args:
+                raise TypeError("on_remove_sc0_message() takes 1 positional argument")
+            calls.append("key")
+
+        client.on_remove_sc0_message = MagicMock(side_effect=remover)
+        real_client = MagicMock()
+        real_client.SC0 = MagicMock(return_value=client)
+        context._order_event_real_client["korea_stock"] = real_client
+        context.set_order_event_masters("korea_stock", {"SC0": lambda r: None})
+
+        await context.cleanup_persistent_nodes()
+
+        assert calls == ["key"]

--- a/src/programgarden/tests/test_tc3_order_event_fill_price.py
+++ b/src/programgarden/tests/test_tc3_order_event_fill_price.py
@@ -1,0 +1,171 @@
+"""해외선물 주문이벤트 노드(TC3)의 체결가 갱신 — 키 오타로 죽어 있던 경로 (M1, 2026-09-12).
+
+무엇이 깨져 있었나
+------------------
+``RealOrderEventNodeExecutor._ls_futures_order_event`` 의 TC3 분기는 바로 위에서 부른
+``_parse_tc3_data`` 의 결과에서 ``event_data.get('fill_price', 0)`` 을 읽었다. 그런데
+그 파서가 만드는 dict 에 ``fill_price`` 라는 키는 **없다** — 체결가는
+``filled_price`` 로 담긴다(노드가 선언한 출력 필드명도 ``filled_price`` 다:
+``programgarden_core/nodes/base.py`` ORDER_EVENT_FIELDS). 그래서 늘 0 을 받아
+``if fill_price > 0:`` 이 한 번도 참이 되지 않았고, 시장가 주문의 체결가 갱신
+(``update_workflow_order_fill_price``)이 이 경로에서 통째로 죽어 있었다.
+
+덧붙여 ``order_date`` 키도 파서에 없어 ``datetime.now()`` 폴백이 쓰였다. TC3 프레임은
+``ordr_dt`` 를 실제로 싣는다(SDK ``overseas_futureoption/real/TC3/blocks.py`` — 이
+파일의 체결 원장 핸들러 ``on_tc3_event`` 는 이미 그 이름을 읽는다). 로컬 날짜를
+주문일자로 지어내면 브로커 영업일과 어긋나는 구간(야간장)에서 (order_no, order_date)
+대조가 조용히 빗나간다.
+
+여기서는 네트워크 없이 실제 SDK 블록(``TC3RealResponseBody``)으로 프레임을 만들어
+핸들러에 직접 흘린다.
+"""
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from programgarden.executor import RealOrderEventNodeExecutor
+from programgarden_finance.ls.overseas_futureoption.real.TC3.blocks import (
+    TC3RealResponseBody,
+)
+
+
+def tc3_body(**overrides):
+    """실제 TC3 응답 블록 — 필수 필드는 빈 문자열로 채우고 관심 필드만 덮어쓴다."""
+    fields = {
+        name: "" for name, field in TC3RealResponseBody.model_fields.items()
+        if field.is_required()
+    }
+    fields.update(
+        lineseq="1", key="k", user="u", svc_id="CH01",
+        ordr_dt="20260909", ordr_no="000123", is_cd="ESM26", s_b_ccd="2",
+        ccls_q="2", ccls_prc="100.25", ccls_no="000777", ccls_tm="001500",
+    )
+    fields.update(overrides)
+    return TC3RealResponseBody(**fields)
+
+
+class FakeContext:
+    """주문이벤트 노드가 실제로 호출하는 표면만 구현한 컨텍스트."""
+
+    is_shutdown = False
+    is_deep_validate = False
+
+    def __init__(self):
+        self.handlers = {}
+        self.fill_price_updates = []
+        self.outputs = []
+        self.logs = []
+
+    # --- 주문이벤트 구독 표면 ---
+    def register_order_event_handler(self, product, tr_cd, node_id, event_filter, handler):
+        self.handlers[tr_cd] = handler
+
+    def has_order_event_subscription(self, product):
+        # 이미 마스터 콜백이 있다고 보고(다른 노드가 먼저 등록한 상태) 실제 WebSocket
+        # 연결 경로를 타지 않게 한다.
+        return True
+
+    def get_order_event_real_client(self, product):
+        return Mock()
+
+    def register_persistent(self, node_id, client, metadata=None):
+        pass
+
+    def register_cleanup_on_flow_end(self, node_id, client):
+        pass
+
+    # --- 출력/이벤트 표면 ---
+    def set_output(self, node_id, port, data):
+        self.outputs.append((node_id, port, data))
+
+    async def notify_output_update(self, **kwargs):
+        pass
+
+    async def emit_event(self, **kwargs):
+        pass
+
+    def log(self, level, message, node_id=None, data=None):
+        self.logs.append((level, message))
+
+    # --- 검증 대상 ---
+    def update_workflow_order_fill_price(self, order_no, order_date, fill_price):
+        self.fill_price_updates.append(
+            {"order_no": order_no, "order_date": order_date, "fill_price": fill_price}
+        )
+
+
+async def _tc3_handler(context):
+    executor = RealOrderEventNodeExecutor()
+    await executor._ls_futures_order_event(
+        ls=Mock(), node_id="evt", config={}, context=context,
+        stay_connected=True, event_filter="all",
+    )
+    return context.handlers["TC3"]
+
+
+def test_parse_tc3_carries_filled_price_and_order_date():
+    """파서 dict 의 실제 키 이름 고정 — 'fill_price' 는 없고 'filled_price' 다."""
+    parsed = RealOrderEventNodeExecutor()._parse_tc3_data(tc3_body())
+    assert parsed["filled_price"] == 100.25
+    assert "fill_price" not in parsed, "이 키를 읽던 게 M1 결함의 원인이었다"
+    assert parsed["order_date"] == "20260909"
+    assert parsed["order_no"] == "000123"
+
+
+@pytest.mark.asyncio
+async def test_tc3_fill_updates_order_fill_price():
+    """체결 프레임 1건 → 체결가 갱신이 **실제로** 호출된다 (구 코드: 0건)."""
+    context = FakeContext()
+    handler = await _tc3_handler(context)
+
+    handler(Mock(body=tc3_body()))
+    await asyncio.sleep(0)
+
+    assert context.fill_price_updates == [
+        {"order_no": "000123", "order_date": "20260909", "fill_price": 100.25}
+    ]
+    ports = [port for _, port, _ in context.outputs]
+    assert ports == ["filled"]
+
+
+@pytest.mark.asyncio
+async def test_tc3_uses_frame_order_date_not_today():
+    """주문일자는 프레임의 ordr_dt 를 그대로 쓴다 — 오늘 날짜로 지어내지 않는다."""
+    from datetime import datetime
+
+    context = FakeContext()
+    handler = await _tc3_handler(context)
+
+    handler(Mock(body=tc3_body(ordr_dt="20260101")))
+    await asyncio.sleep(0)
+
+    assert context.fill_price_updates[0]["order_date"] == "20260101"
+    assert context.fill_price_updates[0]["order_date"] != datetime.now().strftime("%Y%m%d")
+
+
+@pytest.mark.asyncio
+async def test_tc3_without_order_date_skips_update():
+    """ordr_dt 가 비면 갱신을 건너뛴다 — 오늘 날짜를 지어내 원장을 오염시키지 않는다."""
+    context = FakeContext()
+    handler = await _tc3_handler(context)
+
+    handler(Mock(body=tc3_body(ordr_dt="")))
+    await asyncio.sleep(0)
+
+    assert context.fill_price_updates == []
+    # 체결 이벤트 자체는 종전대로 발행된다 (갱신만 건너뛴다).
+    assert [port for _, port, _ in context.outputs] == ["filled"]
+
+
+@pytest.mark.asyncio
+async def test_tc3_without_fill_price_does_not_update():
+    """체결가가 0 이면 갱신하지 않는다 (종전 동작 유지)."""
+    context = FakeContext()
+    handler = await _tc3_handler(context)
+
+    handler(Mock(body=tc3_body(ccls_prc="0")))
+    await asyncio.sleep(0)
+
+    assert context.fill_price_updates == []


### PR DESCRIPTION
## Summary
1.37.0 을 내면서 남긴 **장(브로커) 없이 고칠 수 있는 후속 결함** 묶음 + 검증에서 새로 잡힌 같은 결함 계열.

- **엔진 1.37.1**
  - 국내(SC0~SC4)·해외주식(AS0~AS4) 주문이벤트 노드: 마스터 1개만 걸고 tr_cd 분기 → 스트림별 등록 + 스트림별 파서(SDK 실제 필드명 1:1, 접수 프레임에 없는 체결 필드는 사유 표시), 체결가 execprc/sExecPrc, 소수점 수량 보존, 미등록 스트림 선택 시 `unavailable_streams`.
  - TC3 체결가 갱신 키 오타(`fill_price`→`filled_price`) + `ordr_dt` 기반 주문일자.
  - 브로커 노드 LS 로그인 실패 삼킴(prod 09-12 실관측) → 2회 백오프 재시도 후 노드 실패 + CONNECTION_FAILED 알림, 체결 구독 dry_run 게이트.
  - ConditionNode positions 분기 `context` 전달(상태 플러그인 활성) + 빈 계좌 스윕 호출.
  - 주문이벤트 출력 alias(order_id/quantity/filled_quantity/price) — core 무변경.
  - 정리 경로가 노드 마스터 콜러블만 제거(원장 리스너 보존, SC1~SC4·AS1~AS4 누수 제거).
- **finance 1.9.7**: 실시간 리스너 레지스트리 TR 당 다중 리스너 — 주문이벤트 노드 마스터가 체결 원장 구독을 덮어쓰던 결함의 근본 수정.
- **community 1.15.3**: 상태 기반 플러그인 6종 + var_cvar_monitor 의 트래커 메서드명을 실제 `WorkflowRiskTracker` 시그니처로 정렬(time_based_exit 즉사 회귀 제거, 보유일수 실제 증가, correlation_guard 히스테리시스 실동작).

PyPI 발행 완료: finance 1.9.7 · community 1.15.3 · programgarden 1.37.1 (core 1.28.0 무변경 — lockstep 검사 통과).

## Validation
- engine `1773 passed, 26 skipped, 3 xfailed` · finance `3032 passed` · community `1764 passed, 31 failed`(31 = 선택 의존성 미설치, HEAD 동일).
- 적대적 검증 워크플로우 2회(구현 5 + 검증 7): load-bearing 되돌리기 실험, 두 담당 executor.py 변경 공존, 실제 WorkflowRiskTracker 왕복 테스트.
- 라이브 미검증 — 월 09-14 장중 프로브로 AS1 sExecTime·국내 매체코드 관측 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jgvXMHMiFPHPEsadb6ydr
